### PR TITLE
Revert "Client lib index change"

### DIFF
--- a/site/_layouts/doc.liquid
+++ b/site/_layouts/doc.liquid
@@ -116,13 +116,13 @@
                     <li {% if page.url == "/docs/v1/tech/client-libraries/dart.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/dart">Dart</a></li>
                     <li {% if page.url == "/docs/v1/tech/client-libraries/go.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/go">Go</a></li>
                     <li {% if page.url == "/docs/v1/tech/client-libraries/java.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/java">Java</a></li>
+                    <li {% if page.url == "/docs/v1/tech/client-libraries/javascript.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/javascript">JavaScript</a></li>
                     <li {% if page.url == "/docs/v1/tech/client-libraries/netcore.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/netcore">.NET Core</a></li>
+                    <li {% if page.url == "/docs/v1/tech/client-libraries/node.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/node">Node</a></li>
                     <li {% if page.url == "/docs/v1/tech/client-libraries/php.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/php">PHP</a></li>
                     <li {% if page.url == "/docs/v1/tech/client-libraries/python.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/python">Python</a></li>
                     <li {% if page.url == "/docs/v1/tech/client-libraries/ruby.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/ruby">Ruby</a></li>
                     <li {% if page.url == "/docs/v1/tech/client-libraries/typescript.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/typescript">Typescript</a></li>
-                    <li {% if page.url == "/docs/v1/tech/client-libraries/javascript.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/javascript">JavaScript (deprecated)</a></li>
-                    <li {% if page.url == "/docs/v1/tech/client-libraries/node.html" %}class="active"{% endif %}><a href="/docs/v1/tech/client-libraries/node">Node (deprecated)</a></li>
                   </ul>
                 </li>
                 <li {% if page.url contains "/themes/" %} class="open"{% endif %}>

--- a/site/docs/v1/tech/client-libraries/index.adoc
+++ b/site/docs/v1/tech/client-libraries/index.adoc
@@ -12,19 +12,15 @@ Client libraries will help you quickly integrate your application with FusionAut
 
 If we are missing a language, open a https://github.com/FusionAuth/fusionauth-issues/issues[GitHub Issue] as a Feature Request if you don't see it already listed as an open feature.
 
-* link:dart[Dart]
 * link:go[Go]
 * link:java[Java]
+* link:javascript[JavaScript]
 * link:netcore[.NET Core]
+* link:node[Node]
 * link:php[PHP]
 * link:python[Python]
 * link:ruby[Ruby]
 * link:typescript[Typescript]
-
-=== Deprecated libraries
-
-* link:javascript[JavaScript] - superseded by link:typescript[Typescript]
-* link:node[Node] - superseded by link:typescript[Typescript]
 
 === Request and response objects
 


### PR DESCRIPTION
Reverts FusionAuth/fusionauth-site#84

Per discussion, going to take a more measured approach for deprecating older JS libs. Also need to make sure it is clear how the typescript libs can be used in node, browser side or anywhere else.