### PR TITLE
Added some clarifying language around the 'form' mentioned here.

### DIFF
--- a/site/docs/v1/tech/lambdas/_saml-response-fields.adoc
+++ b/site/docs/v1/tech/lambdas/_saml-response-fields.adoc
@@ -10,7 +10,7 @@ samlResponse.assertion.attributes['firstName'] = [user.firstName];
 ----
 
 [field]#samlResponse.assertion.conditions.audiences# [type]#[Array<String>]#::
-A list of the audiences for this SAML response. By default, the `issuer` or `audience` from the form are used.
+A list of the audiences for this SAML response. By default, the `audience` or `issuer`, in that order, from the corresponding SAML identity provider configuration are used.
 
 [field]#samlResponse.assertion.conditions.notBefore# [type]#[Long]#::
 The instant that this assertion starts being valid. This is the number of milliseconds since Epoch UTC.
@@ -19,7 +19,7 @@ The instant that this assertion starts being valid. This is the number of millis
 The instant that this assertion stops being valid. This is the number of milliseconds since Epoch UTC.
 
 [field]#samlResponse.assertion.issuer# [type]#[String]#::
-The issuer of this SAML assertion. This defaults to the `issuser` from the form.
+The issuer of this SAML assertion. This defaults to the `issuser` from the corresponding SAML identity provider configuration.
 
 [field]#samlResponse.assertion.subject.nameID.format# [type]#[String]#::
 The `NameID` format for the id of the subject (user). FusionAuth uses the `emailaddress` format specified by the SAML specifications. It is not recommended that you change this unless you know what you are doing.


### PR DESCRIPTION
https://fusionauth.io/community/forum/topic/702/retrieve-idp-id-used-for-login/5 indicated some confusion, so I looked at the source and updated the doc.