### PR TITLE
Remove forum sitemap entry.

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -17,7 +17,4 @@ sitemap:
   <sitemap>
     <loc>https://fusionauth.io/sitemap-docs.xml</loc>
   </sitemap>
-  <sitemap>
-    <loc>https://fusionauth.io/community/forum/sitemap.xml</loc>
-  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
Because it is a sitemap index itself, we can't include it in the sitemap index. See https://webmasters.stackexchange.com/questions/18243/can-a-sitemap-index-contain-other-sitemap-indexes/76854#76854 for more.

I just submitted it separately.