### PR TITLE
Updated doc about fabricating email addresses.

### DIFF
--- a/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
+++ b/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
@@ -70,7 +70,9 @@ console.info(JSON.stringify(jwt, null, 2));
 
 === Workarounds
 
-If the JWT from the OIDC identity provider does not come back with a claim called `email`, you can add your own. If the Userinfo response available to you in the lambda has a unique user, you can build a fake email address from it. 
+If the JWT from the OIDC identity provider does not come back with an email claim you can add your own. This claim is `email` by default but may be changed with the `oauth2.emailClaim` as documented in the link:/docs/v1/tech/apis/identity-providers/openid-connect[API docs]. 
+
+If the Userinfo response available to you in the lambda has a unique user, you can build a fake email address from it. 
 
 Here, the `sub` claim is the unique user id, and we're building an email address:
 
@@ -83,7 +85,7 @@ function(user, registration, jwt) {
 
 Make sure you pick an email address for a domain you control to avoid malicious attacks. 
 
-This workaround only is available if you are on version 1.18.7 or greater. 
+This workaround only is available if you are on version 1.18.7 or greater and if no claim is returned.
 
 === Limitations
 

--- a/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
+++ b/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
@@ -68,6 +68,23 @@ During development if you want to get a better idea of what your IdP is returnin
 console.info(JSON.stringify(jwt, null, 2));
 ----
 
+=== Workarounds
+
+If the JWT from the OIDC identity provider does not come back with a claim called `email`, you can add your own. If the Userinfo response available to you in the lambda has a unique user, you can build a fake email address from it. 
+
+Here, the `sub` claim is the unique user id, and we're building an email address:
+
+```javascript
+function(user, registration, jwt) {
+  // The user's unique Id is the 'sub' claim. 
+  user.email = jwt.sub + '@no-email-present.example.com';
+}
+```
+
+Make sure you pick an email address for a domain you control to avoid malicious attacks. 
+
+This workaround only is available if you are on version 1.18.7 or greater. 
+
 === Limitations
 
 The `user.email` field on the user will be ignored if modified by the lambda function. This is to protect the integrity of the `email` claim returned by the identity provider. The `user.username` field on the user will be ignored if modified by the lambda function. This is to mitigate the risks of an account takeover due to a non globally unique identifier.

--- a/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
+++ b/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
@@ -72,7 +72,7 @@ console.info(JSON.stringify(jwt, null, 2));
 
 If the JWT from the OIDC identity provider does not come back with an email claim you can add your own. This claim is `email` by default but may be changed with the `oauth2.emailClaim` as documented in the link:/docs/v1/tech/apis/identity-providers/openid-connect[API docs]. 
 
-If the Userinfo response available to you in the lambda has a unique user, you can build a fake email address from it. 
+If the Userinfo response available to you in the lambda has unique user information, you can build a fake email address from it. 
 
 Here, the `sub` claim is the unique user id, and we're building an email address:
 

--- a/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
+++ b/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
@@ -83,7 +83,7 @@ function(user, registration, jwt) {
 }
 ```
 
-Make sure you pick an email address for a domain you control to avoid malicious attacks. 
+Make sure you pick an email address for a domain you control to avoid malicious attacks. This will run your lambda twice.
 
 This workaround only is available if you are on version 1.18.7 or greater and if no claim is returned.
 


### PR DESCRIPTION
This is from this forum post: https://fusionauth.io/community/forum/topic/304/identity-provider-with-no-email/3