### PR TITLE
Updated idp hint doc.

### DIFF
--- a/site/docs/v1/tech/identity-providers/index.adoc
+++ b/site/docs/v1/tech/identity-providers/index.adoc
@@ -63,7 +63,7 @@ When you are using the FusionAuth hosted login pages, you can bypass the login p
 Hints only work with SAMLv2 or OpenID Connect identity providers.
 ====
 
-An Identity Provider Id is appended to the Login URL for an application using the `idp_hint` request parameter. For example, to send a user directly to the Google login page, you'd append `&idp_hint=82339786-3dff-42a6-aac6-1f1ceecb6c46`.
+An Identity Provider Id is appended to the Login URL for an application using the `idp_hint` request parameter. For example, to send a user directly to a login page for an OIDC identity provider with the id `44449786-3dff-42a6-aac6-1f1ceecb6c46`, you'd append `&idp_hint=44449786-3dff-42a6-aac6-1f1ceecb6c46`.
 
 An email address or domain may be provided in the `login_hint` request parameter, if the IdP is SAMLv2 or OpenID Connect. For example, to send a user directly to the login page of an OIDC IdP configured with a domain of `example.com`, you'd append `&login_hint=example.com` to the application's Login URL.
 


### PR DESCRIPTION
Per https://github.com/FusionAuth/fusionauth-issues/issues/909 google doesn't work, so shouldn't have this in the example.