### PR TITLE
[126] Documentation Changes for 1.20.0 for the Applications API

### DIFF
--- a/site/docs/src/json/applications/post-request.json
+++ b/site/docs/src/json/applications/post-request.json
@@ -84,7 +84,7 @@
       "enabled" : true,
       "issuer" : "example.com",
       "keyId" : "0a52ace4-3016-47da-906a-f7d272fbdaed",
-      "requiredSignedRequests": true,
+      "requireSignedRequests": true,
       "xmlSignatureC14nMethod" : "exclusive_with_comments"
     }
   },

--- a/site/docs/src/json/applications/post-request.json
+++ b/site/docs/src/json/applications/post-request.json
@@ -73,10 +73,15 @@
       }
     ],
     "samlv2Configuration" : {
-      "callbackURL": "https://www.example.com/samlv2/acs",
+      "authorizedRedirectURLs": [
+        "https://www.example.com/samlv2/acs"
+      ],
       "debug": false,
+      "defaultVerificationKeyId": "be980e51-c94c-49f9-bfb5-90571c34a791",
       "enabled" : true,
       "issuer" : "example.com",
+      "keyId" : "0a52ace4-3016-47da-906a-f7d272fbdaed",
+      "requiredSignedRequests": true,
       "xmlSignatureC14nMethod" : "exclusive_with_comments"
     }
   },

--- a/site/docs/src/json/applications/post-request.json
+++ b/site/docs/src/json/applications/post-request.json
@@ -15,6 +15,9 @@
       "externalApplication": "Acme. Customer Support Forum",
       "productOwner": "john@acme.com"
     },
+    "formConfiguration": {
+      "adminRegistrationFormId": "e37dff97-9a94-48af-a0a6-c0bdfdd62c48"
+    },
     "jwtConfiguration": {
       "accessTokenKeyId": "025233ca-d4f3-2aa4-eca9-7e4200e9b472",
       "enabled": true,

--- a/site/docs/src/json/applications/response.json
+++ b/site/docs/src/json/applications/response.json
@@ -17,6 +17,9 @@
       "externalApplication": "Acme. Customer Support Forum",
       "productOwner": "john@acme.com"
     },
+    "formConfiguration": {
+      "adminRegistrationFormId": "e37dff97-9a94-48af-a0a6-c0bdfdd62c48"
+    },
     "insertInstant": 1595361142909,
     "lastUpdateInstant": 1595361143101,
     "jwtConfiguration": {

--- a/site/docs/src/json/applications/response.json
+++ b/site/docs/src/json/applications/response.json
@@ -94,7 +94,7 @@
       "enabled" : true,
       "issuer" : "example.com",
       "keyId" : "0a52ace4-3016-47da-906a-f7d272fbdaed",
-      "requiredSignedRequests": true,
+      "requireSignedRequests": true,
       "xmlSignatureC14nMethod" : "exclusive_with_comments"
     },
     "verifyRegistration": false

--- a/site/docs/src/json/applications/response.json
+++ b/site/docs/src/json/applications/response.json
@@ -89,6 +89,7 @@
       "authorizedRedirectURLs": [
         "https://www.example.com/samlv2/acs"
       ],
+      "callbackURL": "https://www.example.com/samlv2/acs",
       "debug": false,
       "defaultVerificationKeyId": "be980e51-c94c-49f9-bfb5-90571c34a791",
       "enabled" : true,

--- a/site/docs/src/json/applications/response.json
+++ b/site/docs/src/json/applications/response.json
@@ -83,11 +83,15 @@
       }
     ],
     "samlv2Configuration" : {
-      "callbackURL": "https://www.example.com/samlv2/acs",
+      "authorizedRedirectURLs": [
+        "https://www.example.com/samlv2/acs"
+      ],
       "debug": false,
+      "defaultVerificationKeyId": "be980e51-c94c-49f9-bfb5-90571c34a791",
       "enabled" : true,
       "issuer" : "example.com",
       "keyId" : "0a52ace4-3016-47da-906a-f7d272fbdaed",
+      "requiredSignedRequests": true,
       "xmlSignatureC14nMethod" : "exclusive_with_comments"
     },
     "verifyRegistration": false

--- a/site/docs/src/json/applications/responses.json
+++ b/site/docs/src/json/applications/responses.json
@@ -92,7 +92,7 @@
         "enabled" : true,
         "issuer" : "example.com",
         "keyId" : "0a52ace4-3016-47da-906a-f7d272fbdaed",
-        "requiredSignedRequests": true,
+        "requireSignedRequests": true,
         "xmlSignatureC14nMethod" : "exclusive_with_comments"
       },
       "verifyRegistration": false

--- a/site/docs/src/json/applications/responses.json
+++ b/site/docs/src/json/applications/responses.json
@@ -87,6 +87,7 @@
         "authorizedRedirectURLs": [
           "https://www.example.com/samlv2/acs"
         ],
+        "callbackURL": "https://www.example.com/samlv2/acs",
         "debug": false,
         "defaultVerificationKeyId": "be980e51-c94c-49f9-bfb5-90571c34a791",
         "enabled" : true,

--- a/site/docs/src/json/applications/responses.json
+++ b/site/docs/src/json/applications/responses.json
@@ -84,11 +84,15 @@
         }
       ],
       "samlv2Configuration" : {
-        "callbackURL": "https://www.example.com/samlv2/acs",
+        "authorizedRedirectURLs": [
+          "https://www.example.com/samlv2/acs"
+        ],
         "debug": false,
+        "defaultVerificationKeyId": "be980e51-c94c-49f9-bfb5-90571c34a791",
         "enabled" : true,
         "issuer" : "example.com",
         "keyId" : "0a52ace4-3016-47da-906a-f7d272fbdaed",
+        "requiredSignedRequests": true,
         "xmlSignatureC14nMethod" : "exclusive_with_comments"
       },
       "verifyRegistration": false

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -19,7 +19,7 @@ True if CleanSpeak username moderation is enabled.
 [field]#application.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Application that should be persisted.
 
-[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [optional]#Optional#::
+[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
 The Id of the form to use for administration registration purposes.
 
 [field]#application.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.6.0#::

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -263,14 +263,14 @@ The audience for the SAML response sent to back to the service provider from Fus
 [field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [optional]#Optional# [since]#Available since 1.20.0#::
 A list of URLs that are authorized for FusionAuth to redirect the user after logging in via SAML.
 
-[field]#application.samlv2Configuration.callbackURL# [type]#[String]# [optional]#Optional# [since]#Available since 1.6.0# [deprecated]#See `authorizedRedirectURLs` for usage from v1.20.0 forward#::
+[field]#application.samlv2Configuration.callbackURL# [type]#[String]# [optional]#Optional# [since]#Available since 1.6.0# [deprecated]#Deprecated#::
 The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.
 
 [field]#application.samlv2Configuration.debug# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.6.0#::
 Whether or not FusionAuth will log SAML debug messages to the event log. This is useful for debugging purposes.
 
 [field]#application.samlv2Configuration.defaultVerificationKeyId# [type]#[UUID]# [optional]#Optional#  [since]#Available since 1.20.0#::
-Default verification key to use for HTTP Redirect Bindings, and for POST Bindings when no key is found in request.
+Default verification key to use for HTTP Redirect Bindings, and for POST Bindings when no key is found in request. Required if `requiredSignedRequests` is set to `true`
 
 [field]#application.samlv2Configuration.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.6.0#::
 Whether or not the SAML IdP for this Application is enabled or not.
@@ -285,7 +285,7 @@ The id of the Key used to sign the SAML response. If you do not specify this pro
 The URL that the browser is taken to after the user logs out of the SAML service provider. Often service providers need this URL in order to correctly hook up single-logout. **Note** that FusionAuth does not support the SAML single-logout profile because most service providers to not support it properly.
 
 [field]#application.samlv2Configuration.requiredSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
-//TODO : Mikey : What is this for?
+If set to true, will force verification through the key store. When set to true, `defaultVerificationKeyId` must be present in the request.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [optional]#Optional# [default]#Defaults to `exclusive_with_comments`# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response. Unfortunately, many service providers do not correctly implement the XML signature specifications and force a specific canonicalization method. This setting allows you to change the canonicalization method to match the service provider. Often, service providers don't even document their required method. You might need to contact enterprise support at the service provider to figure out what method they use.

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -19,8 +19,10 @@ True if CleanSpeak username moderation is enabled.
 [field]#application.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Application that should be persisted.
 
-[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
-The Id of the form to use for administration registration purposes.
+[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [default]#defaults to the default Admin Registration Form Id# [optional]#Optional# [since]#Available since 1.20.0#::
+The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
++
+A paid edition of FusionAuth is required to utilize custom forms. The default form provided by FusionAuth may be used without a paid edition.
 
 [field]#application.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.6.0#::
 The Id of the signing key used to sign the access token.
@@ -258,11 +260,17 @@ endif::includeRoles[]
 [field]#application.samlv2Configuration.audience# [type]#[String]# [optional]#Optional# [default]#defaults to `issuer`# [since]#Available since 1.6.0#::
 The audience for the SAML response sent to back to the service provider from FusionAuth. Some service providers require different audience values than the `issuer` and this configuration option lets you change the `audience` in the response.
 
-[field]#application.samlv2Configuration.callbackURL# [type]#[String]# [required]#Required# [since]#Available since 1.6.0#::
+[field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [optional]#Optional# [since]#Available since 1.20.0#::
+A list of URLs that are authorized for FusionAuth to redirect the user after logging in via SAML.
+
+[field]#application.samlv2Configuration.callbackURL# [type]#[String]# [optional]#Optional# [since]#Available since 1.6.0# [deprecated]#See `authorizedRedirectURLs` for usage from v1.20.0 forward#::
 The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.
 
 [field]#application.samlv2Configuration.debug# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.6.0#::
 Whether or not FusionAuth will log SAML debug messages to the event log. This is useful for debugging purposes.
+
+[field]#application.samlv2Configuration.defaultVerificationKeyId# [type]#[UUID]# [optional]#Optional#  [since]#Available since 1.20.0#::
+Default verification key to use for HTTP Redirect Bindings, and for POST Bindings when no key is found in request.
 
 [field]#application.samlv2Configuration.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.6.0#::
 Whether or not the SAML IdP for this Application is enabled or not.
@@ -275,6 +283,9 @@ The id of the Key used to sign the SAML response. If you do not specify this pro
 
 [field]#application.samlv2Configuration.logoutURL# [type]#[String]# [optional]#Optional# [default]#Defaults to the system logout URL or `/`# [since]#Available since 1.6.0#::
 The URL that the browser is taken to after the user logs out of the SAML service provider. Often service providers need this URL in order to correctly hook up single-logout. **Note** that FusionAuth does not support the SAML single-logout profile because most service providers to not support it properly.
+
+[field]#application.samlv2Configuration.requiredSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
+//TODO : Mikey : What is this for?
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [optional]#Optional# [default]#Defaults to `exclusive_with_comments`# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response. Unfortunately, many service providers do not correctly implement the XML signature specifications and force a specific canonicalization method. This setting allows you to change the canonicalization method to match the service provider. Often, service providers don't even document their required method. You might need to contact enterprise support at the service provider to figure out what method they use.

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -19,7 +19,7 @@ True if CleanSpeak username moderation is enabled.
 [field]#application.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Application that should be persisted.
 
-[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
+[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [optional]#Optional# [default]#defaults to **[see description]**# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
 +
 A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
@@ -291,7 +291,9 @@ The id of the Key used to sign the SAML response. If you do not specify this pro
 The URL that the browser is taken to after the user logs out of the SAML service provider. Often service providers need this URL in order to correctly hook up single-logout. **Note** that FusionAuth does not support the SAML single-logout profile because most service providers to not support it properly.
 
 [field]#application.samlv2Configuration.requireSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
-Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#application.samlv2Configuration.defaultVerificationKeyId# is required.
+Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected.
++
+When set to `true`, the parameter [field]#application.samlv2Configuration.defaultVerificationKeyId# is required.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [optional]#Optional# [default]#Defaults to `exclusive_with_comments`# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response. Unfortunately, many service providers do not correctly implement the XML signature specifications and force a specific canonicalization method. This setting allows you to change the canonicalization method to match the service provider. Often, service providers don't even document their required method. You might need to contact enterprise support at the service provider to figure out what method they use.

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -263,12 +263,15 @@ endif::includeRoles[]
 The audience for the SAML response sent to back to the service provider from FusionAuth. Some service providers require different audience values than the `issuer` and this configuration option lets you change the `audience` in the response.
 
 [field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [required]#Required# [since]#Available since 1.20.0#::
-A list of URLs for the callback (sometimes called the Assertion Consumer Service or ACS). This is a set of values where FusionAuth may send the browser after the user logs in via SAML.
+One or more authorized URLS that may be specified by the SAML v2 Service Provider in the Authentication request <AssertionConsumerServiceURL> element. If a requested URL is not in this list the request will be rejected by FusionAuth.
++
+This is the URL that FusionAuth will send the SAML response during a SAML login request, this URL is also referred to as the Assertion Consumer Service or ACS). If the the Authentication request does not contain the <AssertionConsumerServiceURL> element, the first URL found in this list will be used to send the SAML response back to the Service Provider.
 
 [field]#application.samlv2Configuration.callbackURL# [type]#[String]# [optional]#Optional# [since]#Available since 1.6.0# [deprecated]#Deprecated#::
 The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.
 +
-[deprecated]#Deprecated in version 1.20.0# In version 1.20.0 and beyond, Callback URLs can be managed via [field]#application.samlv2Configuration.authorizedRedirectURLs#.
+[deprecated]#Deprecated in version 1.20.0# 
+In version 1.20.0 and beyond, Callback URLs can be managed via [field]#application.samlv2Configuration.authorizedRedirectURLs#.
 
 [field]#application.samlv2Configuration.debug# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.6.0#::
 Whether or not FusionAuth will log SAML debug messages to the event log. This is useful for debugging purposes.

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -19,10 +19,10 @@ True if CleanSpeak username moderation is enabled.
 [field]#application.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Application that should be persisted.
 
-[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [default]#defaults to the default Admin Registration Form Id# [optional]#Optional# [since]#Available since 1.20.0#::
+[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
 +
-A paid edition of FusionAuth is required to utilize custom forms. The default form provided by FusionAuth may be used without a paid edition.
+A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
 
 [field]#application.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.6.0#::
 The Id of the signing key used to sign the access token.
@@ -260,17 +260,23 @@ endif::includeRoles[]
 [field]#application.samlv2Configuration.audience# [type]#[String]# [optional]#Optional# [default]#defaults to `issuer`# [since]#Available since 1.6.0#::
 The audience for the SAML response sent to back to the service provider from FusionAuth. Some service providers require different audience values than the `issuer` and this configuration option lets you change the `audience` in the response.
 
-[field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [optional]#Optional# [since]#Available since 1.20.0#::
-A list of URLs that are authorized for FusionAuth to redirect the user after logging in via SAML.
+[field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [required]#Required# [since]#Available since 1.20.0#::
+A list of URLs for the callback (sometimes called the Assertion Consumer Service or ACS). This is a set of values where FusionAuth may send the browser after the user logs in via SAML.
 
 [field]#application.samlv2Configuration.callbackURL# [type]#[String]# [optional]#Optional# [since]#Available since 1.6.0# [deprecated]#Deprecated#::
 The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.
++
+[deprecated]#Deprecated in version 1.20.0# In version 1.20.0 and beyond, Callback URLs can be managed via [field]#application.samlv2Configuration.authorizedRedirectURLs#.
 
 [field]#application.samlv2Configuration.debug# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.6.0#::
 Whether or not FusionAuth will log SAML debug messages to the event log. This is useful for debugging purposes.
 
 [field]#application.samlv2Configuration.defaultVerificationKeyId# [type]#[UUID]# [optional]#Optional#  [since]#Available since 1.20.0#::
-Default verification key to use for HTTP Redirect Bindings, and for POST Bindings when no key is found in request. Required if `requiredSignedRequests` is set to `true`
+The verification key used to verify a signature when the SAML v2 Service Provider is using HTTP Redirect Bindings. 
++ 
+When HTTP POST Bindings are used, this is the default verification key used if a `<KeyInfo>` element is not found in the SAML AuthNRequest. If a `<KeyInfo>` element is found, Key Master will be used to resolve the key and this configuration will not be used to verify the request signature. 
++
+This parameter is required when [field]#requireSignedRequests# is set to `true`. 
 
 [field]#application.samlv2Configuration.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.6.0#::
 Whether or not the SAML IdP for this Application is enabled or not.
@@ -284,8 +290,8 @@ The id of the Key used to sign the SAML response. If you do not specify this pro
 [field]#application.samlv2Configuration.logoutURL# [type]#[String]# [optional]#Optional# [default]#Defaults to the system logout URL or `/`# [since]#Available since 1.6.0#::
 The URL that the browser is taken to after the user logs out of the SAML service provider. Often service providers need this URL in order to correctly hook up single-logout. **Note** that FusionAuth does not support the SAML single-logout profile because most service providers to not support it properly.
 
-[field]#application.samlv2Configuration.requiredSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
-If set to true, will force verification through the key store. When set to true, `defaultVerificationKeyId` must be present in the request.
+[field]#application.samlv2Configuration.requireSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
+Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#defaultVerificationKeyId# is required.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [optional]#Optional# [default]#Defaults to `exclusive_with_comments`# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response. Unfortunately, many service providers do not correctly implement the XML signature specifications and force a specific canonicalization method. This setting allows you to change the canonicalization method to match the service provider. Often, service providers don't even document their required method. You might need to contact enterprise support at the service provider to figure out what method they use.

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -19,6 +19,9 @@ True if CleanSpeak username moderation is enabled.
 [field]#application.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Application that should be persisted.
 
+[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [optional]#Optional#::
+The Id of the form to use for administration registration purposes.
+
 [field]#application.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.6.0#::
 The Id of the signing key used to sign the access token.
 

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -22,7 +22,9 @@ An object that can hold any information about the Application that should be per
 [field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [optional]#Optional# [default]#defaults to **[see description]**# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
 +
-A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
+A paid edition of FusionAuth is required to utilize custom forms. 
++
+When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
 
 [field]#application.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.6.0#::
 The Id of the signing key used to sign the access token.

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -24,7 +24,7 @@ The unique Id of the form to use for the Add and Edit User Registration form whe
 +
 A paid edition of FusionAuth is required to utilize custom forms. 
 +
-When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
+When this parameter is not provided, it will default to the form Id currently assigned to the FusionAuth application.
 
 [field]#application.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.6.0#::
 The Id of the signing key used to sign the access token.

--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -276,7 +276,7 @@ The verification key used to verify a signature when the SAML v2 Service Provide
 + 
 When HTTP POST Bindings are used, this is the default verification key used if a `<KeyInfo>` element is not found in the SAML AuthNRequest. If a `<KeyInfo>` element is found, Key Master will be used to resolve the key and this configuration will not be used to verify the request signature. 
 +
-This parameter is required when [field]#requireSignedRequests# is set to `true`. 
+This parameter is required when [field]#application.samlv2Configuration.requireSignedRequests# is set to `true`. 
 
 [field]#application.samlv2Configuration.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.6.0#::
 Whether or not the SAML IdP for this Application is enabled or not.
@@ -291,7 +291,7 @@ The id of the Key used to sign the SAML response. If you do not specify this pro
 The URL that the browser is taken to after the user logs out of the SAML service provider. Often service providers need this URL in order to correctly hook up single-logout. **Note** that FusionAuth does not support the SAML single-logout profile because most service providers to not support it properly.
 
 [field]#application.samlv2Configuration.requireSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
-Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#defaultVerificationKeyId# is required.
+Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#application.samlv2Configuration.defaultVerificationKeyId# is required.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [optional]#Optional# [default]#Defaults to `exclusive_with_comments`# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response. Unfortunately, many service providers do not correctly implement the XML signature specifications and force a specific canonicalization method. This setting allows you to change the canonicalization method to match the service provider. Often, service providers don't even document their required method. You might need to contact enterprise support at the service provider to figure out what method they use.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -31,8 +31,6 @@ An object that can hold any information about the Application that should be per
 The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
 +
 A paid edition of FusionAuth is required to utilize custom forms. 
-+
-When this parameter is not provided, it will default to the form Id currently assigned to the FusionAuth application.
 
 [field]#application.insertInstant# [type]#[Long]# [since]#Available since 1.18.0#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] that the Application was added to the FusionAuth database.
@@ -245,6 +243,9 @@ A list of URLs for the callback (sometimes called the Assertion Consumer Service
 
 [field]#application.samlv2Configuration.callbackURL# [type]#[String]# [since]#Available since 1.6.0# [deprecated]#Deprecated#::
 The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.
++
+[deprecated]#Deprecated in version 1.20.0# 
+This field is preserved for backwards compatibility and may be removed in a future release. This is the first value found in the [field]#authorizedRedirectURLs# parameter.
 
 [field]#application.samlv2Configuration.debug# [type]#[Boolean]# [since]#Available since 1.6.0#::
 Whether or not FusionAuth will log SAML debug messages to the event log. This is useful for debugging purposes.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -238,7 +238,7 @@ Whether or not the Role is a considered to be a super user role. This is a marke
 [field]#application.samlv2Configuration.audience# [type]#[String]# [since]#Available since 1.6.0#::
 The audience for the SAML response sent to back to the service provider from FusionAuth. Some service providers require different audience values than the `issuer` and this configuration option lets you change the `audience` in the response.
 
-[field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [optional]#Optional# [since]#Available since 1.20.0#::
+[field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [since]#Available since 1.20.0#::
 A list of URLs for the callback (sometimes called the Assertion Consumer Service or ACS). This is a set of values where FusionAuth may send the browser after the user logs in via SAML.
 
 [field]#application.samlv2Configuration.callbackURL# [type]#[String]# [since]#Available since 1.6.0# [deprecated]#Deprecated#::
@@ -247,12 +247,10 @@ The URL of the callback (sometimes called the Assertion Consumer Service or ACS)
 [field]#application.samlv2Configuration.debug# [type]#[Boolean]# [since]#Available since 1.6.0#::
 Whether or not FusionAuth will log SAML debug messages to the event log. This is useful for debugging purposes.
 
-[field]#application.samlv2Configuration.defaultVerificationKeyId# [type]#[UUID]# [optional]#Optional#  [since]#Available since 1.20.0#::
+[field]#application.samlv2Configuration.defaultVerificationKeyId# [type]#[UUID]#  [since]#Available since 1.20.0#::
 The verification key used to verify a signature when the SAML v2 Service Provider is using HTTP Redirect Bindings. 
 + 
-When HTTP POST Bindings are used, this is the default verification key used if a `<KeyInfo>` element is not found in the SAML AuthNRequest. If a `<KeyInfo>` element is found, Key Master will be used to resolve the key and this configuration will not be used to verify the request signature. 
-+
-This parameter is required when [field]#application.samlv2Configuration.requireSignedRequests# is set to `true`. 
+When HTTP POST Bindings are used, this is the default verification key used if a `<KeyInfo>` element is not found in the SAML AuthNRequest. If a `<KeyInfo>` element is found, Key Master will be used to resolve the key and this configuration will not be used to verify the request signature.
 
 [field]#application.samlv2Configuration.enabled# [type]#[Boolean]# [since]#Available since 1.6.0#::
 Whether or not the SAML IdP for this Application is enabled or not.
@@ -266,7 +264,7 @@ The id of the Key used to sign the SAML response.
 [field]#application.samlv2Configuration.logoutURL# [type]#[String]# [since]#Available since 1.6.0#::
 The URL that the browser is taken to after the user logs out of the SAML service provider.
 
-[field]#application.samlv2Configuration.requireSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
+[field]#application.samlv2Configuration.requireSignedRequests# [type]#[Boolean]#  [since]#Available since 1.20.0#::
 Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#application.samlv2Configuration.defaultVerificationKeyId# is required.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [since]#Available since 1.6.0#::

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -250,7 +250,7 @@ The verification key used to verify a signature when the SAML v2 Service Provide
 + 
 When HTTP POST Bindings are used, this is the default verification key used if a `<KeyInfo>` element is not found in the SAML AuthNRequest. If a `<KeyInfo>` element is found, Key Master will be used to resolve the key and this configuration will not be used to verify the request signature. 
 +
-This parameter is required when [field]#requireSignedRequests# is set to `true`. 
+This parameter is required when [field]#application.samlv2Configuration.requireSignedRequests# is set to `true`. 
 
 [field]#application.samlv2Configuration.enabled# [type]#[Boolean]# [since]#Available since 1.6.0#::
 Whether or not the SAML IdP for this Application is enabled or not.
@@ -265,7 +265,7 @@ The id of the Key used to sign the SAML response.
 The URL that the browser is taken to after the user logs out of the SAML service provider.
 
 [field]#application.samlv2Configuration.requireSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
-Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#defaultVerificationKeyId# is required.
+Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#application.samlv2Configuration.defaultVerificationKeyId# is required.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -28,7 +28,9 @@ True if CleanSpeak username moderation is enabled.
 An object that can hold any information about the Application that should be persisted.
 
 [field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
-The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI.
+The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
++
+A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
 
 [field]#application.insertInstant# [type]#[Long]# [since]#Available since 1.18.0#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] that the Application was added to the FusionAuth database.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -236,11 +236,17 @@ Whether or not the Role is a considered to be a super user role. This is a marke
 [field]#application.samlv2Configuration.audience# [type]#[String]# [since]#Available since 1.6.0#::
 The audience for the SAML response sent to back to the service provider from FusionAuth. Some service providers require different audience values than the `issuer` and this configuration option lets you change the `audience` in the response.
 
-[field]#application.samlv2Configuration.callbackURL# [type]#[String]# [since]#Available since 1.6.0#::
+[field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [optional]#Optional# [since]#Available since 1.20.0#::
+A list of URLs that are authorized for FusionAuth to redirect the user after logging in via SAML.
+
+[field]#application.samlv2Configuration.callbackURL# [type]#[String]# [since]#Available since 1.6.0# [deprecated]#Deprecated#::
 The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.
 
 [field]#application.samlv2Configuration.debug# [type]#[Boolean]# [since]#Available since 1.6.0#::
 Whether or not FusionAuth will log SAML debug messages to the event log. This is useful for debugging purposes.
+
+[field]#application.samlv2Configuration.defaultVerificationKeyId# [type]#[UUID]# [optional]#Optional#  [since]#Available since 1.20.0#::
+Default verification key to use for HTTP Redirect Bindings, and for POST Bindings when no key is found in request. Required if `requiredSignedRequests` is set to `true`
 
 [field]#application.samlv2Configuration.enabled# [type]#[Boolean]# [since]#Available since 1.6.0#::
 Whether or not the SAML IdP for this Application is enabled or not.
@@ -253,6 +259,9 @@ The id of the Key used to sign the SAML response.
 
 [field]#application.samlv2Configuration.logoutURL# [type]#[String]# [since]#Available since 1.6.0#::
 The URL that the browser is taken to after the user logs out of the SAML service provider.
+
+[field]#application.samlv2Configuration.requiredSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
+If set to true, will force verification through the key store. When set to true, `defaultVerificationKeyId` must be present in the request.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -27,7 +27,7 @@ True if CleanSpeak username moderation is enabled.
 [field]#application.data# [type]#[Object]#::
 An object that can hold any information about the Application that should be persisted.
 
-[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [default]#defaults to **[see description]**# [since]#Available since 1.20.0#::
+[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
 +
 A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -28,7 +28,7 @@ True if CleanSpeak username moderation is enabled.
 An object that can hold any information about the Application that should be persisted.
 
 [field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
-The Id of the form to use for administration registration purposes.
+The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI.
 
 [field]#application.insertInstant# [type]#[Long]# [since]#Available since 1.18.0#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] that the Application was added to the FusionAuth database.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -32,7 +32,7 @@ The unique Id of the form to use for the Add and Edit User Registration form whe
 +
 A paid edition of FusionAuth is required to utilize custom forms. 
 +
-When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition. 
+When this parameter is not provided, it will default to the form Id currently assigned to the FusionAuth application.
 
 [field]#application.insertInstant# [type]#[Long]# [since]#Available since 1.18.0#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] that the Application was added to the FusionAuth database.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -27,10 +27,10 @@ True if CleanSpeak username moderation is enabled.
 [field]#application.data# [type]#[Object]#::
 An object that can hold any information about the Application that should be persisted.
 
-[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
+[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [default]#defaults to **[see description]**# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
 +
-A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
+A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
 
 [field]#application.insertInstant# [type]#[Long]# [since]#Available since 1.18.0#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] that the Application was added to the FusionAuth database.
@@ -265,7 +265,7 @@ The id of the Key used to sign the SAML response.
 The URL that the browser is taken to after the user logs out of the SAML service provider.
 
 [field]#application.samlv2Configuration.requireSignedRequests# [type]#[Boolean]#  [since]#Available since 1.20.0#::
-Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#application.samlv2Configuration.defaultVerificationKeyId# is required.
+When this value is `true` all requests missing a signature will be rejected.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -239,7 +239,9 @@ Whether or not the Role is a considered to be a super user role. This is a marke
 The audience for the SAML response sent to back to the service provider from FusionAuth. Some service providers require different audience values than the `issuer` and this configuration option lets you change the `audience` in the response.
 
 [field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [since]#Available since 1.20.0#::
-A list of URLs for the callback (sometimes called the Assertion Consumer Service or ACS). This is a set of values where FusionAuth may send the browser after the user logs in via SAML.
+One or more authorized URLS that may be specified by the SAML v2 Service Provider in the Authentication request <AssertionConsumerServiceURL> element. If a requested URL is not in this list the request will be rejected by FusionAuth.
++
+This is the URL that FusionAuth will send the SAML response during a SAML login request, this URL is also referred to as the Assertion Consumer Service or ACS). If the the Authentication request does not contain the <AssertionConsumerServiceURL> element, the first URL found in this list will be used to send the SAML response back to the Service Provider.
 
 [field]#application.samlv2Configuration.callbackURL# [type]#[String]# [since]#Available since 1.6.0# [deprecated]#Deprecated#::
 The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -237,7 +237,7 @@ Whether or not the Role is a considered to be a super user role. This is a marke
 The audience for the SAML response sent to back to the service provider from FusionAuth. Some service providers require different audience values than the `issuer` and this configuration option lets you change the `audience` in the response.
 
 [field]#application.samlv2Configuration.authorizedRedirectURLs# [type]#[Array<String>]# [optional]#Optional# [since]#Available since 1.20.0#::
-A list of URLs that are authorized for FusionAuth to redirect the user after logging in via SAML.
+A list of URLs for the callback (sometimes called the Assertion Consumer Service or ACS). This is a set of values where FusionAuth may send the browser after the user logs in via SAML.
 
 [field]#application.samlv2Configuration.callbackURL# [type]#[String]# [since]#Available since 1.6.0# [deprecated]#Deprecated#::
 The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.
@@ -246,7 +246,11 @@ The URL of the callback (sometimes called the Assertion Consumer Service or ACS)
 Whether or not FusionAuth will log SAML debug messages to the event log. This is useful for debugging purposes.
 
 [field]#application.samlv2Configuration.defaultVerificationKeyId# [type]#[UUID]# [optional]#Optional#  [since]#Available since 1.20.0#::
-Default verification key to use for HTTP Redirect Bindings, and for POST Bindings when no key is found in request. Required if `requiredSignedRequests` is set to `true`
+The verification key used to verify a signature when the SAML v2 Service Provider is using HTTP Redirect Bindings. 
++ 
+When HTTP POST Bindings are used, this is the default verification key used if a `<KeyInfo>` element is not found in the SAML AuthNRequest. If a `<KeyInfo>` element is found, Key Master will be used to resolve the key and this configuration will not be used to verify the request signature. 
++
+This parameter is required when [field]#requireSignedRequests# is set to `true`. 
 
 [field]#application.samlv2Configuration.enabled# [type]#[Boolean]# [since]#Available since 1.6.0#::
 Whether or not the SAML IdP for this Application is enabled or not.
@@ -260,8 +264,8 @@ The id of the Key used to sign the SAML response.
 [field]#application.samlv2Configuration.logoutURL# [type]#[String]# [since]#Available since 1.6.0#::
 The URL that the browser is taken to after the user logs out of the SAML service provider.
 
-[field]#application.samlv2Configuration.requiredSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
-If set to true, will force verification through the key store. When set to true, `defaultVerificationKeyId` must be present in the request.
+[field]#application.samlv2Configuration.requireSignedRequests# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::
+Set this parameter equal to `true` to require the SAML v2 Service Provider to sign the request. When this value is `true` all requests missing a signature will be rejected and [field]#defaultVerificationKeyId# is required.
 
 [field]#application.samlv2Configuration.xmlSignatureC14nMethod# [type]#[String]# [since]#Available since 1.6.0#::
 The XML signature canonicalization method used when digesting and signing the SAML response.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -29,8 +29,6 @@ An object that can hold any information about the Application that should be per
 
 [field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
-+
-A paid edition of FusionAuth is required to utilize custom forms. 
 
 [field]#application.insertInstant# [type]#[Long]# [since]#Available since 1.18.0#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] that the Application was added to the FusionAuth database.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -30,7 +30,9 @@ An object that can hold any information about the Application that should be per
 [field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User Registration form when used in the FusionAuth admin UI. 
 +
-A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
+A paid edition of FusionAuth is required to utilize custom forms. 
++
+When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition. 
 
 [field]#application.insertInstant# [type]#[Long]# [since]#Available since 1.18.0#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] that the Application was added to the FusionAuth database.

--- a/site/docs/v1/tech/apis/_application-response-body.adoc
+++ b/site/docs/v1/tech/apis/_application-response-body.adoc
@@ -27,6 +27,9 @@ True if CleanSpeak username moderation is enabled.
 [field]#application.data# [type]#[Object]#::
 An object that can hold any information about the Application that should be persisted.
 
+[field]#application.formConfiguration.adminRegistrationFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
+The Id of the form to use for administration registration purposes.
+
 [field]#application.insertInstant# [type]#[Long]# [since]#Available since 1.18.0#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] that the Application was added to the FusionAuth database.
 


### PR DESCRIPTION
Related Issues
-----

[126](https://github.com/FusionAuth/fusionauth-internal-issues/issues/126#event-3878959984)

Background
----

Adds documentation for a new optional field on the Application API. That field being `formConfiguration.adminRegistrationFormID`