### PR TITLE
Fixed small typo.

### DIFF
--- a/site/docs/v1/tech/apis/_webhook-request-body.adoc
+++ b/site/docs/v1/tech/apis/_webhook-request-body.adoc
@@ -41,7 +41,7 @@ The HTTP basic authentication username that is sent as part of the HTTP request 
 The read timeout in milliseconds used when FusionAuth sends events to the Webhook.
 
 [field]#webhook.sslCertificate# [type]#[String]# [optional]#Optional#::
-An SSL certificate in PEM format that is used to establish the a SSL (TLS specifically) connection to the Webhook.
+An SSL certificate in PEM format that is used to establish the SSL (TLS specifically) connection to the Webhook.
 
 [field]#webhook.url# [type]#[String]# [required]#Required#::
 The fully qualified URL of the Webhook's endpoint that will accept the event requests from FusionAuth.

--- a/site/docs/v1/tech/apis/_webhook-response-body.adoc
+++ b/site/docs/v1/tech/apis/_webhook-response-body.adoc
@@ -44,7 +44,7 @@ The Id of the Webhook.
 The read timeout in milliseconds used when FusionAuth sends events to the Webhook.
 
 [field]#webhook.sslCertificate# [type]#[String]#::
-An SSL certificate in PEM format that is used to establish the a SSL (TLS specifically) connection to the Webhook.
+An SSL certificate in PEM format that is used to establish the SSL (TLS specifically) connection to the Webhook.
 
 [field]#webhook.url# [type]#[String]#::
 The fully qualified URL of the Webhook's endpoint that will accept the event requests from FusionAuth.


### PR DESCRIPTION
just a `the a` typo in the webhook ssl cert api docs.