### PR TITLE
fixed typo.

### DIFF
--- a/site/docs/v1/tech/themes/index.adoc
+++ b/site/docs/v1/tech/themes/index.adoc
@@ -154,7 +154,7 @@ This page is used if the user is required to change their password or if they ha
 +
 [uri]#/password/change#
 
-[field]#OAuth password password complete# [required]#Required#::
+[field]#OAuth password complete# [required]#Required#::
 This page is used after the user has successfully updated their password (or reset it). This page should instruct the user that their password was updated and that they need to login again.
 +
 [uri]#/password/complete#


### PR DESCRIPTION
This template name had an extra 'password' in it.