### PR TITLE
Fix formatting of example apps on index page

### DIFF
--- a/site/_includes/_example_apps.liquid
+++ b/site/_includes/_example_apps.liquid
@@ -1,13 +1,13 @@
-<ul>
-  {% assign languages = site.data.exampleapps | group_by: "language" |sort: 'name' %}
-  {% for lang in languages %}
-    <li>
+{% assign languages = site.data.exampleapps | group_by: "language" |sort: 'name' %}
+{% for lang in languages %}
+<h2>
       {% unless lang.name == "config" %}
-        <a href='/docs/v1/tech/example-apps/{{ lang.name }}'>{{lang.name | capitalize}}</a>
+        {{lang.name | capitalize}}
       {% endunless %}
       {% if lang.name == "config" %}
         Configuration examples
       {% endif %}
+</h2>
     <ul>
       {% assign sorteditems = lang.items |sort: 'name' %}
       {% for app in sorteditems %}
@@ -19,4 +19,3 @@
       {% endfor %}
     </ul>
   {% endfor %}
-</ul>


### PR DESCRIPTION
The unordered list looked janky, so I changed it to use h2s.