### PR TITLE
Make logout behavior a bit clearer.

### DIFF
--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -363,7 +363,7 @@ The `id_token_hint` parameter as described in the https://openid.net/specs/openi
 Only used if `client_id` is not provided.
 
 [field]#post_logout_redirect_uri# [type]#[String]# [optional]#Optional# [since]#Available since 1.10.0#::
-The URI to redirect to upon a successful logout. This URI must have been configured previously in the FusionAuth Application OAuth configuration. See Applications in the FusionAuth User Guide for additional information on configuring the redirect URI.
+The URI to redirect to upon a successful logout. This URI must have been configured previously in the FusionAuth Application OAuth configuration as an [field]#Authorized Redirect URL#. See the link:/docs/v1/tech/core-concepts/applications/#oauth[Core Concepts OAuth section] for additional information on configuring redirect URIs.
 
 [field]#state# [type]#[String]# [optional]#Optional# [since]#Available since 1.10.0#::
 The `state` parameter as described in the https://openid.net/specs/openid-connect-session-1_0.html#RPLogout[OpenID Connect Session Management] specification. Opaque value used to maintain state between the logout request and the callback.


### PR DESCRIPTION
It was referencing the user guide, which we moved to core concepts. Updated to point to correct fieldname.