### PR TITLE
[126] Documentation Changes for 1.20.0 for the Tenant API

### DIFF
--- a/site/docs/src/json/tenants/request.json
+++ b/site/docs/src/json/tenants/request.json
@@ -134,6 +134,7 @@
         "type": "randomBytes"
       },
       "registrationVerificationIdTimeToLiveInSeconds": 86400,
+      "samlv2AuthNRequestIdTimeToLiveInSeconds": 360,
       "setupPasswordIdGenerator": {
         "length": 32,
         "type": "randomBytes"
@@ -160,6 +161,9 @@
       "minimumOwnerAge": 21,
       "parentEmailRequired": false,
       "parentRegistrationEmailTemplateId": "12345678-1234-5678-90ab-1234567890ab"
+    },
+    "formConfiguration": {
+      "adminUserFormId": "e92751a5-25f4-4bca-ad91-66cdf67725d2"
     },
     "httpSessionMaxInactiveInterval": 3600,
     "issuer": "https://example.com",

--- a/site/docs/src/json/tenants/request.json
+++ b/site/docs/src/json/tenants/request.json
@@ -134,7 +134,7 @@
         "type": "randomBytes"
       },
       "registrationVerificationIdTimeToLiveInSeconds": 86400,
-      "samlv2AuthNRequestIdTimeToLiveInSeconds": 360,
+      "samlv2AuthNRequestIdTimeToLiveInSeconds": 300,
       "setupPasswordIdGenerator": {
         "length": 32,
         "type": "randomBytes"

--- a/site/docs/src/json/tenants/response.json
+++ b/site/docs/src/json/tenants/response.json
@@ -134,6 +134,7 @@
         "type": "randomBytes"
       },
       "registrationVerificationIdTimeToLiveInSeconds": 86400,
+      "samlv2AuthNRequestIdTimeToLiveInSeconds": 360,
       "setupPasswordIdGenerator": {
         "length": 32,
         "type": "randomBytes"
@@ -160,6 +161,9 @@
       "minimumOwnerAge": 21,
       "parentEmailRequired": false,
       "parentRegistrationEmailTemplateId": "12345678-1234-5678-90ab-1234567890ab"
+    },
+    "formConfiguration": {
+      "adminUserFormId": "e92751a5-25f4-4bca-ad91-66cdf67725d2"
     },
     "httpSessionMaxInactiveInterval": 3600,
     "id": "32306536-3036-6431-3865-646430303332",

--- a/site/docs/src/json/tenants/response.json
+++ b/site/docs/src/json/tenants/response.json
@@ -134,7 +134,7 @@
         "type": "randomBytes"
       },
       "registrationVerificationIdTimeToLiveInSeconds": 86400,
-      "samlv2AuthNRequestIdTimeToLiveInSeconds": 360,
+      "samlv2AuthNRequestIdTimeToLiveInSeconds": 300,
       "setupPasswordIdGenerator": {
         "length": 32,
         "type": "randomBytes"

--- a/site/docs/src/json/tenants/responses.json
+++ b/site/docs/src/json/tenants/responses.json
@@ -129,6 +129,7 @@
           "type": "randomBytes"
         },
         "registrationVerificationIdTimeToLiveInSeconds": 86400,
+        "samlv2AuthNRequestIdTimeToLiveInSeconds": 360,
         "setupPasswordIdGenerator": {
           "length": 32,
           "type": "randomBytes"
@@ -155,6 +156,9 @@
         "minimumOwnerAge": 21,
         "parentEmailRequired": false,
         "parentRegistrationEmailTemplateId": "12345678-1234-5678-90ab-1234567890ab"
+      },
+      "formConfiguration": {
+        "adminUserFormId": "e92751a5-25f4-4bca-ad91-66cdf67725d2"
       },
       "httpSessionMaxInactiveInterval": 3600,
       "id": "32306536-3036-6431-3865-646430303332",

--- a/site/docs/src/json/tenants/responses.json
+++ b/site/docs/src/json/tenants/responses.json
@@ -129,7 +129,7 @@
           "type": "randomBytes"
         },
         "registrationVerificationIdTimeToLiveInSeconds": 86400,
-        "samlv2AuthNRequestIdTimeToLiveInSeconds": 360,
+        "samlv2AuthNRequestIdTimeToLiveInSeconds": 300,
         "setupPasswordIdGenerator": {
           "length": 32,
           "type": "randomBytes"

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -261,6 +261,9 @@ Whether a parent email is required.
 [field]#tenant.familyConfiguration.parentRegistrationEmailTemplateId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.8.0#::
 The unique Id of the email template to use for parent registration.
 
+[field]#tenant.formConfiguration.adminUserFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
+The unique Id of the form to use form adminstrator registration of users.
+
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#default is `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
 

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -270,6 +270,7 @@ The unique Id of the form to use for the Add and Edit User form when used in the
 A paid edition of FusionAuth is required to utilize custom forms. 
 +
 When this parameter is not provided, it will default to the form Id currently assigned to the Default tenant.
+
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#default is `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
 

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -188,6 +188,9 @@ include::_tenant-generator-type-config-rules.adoc[]
 [field]#tenant.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
 The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
 
+[field]#tenant.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#300# [since]#Available since 1.19.0#::
+The time in seconds that a SAML AuthN request Id returned by the Start SAML v2 Login Request API will be eligible to be used to complete a SAML v2 Login request. 
+
 [field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.length# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
 +
 :generator_type: setupPasswordIdGenerator
@@ -196,8 +199,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
-[field]#tenant.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#300# [since]#Available since 1.20.0#::
-The time in seconds that a SAML AuthN request will be eligible for use to authenticate with FusionAuth.
+
 
 [field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.type# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
 +
@@ -263,10 +265,10 @@ Whether a parent email is required.
 [field]#tenant.familyConfiguration.parentRegistrationEmailTemplateId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.8.0#::
 The unique Id of the email template to use for parent registration.
 
-[field]#tenant.formConfiguration.adminUserFormId# [type]#[UUID]# [optional]#Optional# [default]#Default provided admin user form id# [since]#Available since 1.20.0#::
+[field]#tenant.formConfiguration.adminUserFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI. 
 +
-A paid edition of FusionAuth is required to utilize custom forms. The default form provided by FusionAuth may be used without a paid edition.
+A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
 
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#default is `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -200,7 +200,6 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-
 [field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.type# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
 +
 :generator_display_name: setup password Id
@@ -265,10 +264,12 @@ Whether a parent email is required.
 [field]#tenant.familyConfiguration.parentRegistrationEmailTemplateId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.8.0#::
 The unique Id of the email template to use for parent registration.
 
-[field]#tenant.formConfiguration.adminUserFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
+[field]#tenant.formConfiguration.adminUserFormId# [type]#[UUID]# [optional]#Optional# [default]#defaults to **[see description]**# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI. 
 +
-A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
+A paid edition of FusionAuth is required to utilize custom forms. 
++
+When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
 
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#default is `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -269,7 +269,7 @@ The unique Id of the form to use for the Add and Edit User form when used in the
 +
 A paid edition of FusionAuth is required to utilize custom forms. 
 +
-When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
+When this parameter is not provided, it will default to the form Id currently assigned to the Default tenant.
 
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#default is `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -196,6 +196,8 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
+[field]#tenant.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#300# [since]#Available since 1.20.0#::
+The time in seconds that a SAML AuthN request will be eligible for use to authenticate with FusionAuth.
 
 [field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.type# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
 +
@@ -261,8 +263,10 @@ Whether a parent email is required.
 [field]#tenant.familyConfiguration.parentRegistrationEmailTemplateId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.8.0#::
 The unique Id of the email template to use for parent registration.
 
-[field]#tenant.formConfiguration.adminUserFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
-The unique Id of the form to use for adminstrator registration of users.
+[field]#tenant.formConfiguration.adminUserFormId# [type]#[UUID]# [optional]#Optional# [default]#Default provided admin user form id# [since]#Available since 1.20.0#::
+The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI. 
++
+A paid edition of FusionAuth is required to utilize custom forms. The default form provided by FusionAuth may be used without a paid edition.
 
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#default is `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -262,7 +262,7 @@ Whether a parent email is required.
 The unique Id of the email template to use for parent registration.
 
 [field]#tenant.formConfiguration.adminUserFormId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.20.0#::
-The unique Id of the form to use form adminstrator registration of users.
+The unique Id of the form to use for adminstrator registration of users.
 
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#default is `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -270,7 +270,6 @@ The unique Id of the form to use for the Add and Edit User form when used in the
 A paid edition of FusionAuth is required to utilize custom forms. 
 +
 When this parameter is not provided, it will default to the form Id currently assigned to the Default tenant.
-
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#default is `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
 

--- a/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
@@ -189,7 +189,7 @@ include::_tenant-generator-type-config-rules.adoc[]
 [field]#{base_field_name}.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [since]#Available since 1.8.0#::
 The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
 
-[field]#tenant.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#300# [since]#Available since 1.19.0#::
+[field]#tenant.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds# [type]#[Integer]# [since]#Available since 1.19.0#::
 The time in seconds that a SAML AuthN request Id returned by the Start SAML v2 Login Request API will be eligible to be used to complete a SAML v2 Login request.
 
 [field]#{base_field_name}.externalIdentifierConfiguration.setupPasswordIdGenerator.length# [type]#[Integer]# [since]#Available since 1.8.0#::
@@ -267,8 +267,6 @@ The unique Id of the email template to use for parent registration.
 
 [field]#{base_field_name}.formConfiguration.adminUserFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI. 
-+
-A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
 
 [field]#{base_field_name}.httpSessionMaxInactiveInterval# [type]#[Integer]# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
@@ -263,7 +263,7 @@ Whether a parent email is required.
 The unique Id of the email template to use for parent registration.
 
 [field]#{base_field_name}.formConfiguration.adminUserFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
-The unique Id of the form to use for adminstrator registration of users.
+The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI. 
 
 [field]#{base_field_name}.httpSessionMaxInactiveInterval# [type]#[Integer]# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
@@ -262,6 +262,9 @@ Whether a parent email is required.
 [field]#{base_field_name}.familyConfiguration.parentRegistrationEmailTemplateId# [type]#[UUID]# [since]#Available since 1.8.0#::
 The unique Id of the email template to use for parent registration.
 
+[field]#{base_field_name}.formConfiguration.adminUserFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
+The unique Id of the form to use form adminstrator registration of users.
+
 [field]#{base_field_name}.httpSessionMaxInactiveInterval# [type]#[Integer]# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
 

--- a/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
@@ -263,7 +263,7 @@ Whether a parent email is required.
 The unique Id of the email template to use for parent registration.
 
 [field]#{base_field_name}.formConfiguration.adminUserFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
-The unique Id of the form to use form adminstrator registration of users.
+The unique Id of the form to use for adminstrator registration of users.
 
 [field]#{base_field_name}.httpSessionMaxInactiveInterval# [type]#[Integer]# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
@@ -189,6 +189,9 @@ include::_tenant-generator-type-config-rules.adoc[]
 [field]#{base_field_name}.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [since]#Available since 1.8.0#::
 The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
 
+[field]#tenant.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#300# [since]#Available since 1.19.0#::
+The time in seconds that a SAML AuthN request Id returned by the Start SAML v2 Login Request API will be eligible to be used to complete a SAML v2 Login request.
+
 [field]#{base_field_name}.externalIdentifierConfiguration.setupPasswordIdGenerator.length# [type]#[Integer]# [since]#Available since 1.8.0#::
 +
 :generator_type: setupPasswordIdGenerator
@@ -264,6 +267,8 @@ The unique Id of the email template to use for parent registration.
 
 [field]#{base_field_name}.formConfiguration.adminUserFormId# [type]#[UUID]# [since]#Available since 1.20.0#::
 The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI. 
++
+A paid edition of FusionAuth is required to utilize custom forms. When this parameter is not provided it will default to a form provided by FusionAuth that may be used without a paid edition.
 
 [field]#{base_field_name}.httpSessionMaxInactiveInterval# [type]#[Integer]# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.

--- a/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_tenant-response-body-base.adoc
@@ -270,7 +270,6 @@ The unique Id of the form to use for the Add and Edit User form when used in the
 
 [field]#{base_field_name}.httpSessionMaxInactiveInterval# [type]#[Integer]# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
-
 [field]#{base_field_name}.id# [type]#[UUID]#::
 The unique identifier for this Tenant.
 


### PR DESCRIPTION
Related Issues
-----

[126](https://github.com/FusionAuth/fusionauth-internal-issues/issues/126#event-3878959984)

Background
----

Adds documentation for a new optional field on the Tenant API. That field being `formConfiguration.adminUserFormId`