### PR TITLE
Added note about facebook images expiring.

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/facebook.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/facebook.adoc
@@ -183,3 +183,12 @@ The response for this API contains the User object.
 :loginProvider: Facebook
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
 :loginProvider!:
+
+
+== Troubleshooting
+
+=== Images
+
+If a user has not logged in using FaceBook recently, their profile image URL may expire. FusionAuth will have a reference to the old image in `imageUrl` and it will cause the image to be missing. The exact timeframe is undocumented, but the community has seen this occur if a user hasn't signed in within the last month. 
+
+You can work around this capturing the image on login, then downloading and storing the image off in some other file storage, and adding the URL for that image in a `user.data` field. Alternatively, the user can log in again and the current image will be retrieved.


### PR DESCRIPTION
I'm not sure if this is a bug/issue worth filing (since we'd have to store images locally), but thought it was worth documenting.

Additional context:

* happens with Auth0: https://community.auth0.com/t/facebook-user-picture-not-showing-up-url-stored-in-auth0-is-expired/13686/5 
* here's the slack convo where a user brought it up: https://fusionauth.slack.com/archives/CG00HG935/p1606210365172200
* FB's API docs: https://developers.facebook.com/docs/graph-api/reference/v3.2/user/picture which have no mention of how long the image URL returned if you pass `redirect=0` is good for.