### PR TITLE
Fix missing image.

### DIFF
--- a/site/docs/v1/tech/samlv2/index.adoc
+++ b/site/docs/v1/tech/samlv2/index.adoc
@@ -23,7 +23,7 @@ In order to configure FusionAuth to act as a SAML identity provider, you need to
 
 The SAML configuration is under the SAML tab on the Application form. In the screenshot below, you can see that we are configuring SAML for the Pied Piper application:
 
-image::samlv2-application.png[Application SAML v2 Configuration,width=1200,role=shadowed]
+image::identity-providers/samlv2-application.png[Application SAML v2 Configuration,width=1200,role=shadowed]
 
 ==== SAML v2 Form Fields
 


### PR DESCRIPTION
The image was moved during the big identity provider rework PR #129, but I missed this image.