### PR TITLE
Remove JWT as documented header prefix.

### DIFF
--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -501,7 +501,7 @@ The access token can be provided to the API using an HTTP request header, or a c
 [field]#Authorization# [type]#[String]# [optional]#Optional#::
 The encoded JWT to validate sent in on the Authorization request header.
 +
-The header is expected be in the following form: `Authorization: Bearer <encoded_access_token>` or `Authorization: JWT <encoded_access_token>`.
+The header is expected be in the following form: `Authorization: Bearer <encoded_access_token>`.
 +
 See link:/docs/v1/tech/apis/authentication/[Authentication] for additional examples.
 


### PR DESCRIPTION
Came out of conversation on this PR: https://github.com/FusionAuth/fusionauth-site/pull/410