### PR TITLE
Fix migration guide typo

### DIFF
--- a/site/docs/v1/tech/guides/migration.adoc
+++ b/site/docs/v1/tech/guides/migration.adoc
@@ -84,8 +84,8 @@ Segment by segment migration decreases cutover risk, but in exchange requires a 
 This approach is a logical extension of segment by segment migration. Here, each segment is a single user. With a slow migration: 
 
 * Map user attributes from the old system to the new system. 
-* You set up a connection between the original auth system and FusionAuth.
-* You modify your application or applications to point to FusionAuth. This is the application cutover point, which may require some downtime.
+* Set up a connection between the original auth system and FusionAuth.
+* Modify your application or applications to point to FusionAuth. This is the application cutover point, which may require some downtime.
 * FusionAuth receives all auth requests, but delegates the first such request for each user to the original user management system. 
 * The old system returns the information and FusionAuth creates a new user. This is the data "cutover" point for this user.
 * For this user's subsequent authentication requests, FusionAuth is now the system of record. The user has been migrated.

--- a/site/docs/v1/tech/guides/migration.adoc
+++ b/site/docs/v1/tech/guides/migration.adoc
@@ -42,7 +42,7 @@ With a big bang migration, you are moving all your users at one time. The exact 
 * Build a set of migration scripts or programs. 
 * Test it well. Ensure that migration accuracy and duration meet your needs.
 * Plan to modify your applications to point to the new system.
-* When you are ready to migrate, bring your systems down or to a mode where authentication is degraded (read-only or disallowed)
+* When you are ready to migrate, bring your systems down or to a mode where authentication is degraded (read-only or disallowed).
 * Run the migration scripts or programs.
 * Perform the cutover and flip the system of record for all your users from the old system to the new.
 

--- a/site/docs/v1/tech/guides/migration.adoc
+++ b/site/docs/v1/tech/guides/migration.adoc
@@ -59,7 +59,7 @@ The big bang approach has some challenges, though.
 * It is common to miss issues during testing because this is a unique procedure. Production systems are often different in subtle ways from testing environments. 
 * Any problems with the migration impact many users, since all are migrated.
 * The big bang requires you to write code which you'll test intensely, use once and then throw away.
-* The new auth system must be compatible with the old system passwords hashing algorithm for the migration to be transparent. (An alternative is to force all users to reset their password.)
+* The new auth system must be compatible with the old system's password hashing algorithm for the migration to be transparent to the end user. (An alternative is to force all users to reset their password.)
 
 In short, this is a high risk, low outage duration, high reward solution.
 


### PR DESCRIPTION
Just a few typos/clarifications.