### PR TITLE
Add forum references

### DIFF
--- a/site/docs/v1/tech/installation-guide/securing.adoc
+++ b/site/docs/v1/tech/installation-guide/securing.adoc
@@ -8,7 +8,7 @@ description: Secure your installation by limiting network traffic
 
 == Securing
 
-If you're installing FusionAuth on your own server, use the following guide as a baseline for securing the network services. If you need further assistance to secure FusionAuth, please ask a question on https://fusionauth.io/community/forum/[forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.
+If you're installing FusionAuth on your own server, use the following guide as a baseline for securing the network services. If you need further assistance to secure FusionAuth, please ask a question in the https://fusionauth.io/community/forum/[FusionAuth forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.
 
 == Required ports
 See the link:../reference/configuration[Configuration Reference] for more information on default port configuration. The documentation below

--- a/site/docs/v1/tech/installation-guide/securing.adoc
+++ b/site/docs/v1/tech/installation-guide/securing.adoc
@@ -8,7 +8,7 @@ description: Secure your installation by limiting network traffic
 
 == Securing
 
-If you're installing FusionAuth on your own server, use the following guide as a baseline for securing the network services. If you need further assistance to secure FusionAuth, please ask a question in the https://fusionauth.io/community/forum/[FusionAuth forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.
+If you're installing FusionAuth on your own server, use the following guide as a baseline for securing the network services. If you need further assistance to secure FusionAuth, please ask a question in the https://fusionauth.io/community/forum/[FusionAuth forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"]. If you have a licensed edition you may open a https://account.fusionauth.io[support request from your account, window="_blank"].
 
 == Required ports
 See the link:../reference/configuration[Configuration Reference] for more information on default port configuration. The documentation below

--- a/site/docs/v1/tech/installation-guide/securing.adoc
+++ b/site/docs/v1/tech/installation-guide/securing.adoc
@@ -8,7 +8,7 @@ description: Secure your installation by limiting network traffic
 
 == Securing
 
-If you're installing FusionAuth on your own server, use the following guide as a baseline for securing the network services. If you need further assistance to secure FusionAuth, please ask a question on https://stackoverflow.com/questions/tagged/fusionauth[Stack Overflow, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.
+If you're installing FusionAuth on your own server, use the following guide as a baseline for securing the network services. If you need further assistance to secure FusionAuth, please ask a question on https://fusionauth.io/community/forum/[forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.
 
 == Required ports
 See the link:../reference/configuration[Configuration Reference] for more information on default port configuration. The documentation below

--- a/site/docs/v1/tech/installation-guide/system-requirements.adoc
+++ b/site/docs/v1/tech/installation-guide/system-requirements.adoc
@@ -7,7 +7,7 @@ description: The minimum system requirements required to install and run FusionA
 == System Requirements
 
 FusionAuth will install and run on nearly any system. We have done our best to document the supported configurations here. If you
-have any questions about platform support, please contact us. Please read through this documentation and ensure you have met all of
+have any questions about platform support, please ask a question on https://fusionauth.io/community/forum/[the forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"]. If you have a licensed edition you may send a request to support@fusionauth.io.please contact us. Please read through this documentation and ensure you have met all of
 the requirements before continuing with the installation of FusionAuth.
 
 == Operating System

--- a/site/docs/v1/tech/installation-guide/system-requirements.adoc
+++ b/site/docs/v1/tech/installation-guide/system-requirements.adoc
@@ -7,8 +7,9 @@ description: The minimum system requirements required to install and run FusionA
 == System Requirements
 
 FusionAuth will install and run on nearly any system. We have done our best to document the supported configurations here. If you
-have any questions about platform support, please ask a question on https://fusionauth.io/community/forum/[the forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"]. If you have a licensed edition you may send a request to support@fusionauth.io. Please read through this documentation and ensure you have met all of
-the requirements before continuing with the installation of FusionAuth.
+have any questions about platform support, please ask a question on https://fusionauth.io/community/forum/[the forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"]. If you have a licensed edition you may open a https://account.fusionauth.io[support request from your account, window="_blank"]. 
+
+Please read through this documentation and ensure you have met all of the requirements before continuing with the installation of FusionAuth.
 
 == Operating System
 

--- a/site/docs/v1/tech/installation-guide/system-requirements.adoc
+++ b/site/docs/v1/tech/installation-guide/system-requirements.adoc
@@ -7,7 +7,7 @@ description: The minimum system requirements required to install and run FusionA
 == System Requirements
 
 FusionAuth will install and run on nearly any system. We have done our best to document the supported configurations here. If you
-have any questions about platform support, please ask a question on https://fusionauth.io/community/forum/[the forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"]. If you have a licensed edition you may send a request to support@fusionauth.io.please contact us. Please read through this documentation and ensure you have met all of
+have any questions about platform support, please ask a question on https://fusionauth.io/community/forum/[the forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"]. If you have a licensed edition you may send a request to support@fusionauth.io. Please read through this documentation and ensure you have met all of
 the requirements before continuing with the installation of FusionAuth.
 
 == Operating System

--- a/site/docs/v1/tech/tutorials/migrate-users.adoc
+++ b/site/docs/v1/tech/tutorials/migrate-users.adoc
@@ -92,4 +92,4 @@ This code reads each user from the existing database, creates a new FusionAuth U
 
 This example uses a FusionAuthClient to perform the import. You may also call the link:../apis/users#import-users[Import Users] API directly if you prefer (or if a FusionAuthClient is not available for your language of choice).
 
-If you need further assistance migrating to FusionAuth, please ask a question on https://fusionauth.io/community/forum/[forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.
+If you need further assistance migrating to FusionAuth, please ask a question in the https://fusionauth.io/community/forum/[FusionAuth forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.

--- a/site/docs/v1/tech/tutorials/migrate-users.adoc
+++ b/site/docs/v1/tech/tutorials/migrate-users.adoc
@@ -92,4 +92,4 @@ This code reads each user from the existing database, creates a new FusionAuth U
 
 This example uses a FusionAuthClient to perform the import. You may also call the link:../apis/users#import-users[Import Users] API directly if you prefer (or if a FusionAuthClient is not available for your language of choice).
 
-If you need further assistance migrating to FusionAuth, please ask a question on https://stackoverflow.com/questions/tagged/fusionauth[Stack Overflow, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.
+If you need further assistance migrating to FusionAuth, please ask a question on https://fusionauth.io/community/forum/[forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.

--- a/site/docs/v1/tech/tutorials/migrate-users.adoc
+++ b/site/docs/v1/tech/tutorials/migrate-users.adoc
@@ -92,4 +92,4 @@ This code reads each user from the existing database, creates a new FusionAuth U
 
 This example uses a FusionAuthClient to perform the import. You may also call the link:../apis/users#import-users[Import Users] API directly if you prefer (or if a FusionAuthClient is not available for your language of choice).
 
-If you need further assistance migrating to FusionAuth, please ask a question in the https://fusionauth.io/community/forum/[FusionAuth forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"] if you have additional questions. If you have a licensed edition you may send a request to support@fusionauth.io.
+If you need further assistance migrating to FusionAuth, please ask a question in the https://fusionauth.io/community/forum/[FusionAuth forum, window="_blank"] or open an issue on https://github.com/FusionAuth/fusionauth-issues/issues/new/choose[Github, window="_blank"]. If you have a licensed edition you may open a https://account.fusionauth.io[support request from your account, window="_blank"].


### PR DESCRIPTION
Removed Stack Overflow references where present in the doc. 

In the system requirements we just said "contact us" but I replaced it with common verbiage ("forum, github issues, if you have a license email is").