### PR TITLE
Fixed typo.

### DIFF
--- a/site/docs/v1/tech/apis/_user-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-request-body.adoc
@@ -83,7 +83,6 @@ The User's plain texts password. This password will be hashed and the provided v
 ifeval::["{http_method}" == "POST"]
 This field is optional only if `sendSetPasswordEmail` is set to `true`. By default `sendSetPasswordEmail` is `false`, and then this field will be required.
 endif::[]
-+
 ifeval::["{http_method}" == "PUT"]
 If this parameter is provided it indicates you wish to change the User's password. If you do not want to change the User's password omit this field from the request.
 endif::[]


### PR DESCRIPTION
There was an extra plus that showed up in the user.password request field.

Removed the plus sign to fix the typo.