### PR TITLE
Fixed 1.10 note

### DIFF
--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -339,7 +339,12 @@ The possible values are:
 
 This endpoint provides a mechanism to invalidate the user's session held by FusionAuth, this effectively logs the user out of FusionAuth.
 
-Since 1.10.0 The logout behavior follows that of the https://openid.net/specs/openid-connect-frontchannel-1_0.html[OpenID Connect Front-Channel Logout] specification.
+[NOTE.since]
+====
+This API has been available since 1.10.0
+====
+
+The logout behavior follows that of the https://openid.net/specs/openid-connect-frontchannel-1_0.html[OpenID Connect Front-Channel Logout] specification.
 Additionally, the logoutUrl used for each application is determined as follows: The logoutUrl of the Application is used, if that isn't set then the logoutUrl of the Tenant is used.
 
 === Request


### PR DESCRIPTION
It wasn't using the correct markup.