### PR TITLE
Add Connector video to docs

### DIFF
--- a/site/docs/v1/tech/connectors/index.adoc
+++ b/site/docs/v1/tech/connectors/index.adoc
@@ -8,6 +8,11 @@ description: FusionAuth Identity Providers
 
 == Overview
 
+[NOTE.since]
+====
+Available since 1.18.0
+====
+
 Connectors allow you to connect other sources of user data to your FusionAuth instance. Once the connection is created, you may either:
 
 * Authenticate the user against the external data source, or

--- a/site/docs/v1/tech/connectors/ldap-connector.adoc
+++ b/site/docs/v1/tech/connectors/ldap-connector.adoc
@@ -23,6 +23,14 @@ To use a LDAP Connector:
 ** LDAP directory settings
 * Add the Connector Policy in [breadcrumb]#Tenants -> Your Tenant -> Connectors# to configure to which domains the connector applies.
 
+=== Active Directory
+
+User data stored in Microsoft Active Directory is accessible via LDAP. If you'd like to federate and allow some of your users to authenticate against Active Directory, use the LDAP Connector.
+
+Here's a video walking through such a configuration of FusionAuth and Microsoft Active Directory:
+
+video::Cqd7EgK4ess[youtube,width=560,height=315]
+
 === LDAP Directory Settings
 
 These allow FusionAuth to access your LDAP directory and map the data from it to FusionAuth.


### PR DESCRIPTION
This adds the microsoft active directory video to the connector docs.

Also adds a 'since 1.18.0' label to the connector docs.