### PR TITLE
Added more details about the login_hint.

### DIFF
--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -72,7 +72,9 @@ The link:/docs/v1/tech/reference/data-types/#locales[locale] to be used to rende
 [field]#login_hint# [type]#[String]# [optional]#Optional# [since]#Available since 1.19.0#::
 An optional email address or top level domain that can allow you to bypass the FusionAuth login page when using managed domains.
 +
-Adding this request parameter will cause the FusionAuth login page to be skipped, and instead a `302` will be returned with a `Location` header of the IdP login URL. The end result is functionally equivalent to the end entering their email address when using the IdP configuration with managed domains.
+If using managed domains, adding this request parameter will cause the FusionAuth login page to be skipped, and instead a `302` will be returned with a `Location` header of the IdP login URL. The end result is functionally equivalent to the end entering their email address when using the IdP configuration with managed domains.
++ 
+If not using managed domains, providing an email address using this parameter prepopulates the email address in the login page.
 
 [field]#metaData.device.description# [type]#[String]# [optional]#Optional#::
 A human readable description of the device used during login. This meta data is used to describe the refresh token that may be generated for this login request.
@@ -208,6 +210,8 @@ The link:/docs/v1/tech/reference/data-types/#locales[locale] to be used to rende
 An optional email address or top level domain that can allow you to bypass the FusionAuth login page when using managed domains.
 +
 Adding this request parameter will cause the FusionAuth login page to be skipped, and instead a `302` will be returned with a `Location` header of the IdP login URL. The end result is functionally equivalent to the end entering their email address when using the IdP configuration with managed domains.
++ 
+If not using managed domains, providing an email address using this parameter prepopulates the email address in the login page.
 
 [field]#nonce# [type]#[String]# [optional]#Optional# [since]#Available since 1.5.0#::
 The `nonce` parameter as described in the https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect core] specification. When this parameter is provided during the Authorization request, the value will be returned in the `id_token` if requested by the `response_type` parameter.

--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -209,7 +209,7 @@ The link:/docs/v1/tech/reference/data-types/#locales[locale] to be used to rende
 [field]#login_hint# [type]#[String]# [optional]#Optional# [since]#Available since 1.19.0#::
 An optional email address or top level domain that can allow you to bypass the FusionAuth login page when using managed domains.
 +
-Adding this request parameter will cause the FusionAuth login page to be skipped, and instead a `302` will be returned with a `Location` header of the IdP login URL. The end result is functionally equivalent to the end entering their email address when using the IdP configuration with managed domains.
+If using managed domains, adding this request parameter will cause the FusionAuth login page to be skipped, and instead a `302` will be returned with a `Location` header of the IdP login URL. The end result is functionally equivalent to the end entering their email address when using the IdP configuration with managed domains.
 + 
 If not using managed domains, providing an email address using this parameter prepopulates the email address in the login page.
 


### PR DESCRIPTION
I didn't realize it could be used outside of managed domains to prepopulate the email address on the login form.