### PR TITLE
Spacing was causing theme formatting to reset.

### DIFF
--- a/site/docs/v1/tech/themes/index.adoc
+++ b/site/docs/v1/tech/themes/index.adoc
@@ -58,7 +58,7 @@ This CSS will be included in the `head` tag in the Helpers `head` macro. You may
 
 [field]#Messages# [optional]#Optional#::
 This section allows you to add additional localized messages to your theme. When creating an additional locale it is not required that all messages are defined for each language. If a message key is not defined for the specified locale, the value from the default bundles will be used.
-
++
 If you intend to localize your login templates, you may find our community contributed and maintained messages in our GitHub repository.
 https://github.com/FusionAuth/fusionauth-localization
 


### PR DESCRIPTION
After the 'messages' section, the formatting was lost. Tweaked asciidoc text to bring it back.