### PR TITLE
Updated to allow either JWT or Bearer as the prefix for this call.

### DIFF
--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -501,7 +501,7 @@ The access token can be provided to the API using an HTTP request header, or a c
 [field]#Authorization# [type]#[String]# [optional]#Optional#::
 The encoded JWT to validate sent in on the Authorization request header.
 +
-The header is expected be in the following form: `Authorization: JWT <encoded_access_token>`
+The header is expected be in the following form: `Authorization: Bearer <encoded_access_token>` or `Authorization: JWT <encoded_access_token>`.
 +
 See link:/docs/v1/tech/apis/authentication/[Authentication] for additional examples.
 


### PR DESCRIPTION
From https://github.com/prime-framework/prime-mvc/blob/master/src/main/java/org/primeframework/mvc/security/DefaultJWTRequestAdapter.java

it looks like either prefix will work. There was a user confused by this: https://github.com/FusionAuth/fusionauth-issues/issues/1095

So wanted to clarify.

This appears to be the only place in the documentation where the `Authorization: JWT` format is used.