### PR TITLE
color references

### DIFF
--- a/site/docs/v1/tech/apis/authentication.adoc
+++ b/site/docs/v1/tech/apis/authentication.adoc
@@ -48,7 +48,7 @@ curl -H 'Authorization: 2524a832-c1c6-4894-9125-41a9ea84e013'
 
 == JWT Authentication
 
-When an API is marked with a green identity icon such as &nbsp;icon:id-badge[role=green, title="Supports JWT",type=fas]&nbsp; it means you may call this API without
+When an API is marked with a blue identity icon such as &nbsp;icon:id-badge[role=green, title="Supports JWT",type=fas]&nbsp; it means you may call this API without
  an API key but instead provide a JSON Web Token (JWT) pronounced "jot". These APIs may be called with a signed token in place of an API key. A JWT is
  obtained from the Login API. The token will also be provided as an HTTP Only Session cookie. If cookies are being managed for you by the browser or some
  other RESTful client, the JWT cookie will automatically be send to FusionAuth on your behalf and you may omit the `Authorization` header.
@@ -90,7 +90,7 @@ Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODUxNDA5OD
 
 == No Authentication Required
 
-When an API that is marked with an unlocked icon such as &nbsp;icon:unlock-alt[role=green, title="No authentication required",type=fas] it means that you are not
+When an API that is marked with a green unlocked icon such as &nbsp;icon:unlock-alt[role=green, title="No authentication required",type=fas] it means that you are not
  required to provide an `Authorization` header as part of the request. The API is either designed to be publicly accessible or the request may take a parameter that is itself secure.
 
 == Manage API Keys


### PR DESCRIPTION
Fix blue-green references to authentication requirement icons
Validate visually here: https://fusionauth.io/docs/v1/tech/apis/authentication