### PR TITLE
More details about this setting.

### DIFF
--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -104,7 +104,7 @@ If you do not intend to use the Login API, or will only be calling this API from
 The name of the Application.
 
 [field]#application.oauthConfiguration.authorizedOriginURLs# [type]#[Array<String>]# [optional]#Optional#::
-An array of URLs that are the authorized origins for FusionAuth OAuth.
+An array of URLs that are the authorized origins for FusionAuth OAuth. If configured, these URLs will be allowed to embed a FusionAuth hosted login page, otherwise the `X-Frame-Options` header will be set to `DENY`.
 
 [field]#application.oauthConfiguration.authorizedRedirectURLs# [type]#[Array<String>]# [optional]#Optional#::
 An array of URLs that are the authorized redirect URLs for FusionAuth OAuth.

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -104,7 +104,9 @@ If you do not intend to use the Login API, or will only be calling this API from
 The name of the Application.
 
 [field]#application.oauthConfiguration.authorizedOriginURLs# [type]#[Array<String>]# [optional]#Optional#::
-An array of URLs that are the authorized origins for FusionAuth OAuth. If configured, these URLs will be allowed to embed a FusionAuth hosted login page, otherwise the `X-Frame-Options` header will be set to `DENY`.
+An array of URLs that are the authorized origins for FusionAuth OAuth.
++
+For improved security, all FusionAuth hosted login pages add an HTTP response header of `X-Frame-Options: DENY`. This response header disallows loading the FusionAuth pages from an iframe. To utilize an iframe and load one or more of the FusionAuth hosted login pages, add the iframe page URLs to this property. For that host, FusionAuth will remove the `X-Frame-Options` header allowing the page to load in the iframe.
 
 [field]#application.oauthConfiguration.authorizedRedirectURLs# [type]#[Array<String>]# [optional]#Optional#::
 An array of URLs that are the authorized redirect URLs for FusionAuth OAuth.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -98,7 +98,7 @@ Indicates if a Refresh Token should be issued from the Login API.
 Indicates if the Login API should require an API key. If you set this value to `false` and your FusionAuth API is on a public network, anyone may attempt to use the Login API.
 
 [field]#application.oauthConfiguration.authorizedOriginURLs# [type]#[Array<String>]#::
-An array of URLs that are the authorized origins for FusionAuth OAuth.
+An array of URLs that are the authorized origins for FusionAuth OAuth. If configured, these URLs will be allowed to embed a FusionAuth hosted login page, otherwise the `X-Frame-Options` header will be set to `DENY`.
 
 [field]#application.oauthConfiguration.authorizedRedirectURLs# [type]#[Array<String>]#::
 An array of URLs that are the authorized redirect URLs for FusionAuth OAuth.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -98,7 +98,9 @@ Indicates if a Refresh Token should be issued from the Login API.
 Indicates if the Login API should require an API key. If you set this value to `false` and your FusionAuth API is on a public network, anyone may attempt to use the Login API.
 
 [field]#application.oauthConfiguration.authorizedOriginURLs# [type]#[Array<String>]#::
-An array of URLs that are the authorized origins for FusionAuth OAuth. If configured, these URLs will be allowed to embed a FusionAuth hosted login page, otherwise the `X-Frame-Options` header will be set to `DENY`.
+An array of URLs that are the authorized origins for FusionAuth OAuth. 
++
+When this configuration is omitted, all HTTP origins are allowed to use the browser based grants and the HTTP response header of `X-Frame-Options: DENY` will be added to each response to disallow iframe loading.
 
 [field]#application.oauthConfiguration.authorizedRedirectURLs# [type]#[Array<String>]#::
 An array of URLs that are the authorized redirect URLs for FusionAuth OAuth.

--- a/site/docs/v1/tech/core-concepts/applications.adoc
+++ b/site/docs/v1/tech/core-concepts/applications.adoc
@@ -92,7 +92,7 @@ In order to utilize grants that require a browser redirect using the `redirect_u
 [field]#Authorized request origin URLs# [optional]#Optional#::
 This optional configuration allows you to restrict the origin of an OAuth2 / OpenID Connect grant request. If no origins are registered for this application, all origins are allowed.
 +
-By default FusionAuth will add the `X-Frame-Deny` HTTP response header to the login pages to keep these pages from being rendered in an IFRAME. If the request comes from an authorized origin, FusionAuth will not add this header to the response. If you wish to load FusionAuth login pages in an IFRAME you will need to add the request origin to this configuration.
+By default FusionAuth will add the `X-Frame-Options: DENY` HTTP response header to the login pages to keep these pages from being rendered in an iframe. If the request comes from an authorized origin, FusionAuth will not add this header to the response. If you wish to load FusionAuth login pages in an iframe you will need to add the request origin to this configuration.
 
 [field]#Logout URL# [optional]#Optional#::
 The optional logout URL for this application. When provided this logout URL should handle the logout of a user in your application.

--- a/site/docs/v1/tech/core-concepts/applications.adoc
+++ b/site/docs/v1/tech/core-concepts/applications.adoc
@@ -97,7 +97,7 @@ By default FusionAuth will add the `X-Frame-Options: DENY` HTTP response header 
 [field]#Logout URL# [optional]#Optional#::
 The optional logout URL for this application. When provided this logout URL should handle the logout of a user in your application.
 +
-If you need to end an HTTP session, or delete cookies to logout a user from your application, these operations should be handled by this URL. When the `/oauth2/logout` endpoint is utilized, each Logout URL registered for applications in this tenant will be called within an IFRAME to complete the SSO logout.
+If you need to end an HTTP session, or delete cookies to logout a user from your application, these operations should be handled by this URL. When the `/oauth2/logout` endpoint is utilized, each Logout URL registered for applications in this tenant will be called within an iframe to complete the SSO logout.
 +
 If the OAuth2 logout endpoint is used with this Client Id this configured Logout URL will be also utilized as the redirect URL if the `post_logout_redirect_uri` parameter was not provided.
 +


### PR DESCRIPTION
The authorized origin urls setting is a bit opaque to me, so this adds some details.

Came out of this forum post: https://fusionauth.io/community/forum/topic/359/why-can-t-i-disable-x-frame-options-or-use-csp-instead