### PR TITLE
remove 'roles' in example lambda.

### DIFF
--- a/site/docs/v1/tech/lambdas/index.adoc
+++ b/site/docs/v1/tech/lambdas/index.adoc
@@ -19,8 +19,8 @@ Here is an example of a FusionAuth lambda that adds some additional fields to a 
 [source,javascript]
 ----
 function populate(jwt, user, registration) {
-  jwt.roles = registration.roles || [];
   jwt.favoriteColor = user.data.favoriteColor;
+  jwt.applicationBackgroundColor = registration.data.backgroundColor;
 }
 ----
 


### PR DESCRIPTION
We provide the roles for free, no need to put them in the jwt.