### PR TITLE
Added user switch note.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ Only master is ever released. You should work on a feature branch so that nothin
 
 After master contains what you want to release, there is a Savant build target called push. When you run `sb push` it will pull master, re-build and updates the website.
 
+If your user is different on the webserver than on your localhost, you'll want to use the --user switch:
+
+`sb push --user=yourremoteusername`


### PR DESCRIPTION
When you don't have the same username, you need to use --user=foo
syntax. I was thrown off by it, tried --user foo syntax, which doesn't
work.