### PR TITLE
[126] Documentation Changes for 1.20.0 for the Forms API

### DIFF
--- a/site/docs/v1/tech/apis/_form-request-body.adoc
+++ b/site/docs/v1/tech/apis/_form-request-body.adoc
@@ -5,6 +5,15 @@
 [field]#form.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Form that should be persisted.
 
+[field]#form.type# [type]#[String]# [optional]#Optional#::
+The type of registration associated with this form. The possible values are:
++
+ * `registration` which is used for self-service registration processes
+ * `adminRegistration` which is used for administrator registration processes, utilizes `registration.data.*` custom fields
+ * `adminUser` which is used for administrator registration process, utilizes `user.data.*` custom fields
++
+The form will default to `registration` type if not passed in.
+
 [field]#form.name# [type]#[String]# [required]#Required#::
 The unique name of the Form.
 

--- a/site/docs/v1/tech/apis/_form-request-body.adoc
+++ b/site/docs/v1/tech/apis/_form-request-body.adoc
@@ -5,7 +5,7 @@
 [field]#form.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Form that should be persisted.
 
-[field]#form.type# [type]#[String]# [optional]#Optional#::
+[field]#form.type# [type]#[String]# [optional]#Optional# [since]#Available since 1.20.0#::::
 The type of registration associated with this form. The possible values are:
 +
  * `registration` which is used for self-service registration processes

--- a/site/docs/v1/tech/apis/_form-request-body.adoc
+++ b/site/docs/v1/tech/apis/_form-request-body.adoc
@@ -35,7 +35,7 @@ If you were to add the following messages to your theme, the localized form of t
 If you utilize the same form for multiple tenants, you can specify the specific configuration for the tenant by providing the unique Id for the tenant. An example would be as follows:
 +
 ```
-{user-form-section.cbeaf8fe-f4a7-4a27-9f77-c609f1b01856}2=Tenant specific section name
+{user-form-section.cbeaf8fe-f4a7-4a27-9f77-c609f1b01856}2=Tenant specific label for section 2
 ```
 +
 If you would like to configure a form to have different section names based on an application, you can provide the unique Id for the application. An example would be as follows:

--- a/site/docs/v1/tech/apis/_form-request-body.adoc
+++ b/site/docs/v1/tech/apis/_form-request-body.adoc
@@ -6,11 +6,12 @@
 An object that can hold any information about the Form that should be persisted.
 
 [field]#form.type# [type]#[String]# [optional]#Optional# [default]#defaults to `registration`# [since]#Available since 1.20.0#::
-The type of registration associated with this form. The possible values are:
+The type of form being created, a form type cannot be changed after the form has been created. This type will be used to identify how this form can be utilized by FusionAuth.
 +
- * `registration` which is used for self-service registration processes
- * `adminRegistration` which is used for administrator registration processes, utilizes `registration.data.*` custom fields
- * `adminUser` which is used for administrator registration process, utilizes `user.data.*` custom fields
+ * `registration` This form will be used for self service registration.
+ * `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI.
+ * `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI.
+
 
 [field]#form.name# [type]#[String]# [required]#Required#::
 The unique name of the Form.

--- a/site/docs/v1/tech/apis/_form-request-body.adoc
+++ b/site/docs/v1/tech/apis/_form-request-body.adoc
@@ -8,9 +8,9 @@ An object that can hold any information about the Form that should be persisted.
 [field]#form.type# [type]#[String]# [optional]#Optional# [default]#defaults to `registration`# [since]#Available since 1.20.0#::
 The type of form being created, a form type cannot be changed after the form has been created. This type will be used to identify how this form can be utilized by FusionAuth.
 +
- * `registration` This form will be used for self service registration.
- * `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI.
- * `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI.
+ * `registration` - This form will be used for self service registration.
+ * `adminRegistration` - This form be used to customize the add and edit User Registration form in the FusionAuth UI.
+ * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI.
 
 
 [field]#form.name# [type]#[String]# [required]#Required#::
@@ -26,22 +26,22 @@ Steps manifest in two different ways. When the form type is `adminRegistration` 
 You may localize the displayed value of this key during registration by adding the key to your theme.
 For example, if you specify the key value of `{user-form-section}1` this key value be rendered in the UI, where `1` specifies the section number to adjust the value of.
 +
-If you were to add the following messages to your theme, the localized form of the value will be shown during the administrator registration. This allows you to provide a customized section name and optionally localize the field name as well.
+Adding the following message to your theme will cause the first section of the User add or edit form to be rendered as "Optionally name me!". This feature allows you to customize and optionally localize each section heading within the User form.
 + 
 ```
 {user-form-section}1=Optionally name me!
 ```
 +
-If you utilize the same form for multiple tenants, you can specify the specific configuration for the tenant by providing the unique Id for the tenant. An example would be as follows:
+You may optionally provide a specific label per tenant by prefixing the value the with the tenant Id as follows:
 +
 ```
-{user-form-section.cbeaf8fe-f4a7-4a27-9f77-c609f1b01856}2=Tenant specific label for section 2
+[cbeaf8fe-f4a7-4a27-9f77-c609f1b01856]{user-form-section}2=Tenant specific label for section 2
 ```
 +
-If you would like to configure a form to have different section names based on an application, you can provide the unique Id for the application. An example would be as follows:
+You may also optionally provide a specific label per application for a registration form by prefixing the value the with the application Id as follows:
 +
 ```
-{registration-form-section.cfb5fab7-b3b6-41bb-adfa-d23ac83a96e5}2=Application specific label for section 2
+[cfb5fab7-b3b6-41bb-adfa-d23ac83a96e5]{registration-form-section}2=Application specific label for section 2
 ```
 
 [field]#form.steps``[x]``.fields# [type]#[Array<UUID>]#::

--- a/site/docs/v1/tech/apis/_form-request-body.adoc
+++ b/site/docs/v1/tech/apis/_form-request-body.adoc
@@ -18,6 +18,31 @@ The unique name of the Form.
 
 [field]#form.steps# [type]#[Array<Object>]# [required]#Required#::
 An ordered list of objects containing one or more Form Fields. A Form must have at least one step defined.
++
+Steps manifest in two different ways. When the form type is `adminRegistration` or `adminUser` steps will be rendered as `sections` because there are no multi-step forms within the UI. For `registration` each step will be considered a step within a multi-step form.
++
+*Localization*
++
+You may localize the displayed value of this key during registration by adding the key to your theme.
+For example, if you specify the key value of `{user-form-section}1` this key value be rendered in the UI, where `1` specifies the section number to adjust the value of.
++
+If you were to add the following messages to your theme, the localized form of the value will be shown during the administrator registration. This allows you to provide a customized section name and optionally localize the field name as well.
++ 
+```
+{user-form-section}1=Optionally name me!
+```
++
+If you utilize the same form for multiple tenants, you can specify the specific configuration for the tenant by providing the unique Id for the tenant. An example would be as follows:
++
+```
+{user-form-section.cbeaf8fe-f4a7-4a27-9f77-c609f1b01856}2=Tenant specific section name
+```
++
+If you would like to configure a form to have different section names based on an application, you can provide the unique Id for the application. An example would be as follows:
++
+```
+{registration-form-section.cfb5fab7-b3b6-41bb-adfa-d23ac83a96e5}2=Application specific label for section 2
+```
 
 [field]#form.steps``[x]``.fields# [type]#[Array<UUID>]#::
 An ordered list of Form Field Ids assigned to this step.

--- a/site/docs/v1/tech/apis/_form-request-body.adoc
+++ b/site/docs/v1/tech/apis/_form-request-body.adoc
@@ -5,14 +5,12 @@
 [field]#form.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Form that should be persisted.
 
-[field]#form.type# [type]#[String]# [optional]#Optional# [since]#Available since 1.20.0#::::
+[field]#form.type# [type]#[String]# [optional]#Optional# [default]#defaults to `registration`# [since]#Available since 1.20.0#::
 The type of registration associated with this form. The possible values are:
 +
  * `registration` which is used for self-service registration processes
  * `adminRegistration` which is used for administrator registration processes, utilizes `registration.data.*` custom fields
  * `adminUser` which is used for administrator registration process, utilizes `user.data.*` custom fields
-+
-The form will default to `registration` type if not passed in.
 
 [field]#form.name# [type]#[String]# [required]#Required#::
 The unique name of the Form.

--- a/site/docs/v1/tech/apis/_form-response-body.adoc
+++ b/site/docs/v1/tech/apis/_form-response-body.adoc
@@ -25,9 +25,9 @@ An ordered list of Form Field Ids assigned to this step.
 [field]#form.type# [type]#[String]#::
 The form type. The possible values are:
 +
-* `registration` This form will be used for self service registration.
-* `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI. [since]#Available since 1.20.0#
-* `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI. [since]#Available since 1.20.0#
+* `registration` - This form will be used for self service registration.
+* `adminRegistration` - This form be used to customize the add and edit User Registration form in the FusionAuth UI. [since]#Available since 1.20.0#
+* `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. [since]#Available since 1.20.0#
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/_form-response-body.adoc
+++ b/site/docs/v1/tech/apis/_form-response-body.adoc
@@ -26,8 +26,8 @@ An ordered list of Form Field Ids assigned to this step.
 The form type. The possible values are:
 +
 * `registration` This form will be used for self service registration.
-* `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI.
-* `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI.
+* `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI. [since]#Available since 1.20.0#
+* `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI. [since]#Available since 1.20.0#
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/_form-response-body.adoc
+++ b/site/docs/v1/tech/apis/_form-response-body.adoc
@@ -26,6 +26,8 @@ An ordered list of Form Field Ids assigned to this step.
 The form type. The possible values are:
 +
 * `registration`
+* `adminRegistration`
+* `adminUser`
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/_form-response-body.adoc
+++ b/site/docs/v1/tech/apis/_form-response-body.adoc
@@ -25,9 +25,9 @@ An ordered list of Form Field Ids assigned to this step.
 [field]#form.type# [type]#[String]#::
 The form type. The possible values are:
 +
-* `registration`
-* `adminRegistration`
-* `adminUser`
+* `registration` This form will be used for self service registration.
+* `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI.
+* `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI.
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/_forms-response-body.adoc
+++ b/site/docs/v1/tech/apis/_forms-response-body.adoc
@@ -29,8 +29,8 @@ An ordered list of Form Field Id's assigned to this step.
 The Form type. The possible values are:
 +
 * `registration` This form will be used for self service registration.
-* `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI.
-* `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI.
+* `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI. [since]#Available since 1.20.0#
+* `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI. [since]#Available since 1.20.0#
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/_forms-response-body.adoc
+++ b/site/docs/v1/tech/apis/_forms-response-body.adoc
@@ -28,9 +28,9 @@ An ordered list of Form Field Id's assigned to this step.
 [field]#forms``[x]``.type# [type]#[String]#::
 The Form type. The possible values are:
 +
-* `registration` This form will be used for self service registration.
-* `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI. [since]#Available since 1.20.0#
-* `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI. [since]#Available since 1.20.0#
+* `registration` - This form will be used for self service registration.
+* `adminRegistration` - This form be used to customize the add and edit User Registration form in the FusionAuth UI. [since]#Available since 1.20.0#
+* `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. [since]#Available since 1.20.0#
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/_forms-response-body.adoc
+++ b/site/docs/v1/tech/apis/_forms-response-body.adoc
@@ -28,7 +28,9 @@ An ordered list of Form Field Id's assigned to this step.
 [field]#forms``[x]``.type# [type]#[String]#::
 The Form type. The possible values are:
 +
-* `registration`
+* `registration` This form will be used for self service registration.
+* `adminRegistration` This form be used to customize the add and edit User Registration form in the FusionAuth UI.
+* `adminUser` This form can be used to customize the add and edit User form in the FusionAuth UI.
 
 [source,json]
 .Example Response JSON


### PR DESCRIPTION
Related Issues
-----

[126](https://github.com/FusionAuth/fusionauth-internal-issues/issues/126#event-3878959984)

Background
----

Adds documentation for a new optional field on the Forms API. That field being `form.type`