### PR TITLE
Updated doc to clarify implicit grant.

### DIFF
--- a/site/docs/v1/tech/oauth/index.adoc
+++ b/site/docs/v1/tech/oauth/index.adoc
@@ -206,18 +206,18 @@ Location: https://www.piedpiper.com
 ====
 *Warning*
 
-The Authorization Code Grant is always preferred over the Implicit Grant due to the inherent security risks of this grant. This grant is provided for compatibility with existing integrations but the use of this grant is not recommended it should be avoided.
+The Authorization Code Grant is always preferred over the Implicit Grant due to the inherent security risks of this grant. This grant is provided for compatibility with existing integrations but the use of this grant is not recommended.
 
-When using this grant type the access token will be returned on the URL as a fragment which makes it susceptible to be intercepted. Additionally the client (browser) does not have a secure way to store the token which makes the token susceptible to theft.
+When using this grant type the access token will be returned on the URL as a fragment which makes it susceptible to be intercepted. Additionally the client (the browser) does not have a secure way to store the token which makes the token susceptible to theft.
 
 If you are still not convinced, proceed at your own risk and implement his grant type using the following example.
 ====
 
 The Implicit Grant is similar to the Authorization grant, instead of exchanging a code for an access token, the token is provided on the initial request.
 
-=== Exchange the user credentials for an access token
+=== Redirect the user to the authorization server
 
-Once you have collected the user's email and password you will make a `GET` request to the Authorize endpoint. Below is an example HTTP request where the user's email is `richard@piedpiper.com` and password is `disrupt`. The `response_type` will always be `token`.
+Make a `GET` request to the Authorize endpoint with the `client_id` and `redirect_uri`. Below is an example HTTP request. The `response_type` will always be `token`.
 
 Line breaks have been added for readability.
 
@@ -227,8 +227,7 @@ Line breaks have been added for readability.
 GET /oauth2/authorize?
       client_id=3c219e58-ed0e-4b18-ad48-f4f92793ae32
       &response_type=token
-      &username=richard%40piedpiper.com
-      &password=disrupt HTTP/1.1
+      &redirect_uri=https%3A%2F%2Fwww.piedpiper.com%2Fcallback
 Host: piedpiper.fusionauth.io
 ----
 

--- a/site/docs/v1/tech/oauth/index.adoc
+++ b/site/docs/v1/tech/oauth/index.adoc
@@ -208,16 +208,16 @@ Location: https://www.piedpiper.com
 
 The Authorization Code Grant is always preferred over the Implicit Grant due to the inherent security risks of this grant. This grant is provided for compatibility with existing integrations but the use of this grant is not recommended.
 
-When using this grant type the access token will be returned on the URL as a fragment which makes it susceptible to be intercepted. Additionally the client (the browser) does not have a secure way to store the token which makes the token susceptible to theft.
+When using this grant type the access token will be returned on the URL as a fragment which makes it susceptible to being intercepted. Additionally the client (the browser) does not have a secure way to store the token which makes the token susceptible to theft.
 
-If you are still not convinced, proceed at your own risk and implement his grant type using the following example.
+If you are still not convinced, proceed at your own risk and implement this grant type using the following example.
 ====
 
-The Implicit Grant is similar to the Authorization grant, instead of exchanging a code for an access token, the token is provided on the initial request.
+The Implicit Grant is similar to the Authorization grant, instead of exchanging a code for an access token, the token is provided on in response to the initial authorization request.
 
-=== Redirect the user to the authorization server
+=== Make the authorization request to the authorization server
 
-Make a `GET` request to the Authorize endpoint with the `client_id` and `redirect_uri`. Below is an example HTTP request. The `response_type` will always be `token`.
+Make a `GET` request to the Authorize endpoint with the `client_id` and `redirect_uri`. The `response_type` will always be `token`. Below is an example HTTP request.
 
 Line breaks have been added for readability.
 
@@ -233,7 +233,7 @@ Host: piedpiper.fusionauth.io
 
 &nbsp;
 
-Upon successful authentication, a redirect to the configured [field]#redirect_uri# will be made an [field]#access_token# as one of the redirect parameters. The following is an example HTTP 302 redirect, line breaks added to improve readability. The redirect from an Implicit Grant will contain parameters after the fragment `#`.
+Upon successful authentication, a redirect to the configured [field]#redirect_uri# will be made with an [field]#access_token# as one of the redirect parameters. The following is an example HTTP 302 redirect, with line breaks added to improve readability. The redirect from an Implicit Grant will contain parameters after the fragment delimiter, `#`.
 
 [source]
 .HTTP Redirect Response


### PR DESCRIPTION
The username/password is not required for the implicit grant, and previously this doc specified that.