### PR TITLE
Corrected the endpoint for monthly, daily users.

### DIFF
--- a/site/docs/v1/tech/apis/reports.adoc
+++ b/site/docs/v1/tech/apis/reports.adoc
@@ -21,7 +21,7 @@ This page contains the APIs for retrieving the reports available in FusionAuth. 
 :reportType: daily active users
 :reportDescription:
 :reportJSON: dailyActiveUsers.json
-:reportURI: daily-active-users
+:reportURI: daily-active-user
 :reportUnit: days
 include::docs/v1/tech/apis/_report.adoc[]
 
@@ -41,7 +41,7 @@ include::docs/v1/tech/apis/_report.adoc[]
 :reportType: monthly active users
 :reportDescription: The report is always generated using months as the interval.
 :reportJSON: monthlyActiveUsers.json
-:reportURI: monthly-active-users
+:reportURI: monthly-active-user
 :reportUnit: months
 include::docs/v1/tech/apis/_report.adoc[]
 


### PR DESCRIPTION
It was previously pluralized, but it is actually singular. See also https://fusionauth.io/community/forum/topic/813/typo-in-report-api