### PR TITLE
Add in further explanation of the enforce-utf8mb4 setting.

### DIFF
--- a/site/docs/v1/tech/reference/configuration.adoc
+++ b/site/docs/v1/tech/reference/configuration.adoc
@@ -47,9 +47,9 @@ include::docs/v1/tech/reference/_property-database-username.adoc[]
 include::docs/v1/tech/reference/_property-database-password.adoc[]
 
 [field]#database.mysql.enforce-utf8mb4# [type]#[String]# [default]#defaults to `true`#::
-When set to `true` and using MySQL, full 4 byte unique configuration is enforced at startup.
+When set to `true` and using MySQL, a 4 byte UTF compatible character set configuration is enforced at startup.
 +
-If this validation is not desired or not it is not possible to modify your MySQL configuration so satisfy the validation, disable this check by setting this value to `false`.
+If this validation is not desired or not it is not possible to modify your MySQL configuration to satisfy the validation, disable this check by setting this value to `false`. If this is `false`, any attempt to store a 4 byte unicode character the INSERT or UPDATE request will fail. The initial MySQL UTF-8 support only supported 3 byte characters; utf8mb4 with support for 4 byte characters was a later addition.
 
 [field]#fusionauth.runtime-mode# [type]#[String]# [default]#defaults to `development`# [since]#Available Since 1.16.0#::
 include::docs/v1/tech/reference/_property-runtime-mode.adoc[]

--- a/site/docs/v1/tech/reference/configuration.adoc
+++ b/site/docs/v1/tech/reference/configuration.adoc
@@ -49,7 +49,7 @@ include::docs/v1/tech/reference/_property-database-password.adoc[]
 [field]#database.mysql.enforce-utf8mb4# [type]#[String]# [default]#defaults to `true`#::
 When set to `true` and using MySQL, a 4 byte UTF compatible character set configuration is enforced at startup.
 +
-If this validation is not desired or not it is not possible to modify your MySQL configuration to satisfy the validation, disable this check by setting this value to `false`. If this is `false`, any attempt to store a 4 byte unicode character the INSERT or UPDATE request will fail. The initial MySQL UTF-8 support only supported 3 byte characters; utf8mb4 with support for 4 byte characters was a later addition.
+If this validation is not desired or not it is not possible to modify your MySQL configuration to satisfy the validation, disable this check by setting this value to `false`. If this is `false`, any attempt to store a 4 byte unicode character will cause the `INSERT` or `UPDATE` request to fail. The initial MySQL UTF-8 implementation only supported up to characters up to 3 bytes in length; utf8mb4 extends this to 4 byte characters.
 
 [field]#fusionauth.runtime-mode# [type]#[String]# [default]#defaults to `development`# [since]#Available Since 1.16.0#::
 include::docs/v1/tech/reference/_property-runtime-mode.adoc[]


### PR DESCRIPTION
Basically, Dan's explanation here: https://github.com/FusionAuth/fusionauth-issues/issues/234#issuecomment-632757441 was too good not to incorporate.

So I pulled it into the docs.