### PR TITLE
Added note about local validation of JWTs

### DIFF
--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -481,6 +481,8 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 
 This API is used to validate a JSON Web Token. A valid JWT indicates the signature is valid and the payload has not be tampered with and the token is not expired.
 
+You can also validate a JWT without using this API call. You can validate the JWT attributes and signature locally. Most programming languages have libraries to help with this. Here's an https://github.com/fusionauth/fusionauth-jwt#verify-and-decode-a-jwt-using-hmac[example in Java]. Unless an HMAC key was used to sign the JWT and you don't have access to the key, it is recommended to validate the JWT locally.
+
 === Request
 
 [.api-authentication]

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -481,7 +481,7 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 
 This API is used to validate a JSON Web Token. A valid JWT indicates the signature is valid and the payload has not be tampered with and the token is not expired.
 
-You can also validate a JWT without using this API call. You can validate the JWT attributes and signature locally. Most programming languages have libraries to help with this. Here's an https://github.com/fusionauth/fusionauth-jwt#verify-and-decode-a-jwt-using-hmac[example in Java]. Unless an HMAC key was used to sign the JWT and you don't have access to the key, it is recommended to validate the JWT locally.
+You can also validate a JWT without using this API call. To do so, validate the JWT attributes and signature locally. Many programming languages have libraries to do this. Here's an https://github.com/fusionauth/fusionauth-jwt#verify-and-decode-a-jwt-using-hmac[example in Java]. 
 
 === Request
 


### PR DESCRIPTION
Just seems to me that there's not much reason to call the `validate` endpoint.