### PR TITLE
Added more examples for search queries.

### DIFF
--- a/site/docs/src/json/users/search-email-address-query-request.json
+++ b/site/docs/src/json/users/search-email-address-query-request.json
@@ -1,0 +1,14 @@
+{
+  "search": {
+    "numberOfResults": 50,
+    "query":"{\"match\":{\"email\":{\"query\":\"dinesh@fusionauth.io\"}}}",
+    "sortFields": [
+      {
+        "missing": "_first",
+        "name": "email",
+        "order": "asc"
+      }
+    ],
+    "startRow": 0
+  }
+}

--- a/site/docs/src/json/users/search-user-data-query-request.json
+++ b/site/docs/src/json/users/search-user-data-query-request.json
@@ -1,0 +1,14 @@
+{
+  "search": {
+    "numberOfResults": 50,
+    "query":"{\"match\":{\"data.userMigrated\":{\"query\":\"true\"}}}",
+    "sortFields": [
+      {
+        "missing": "_first",
+        "name": "email",
+        "order": "asc"
+      }
+    ],
+    "startRow": 0
+  }
+}

--- a/site/docs/v1/tech/apis/_user-search-request-body-elasticsearch-examples.adoc
+++ b/site/docs/v1/tech/apis/_user-search-request-body-elasticsearch-examples.adoc
@@ -29,6 +29,18 @@ include::../../../src/json/users/search-role-query-request.json[]
 ----
 
 [source,json]
+.Example JSON searching by `query` for users with a given email address
+----
+include::../../../src/json/users/search-email-address-query-request.json[]
+----
+
+[source,json]
+.Example JSON searching by `query` for users with custom user data of dataMigrated equal to true
+----
+include::../../../src/json/users/search-user-data-query-request.json[]
+----
+
+[source,json]
 .Example Request JSON searching by [field]#queryString# for users with an email address matching a pattern
 ----
 include::../../../src/json/users/search-queryString-email-request.json[]

--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -16,12 +16,14 @@ This page contains all of the APIs for managing users.
 * <<Reactivate a User>>
 * <<Retrieve Recent Logins>>
 
-=== Import Users
+=== Importing Users
 * <<Import Users>>
 * <<Import Refresh Tokens>>
 
 === User Search
 * <<Search for Users>>
+** <<Database Search Engine>>
+** <<Elasticsearch Search Engine>>
 * <<Flush the Search Engine>>
 
 === Email Verification


### PR DESCRIPTION
Per issue https://github.com/fusionauth/fusionauth-issues/issues/30 the user.data field is searchable but no docs explain how to do so.

Need to close that issue if this resolves it.