### PR TITLE
Removed extra === 

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc
@@ -78,4 +78,3 @@ The access token, this string is an encoded JSON Web Token (JWT). This cookie is
 [field]#refresh_token# [type]#[String]#::
 The refresh token. This cookie is written in the response as an HTTP only persistent cookie. The cookie expiration is configured in the JWT
 configuration for the application or the global JWT configuration.
-===


### PR DESCRIPTION
which was causing the refresh_token response cookie field to be rendered incorrectly.

I saw this originally at https://fusionauth.io/docs/v1/tech/apis/identity-providers/twitter#complete-the-twitter-login but this shows up on facebook too.