### PR TITLE
Fix borked css on theme page.

### DIFF
--- a/site/docs/v1/tech/themes/index.adoc
+++ b/site/docs/v1/tech/themes/index.adoc
@@ -381,7 +381,7 @@ A map of field messages (usually errors) that were generated during the processi
 
 [field]#locale# [type]#[Locale]#::
 The locale used to localize messages.
-
++
 You can find the JavaDoc for this object available here: https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html
 
 [field]#request# [type]#[HttpServletRequest]#::


### PR DESCRIPTION
The locale variable section wasn't treated as one section, causing the css to bust.