### PR TITLE
Update api login doc

### DIFF
--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -6,6 +6,8 @@ ifdef::login_response,passwordless_login_response[]
 The refresh token that can be used to obtain a new access token once the provide one has expired.
 +
 Because a refresh token is per user and per application, this value will only be returned when an [field]#applicationId# was provided on the login request.
++
+You must configure the application to allow generation of refresh tokens. Configure the [field]#application.loginConfiguration.generateRefreshTokens# setting in the application.
 
 ifdef::login_response[]
 [field]#state# [type]#[Object]#::

--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -7,7 +7,7 @@ The refresh token that can be used to obtain a new access token once the provide
 +
 Because a refresh token is per user and per application, this value will only be returned when an [field]#applicationId# was provided on the login request.
 +
-You must configure the application to allow generation of refresh tokens. Configure the [field]#application.loginConfiguration.generateRefreshTokens# setting in the application.
+You must explicitly allow generation of refresh tokens when using the Login API. Configure the [field]#application.loginConfiguration.generateRefreshTokens# setting via the API or enable the setting by navigating to the [breadcrumb]#Application -> My Application -> Security# tab.
 
 ifdef::login_response[]
 [field]#state# [type]#[Object]#::


### PR DESCRIPTION
Make it more clear that refresh tokens aren't sent by default, but that you have to configure the application to do so.