### PR TITLE
Updating the docs.

### DIFF
--- a/site/docs/v1/tech/client-libraries/ruby.adoc
+++ b/site/docs/v1/tech/client-libraries/ruby.adoc
@@ -34,13 +34,11 @@ Here is an example of using the `register` and the `login` methods to create a n
 # Construct the FusionAuth Client with the following values:
 #  - API Key: 6b87a398-39f2-4692-927b-13188a81a9a3
 #  - Host: http://localhost:9011
-client = FusionAuth::FusionAuthClient.new('6b87a398-39f2-4692-927b-13188a81a9a3', 'http://localhost:9011',
-  ->(cr) { cr.success_response },
-  ->(cr) { raise "Status = #{cr.status} error body = #{cr.error_response}" })
+client = FusionAuth::FusionAuthClient.new('6b87a398-39f2-4692-927b-13188a81a9a3', 'http://localhost:9011')
 
 # Create a user + registration
 id = SecureRandom.uuid
-client.register!(id, {
+client.register(id, {
     :user => {
         :firstName => 'Ruby',
         :lastName => 'Client',
@@ -58,7 +56,7 @@ client.register!(id, {
 })
 
 # Authenticate the user
-response = client.login!({
+response = client.login({
     :loginId => 'ruby.client.test@fusionauth.io',
     :password => 'password',
     :applicationId => application_id


### PR DESCRIPTION
The client library no longer requires the exclamation points. See https://github.com/FusionAuth/fusionauth-ruby-client/issues/3 for an issue that was filed against the lib.