### PR TITLE
Added note about windows logging.

### DIFF
--- a/site/docs/v1/tech/troubleshooting.adoc
+++ b/site/docs/v1/tech/troubleshooting.adoc
@@ -44,6 +44,8 @@ These paths assume the suggested product location of `\fusionauth`. This path ma
 \fusionauth\logs\fusionauth-search.log
 ----
 
+Note that if you started Windows via Fast Path, the `fusionauth-app.log` file will not be created. Instead the services are running interactively and all logging is written to to stdout.
+
 === Event Log
 
 [NOTE.since]


### PR DESCRIPTION
This caused an issue in this forum post: https://fusionauth.io/community/forum/topic/135/can-t-get-by-maintenance-mode so I thought it'd be worth documenting. This seems like the right place.

Alternatively I could break this out to a separate 'stdout' logs section, but didn't think that made sense right now.