### PR TITLE
Updated verbiage to be more in line with the other 404 messages.

### DIFF
--- a/site/docs/v1/tech/apis/passwordless.adoc
+++ b/site/docs/v1/tech/apis/passwordless.adoc
@@ -69,7 +69,7 @@ include::docs/src/json/passwordless/start-request.json[]
 |You did not supply a valid Authorization header. The header was omitted or your API key was not valid. The response will be empty. See link:/docs/v1/tech/apis/authentication[Authentication].
 
 |404
-|The user was not found.
+|The user was not found. The response will be empty.
 
 |500
 |There was an internal error. A stack trace is provided and logged in the FusionAuth log files. The response will be empty.


### PR DESCRIPTION
We can't really reuse the verbiage from _login-response-codes.adoc because
that references passwords. But in this case we definitely don't have a
password.

Fix for comments on PR #87 