### PR TITLE
Updated the PHP client lib page.

### DIFF
--- a/site/docs/v1/tech/client-libraries/php.adoc
+++ b/site/docs/v1/tech/client-libraries/php.adoc
@@ -9,13 +9,18 @@ description: The FusionAuth PHP Client library allows you to call FusionAuth fro
 
 == PHP Client Library
 
-The PHP client library allows you to integrate FusionAuth with your PHP application.
+The PHP client library allows you to integrate FusionAuth with your PHP application. 
 
 Source code:
 
 * https://github.com/FusionAuth/fusionauth-php-client
 
-Packagist:
+=== Install the library
+
+To use the client library on your project simply copy the PHP source files from the `src` directory to your project or the following
+ Composer package.
+
+Packagist
 
 * https://packagist.org/packages/fusionauth/fusionauth-client
 
@@ -23,24 +28,37 @@ Packagist:
 composer require fusionauth/fusionauth-client
 ```
 
-The following code assumes FusionAuth is running on `\http://localhost:9011` and uses an API key `6b87a398-39f2-4692-927b-13188a81a9a3`, you will need to supply your own API key, and if you are not running FusionAuth locally, your host parameter may be different.
+Include composer autoloader
 
-Here is an example of using the `retrieveUserByEmail` method to retrieve a User by an email address.
+```PHP
+require __DIR__ . '/vendor/autoload.php';
+```
 
-[source,javascript]
-----
-include_once 'FusionAuthClient.php'
+=== Create the Client
 
-$client = new FusionAuthClient('6b87a398-39f2-4692-927b-13188a81a9a3', 'http://localhost:9011');
+The following code assumes FusionAuth is running on `\http://localhost:9011` and uses an API key `5a826da2-1e3a-49df-85ba-cd88575e4e9d`, you will need to supply your own API key, and if you are not running FusionAuth locally, your host parameter may be different.
 
-$email = "user@example.com";
-$response = client->retrieveUserByEmail($email);
-if ($response->wasSuccessful()) {
-  $user = $response->successResponse->user;
-} else {
-  // Handle $response->errorResponse or $response->exception
+```PHP
+$apiKey = "5a826da2-1e3a-49df-85ba-cd88575e4e9d";
+$client = new FusionAuth\FusionAuthClient($apiKey, "http://localhost:9011");
+```
+
+=== Login a user
+
+```PHP
+$applicationId = "68364852-7a38-4e15-8c48-394eceafa601";
+
+$request = array();
+$request["applicationId"] = $applicationId;
+$request["loginId"] = "joe@fusionauth.io";
+$request["password"] = "abc123";
+$result = $client->login($request);
+if (!$result->wasSuccessful()) {
+ // Error
 }
-----
+
+// Hooray! Success
+```
 
 ++++
 {% capture relatedTag %}client-php{% endcapture %}


### PR DESCRIPTION
The existing example was busted. Pulled over the github readme which looks correct.

Looked at an automated way to do this, but after 15 min didn't find one (asciidoctor can pull in urls, but couldn't find a way to allow jekyll to pass the 'allow-uri-read' param to it)