### PR TITLE
Refresh token note

### DIFF
--- a/site/docs/v1/tech/apis/_login-applicationId-parameter.adoc
+++ b/site/docs/v1/tech/apis/_login-applicationId-parameter.adoc
@@ -1,8 +1,13 @@
 The Id of the Application the user is to be logged into. This parameter is optional but there is not likely a production use case where you want to omit the value. If this parameter is omitted the user will still be authenticated but a login count will not be recorded for an Application.
 +
+
+ifndef::login_instant_section[]
 Because a refresh token is per user and per application, when this parameter is not provided a refresh token will not be returned. 
 +
 You likely want the user being logged in to be registered for this application. If that user isn't, the call will succeed, the response body will be different, no refresh token will be issued, and you'll receive a `202` HTTP status. 
 +
-See link:/docs/v1/tech/core-concepts/authentication-authorization/[the difference between authentication and authorization] for more.
 
+endif::[]
++
+See link:/docs/v1/tech/core-concepts/authentication-authorization/[the difference between authentication and authorization] for more.
++

--- a/site/docs/v1/tech/apis/_login-applicationId-parameter.adoc
+++ b/site/docs/v1/tech/apis/_login-applicationId-parameter.adoc
@@ -1,0 +1,8 @@
+The Id of the Application the user is to be logged into. This parameter is optional but there is not likely a production use case where you want to omit the value. If this parameter is omitted the user will still be authenticated but a login count will not be recorded for an Application.
++
+Because a refresh token is per user and per application, when this parameter is not provided a refresh token will not be returned. 
++
+You likely want the user being logged in to be registered for this application. If that user isn't, the call will succeed, the response body will be different, no refresh token will be issued, and you'll receive a `202` HTTP status. 
++
+See link:/docs/v1/tech/core-concepts/authentication-authorization/[the difference between authentication and authorization] for more.
+

--- a/site/docs/v1/tech/apis/login.adoc
+++ b/site/docs/v1/tech/apis/login.adoc
@@ -416,11 +416,14 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-o
 
 ==== Request Parameters
 
+:login_instant_section:
+
 [.api]
 [field]#userId# [type]#[UUID]# [required]#Required#::
 The Id of the user logging in.
 
 [field]#applicationId# [type]#[UUID]# [optional]#Optional#::
++
 include::docs/v1/tech/apis/_login-applicationId-parameter.adoc[]
 
 [field]#ipAddress# [type]#[String]# [optional]#Optional#::
@@ -437,6 +440,9 @@ link:/docs/v1/tech/apis/authentication#jwt-authentication[icon:id-badge[type=fas
 --
 
 The `userId` is not required on the request. The `userId` and `applicationId` values will be retrieved from the identity claims in the JWT payload.
+
+// unset from above. Can't put right next to the include file because it doesn't get processed correctly there.
+:login_instant_section!:
 
 ==== Request Parameters
 

--- a/site/docs/v1/tech/apis/login.adoc
+++ b/site/docs/v1/tech/apis/login.adoc
@@ -57,13 +57,7 @@ The Two Factor Trust identifier returned by the Two Factor Login API response. T
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional#::
-The Id of the Application the user is to be logged into. This parameter is optional but there is not likely a production use case where you want to omit the value.
-+
-Because a refresh token is per user and per application, when this parameter is not provided a refresh token will not be returned.
-+
-You likely want the user being logged in to be registered for this application. If that user isn't, the call will succeed, the response body will be different, no refresh token will be issued, and you'll receive a `202` HTTP status. 
-+
-See link:/docs/v1/tech/core-concepts/authentication-authorization/[the difference between authentication and authorization] for more.
+include::docs/v1/tech/apis/_login-applicationId-parameter.adoc[]
 
 [field]#ipAddress# [type]#[String]# [optional]#Optional#::
 The IP address of the end-user that is logging into FusionAuth. If this value is omitted FusionAuth will attempt to obtain the IP address of
@@ -163,8 +157,7 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-o
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional#::
-The Id of the Application the user is to be logged into. If this parameter is omitted the user will still be authenticated but a login
-count will not be recorded for an Application.
+include::docs/v1/tech/apis/_login-applicationId-parameter.adoc[]
 
 [field]#ipAddress# [type]#[String]# [optional]#Optional#::
 The IP address of the end-user that is logging into FusionAuth. If this value is omitted FusionAuth will attempt to obtain the IP address of
@@ -260,8 +253,7 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-o
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional#::
-The Id of the Application the user is to be logged into. If this parameter is omitted the user will still be authenticated but a login
-count will not be recorded for an Application.
+include::docs/v1/tech/apis/_login-applicationId-parameter.adoc[]
 
 [field]#code# [type]#[String]# [required]#Required#::
 The time based one time use password, also called a Two Factor verification code.
@@ -429,7 +421,7 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-o
 The Id of the user logging in.
 
 [field]#applicationId# [type]#[UUID]# [optional]#Optional#::
-The Id of the Application the user is logging into. If this parameter is omitted the user will still be authenticated but a login count will not be recorded for an Application.
+include::docs/v1/tech/apis/_login-applicationId-parameter.adoc[]
 
 [field]#ipAddress# [type]#[String]# [optional]#Optional#::
 The IP address of the end-user that is logging into FusionAuth. If this value is omitted FusionAuth will attempt to obtain the IP address of

--- a/site/docs/v1/tech/apis/login.adoc
+++ b/site/docs/v1/tech/apis/login.adoc
@@ -25,7 +25,7 @@ The Login API is used authenticate a user in FusionAuth. The issuer of the One T
 
 === Request
 
-By default, this API will require authentication when called with an [field]#applicationId#. Authentication may be disabled per Application, see [field]#application.loginConfiguration.requireAuthentication# in the link:/docs/v1/tech/apis/applications/[Application API] or navigate to [breadcrumb]#Applications -> Edit -> Security# in the user interface.
+By default, this API will require API key authentication when called with an [field]#applicationId#. API key authentication may be disabled per Application, see [field]#application.loginConfiguration.requireAuthentication# in the link:/docs/v1/tech/apis/applications/[Application API] or navigate to [breadcrumb]#Applications -> Edit -> Security# in the user interface.
 
 
 Prior to version `1.5.0` this API did not accept an API key and never required authentication.

--- a/site/docs/v1/tech/apis/login.adoc
+++ b/site/docs/v1/tech/apis/login.adoc
@@ -60,6 +60,10 @@ The Two Factor Trust identifier returned by the Two Factor Login API response. T
 The Id of the Application the user is to be logged into. This parameter is optional but there is not likely a production use case where you want to omit the value.
 +
 Because a refresh token is per user and per application, when this parameter is not provided a refresh token will not be returned.
++
+You likely want the user being logged in to be registered for this application. If that user isn't, the call will succeed, the response body will be different, no refresh token will be issued, and you'll receive a `202` HTTP status. 
++
+See link:/docs/v1/tech/core-concepts/authentication-authorization/[the difference between authentication and authorization] for more.
 
 [field]#ipAddress# [type]#[String]# [optional]#Optional#::
 The IP address of the end-user that is logging into FusionAuth. If this value is omitted FusionAuth will attempt to obtain the IP address of


### PR DESCRIPTION
Highlights that you almost certainly want the user to be registered for an application when you are using the login API.

Came out of this issue: https://github.com/FusionAuth/fusionauth-issues/issues/1097