### PR TITLE
Updated group doc.

### DIFF
--- a/site/docs/v1/tech/core-concepts/groups.adoc
+++ b/site/docs/v1/tech/core-concepts/groups.adoc
@@ -10,7 +10,7 @@ description: An overview of FusionAuth Groups
 
 There are a few reasons you may want to use a FusionAuth Group.
 
-The first use may be to simply logically group one or more users within a Tenant. Once a User is a member of a Group they may be identified as a member of the Group and retrieved using the link:../apis/users[User Search APIs] and the Elasticsearch search engine.
+The first use may be to simply logically group one or more users within a Tenant. Once a User is a member of a Group they may be identified as a member of the Group and retrieved using the link:../apis/users#search-for-users[User Search API] and the Elasticsearch search engine.
 
 The second reason you may wish to use a FusionAuth group is to manage Application Role assignment. A Group may be assigned roles from one or more Applications, a member of this Group will be dynamically assigned these roles if they have a registration for the Application.
 

--- a/site/docs/v1/tech/core-concepts/groups.adoc
+++ b/site/docs/v1/tech/core-concepts/groups.adoc
@@ -10,7 +10,7 @@ description: An overview of FusionAuth Groups
 
 There are a few reasons you may want to use a FusionAuth Group.
 
-The first use may be to simply logically group one or more users within a Tenant. Once a User is a member of a Group they may be identified as a member of the Group and retrieved using the link:../apis/groups[Group APIs].
+The first use may be to simply logically group one or more users within a Tenant. Once a User is a member of a Group they may be identified as a member of the Group and retrieved using the link:../apis/users[User Search APIs] and the Elasticsearch search engine.
 
 The second reason you may wish to use a FusionAuth group is to manage Application Role assignment. A Group may be assigned roles from one or more Applications, a member of this Group will be dynamically assigned these roles if they have a registration for the Application.
 


### PR DESCRIPTION
This slack thread: https://fusionauth.slack.com/archives/CG00HG935/p1595407226285800 pointed out that the groups API isn't used to retrieve users.

This commit fixes that.