### PR TITLE
Improvements to algolia config.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,9 @@ algolia:
   application_id: 'MN6ZCVNV21'
   index_name: 'website'
   search_only_api_key: 'e65ffc9f8bb352def753e7614de78416'
+  files_to_exclude: []
+  max_record_size: 20000
+  nodes_to_index: 'p,dt,dd'
   extensions_to_index:
     - md
     - adoc


### PR DESCRIPTION
We explicitly include index.html files in the index.

Increase the max record size to as much as Algolia will take.

And make sure we index dt and dd elements, which are where the bulk of our API docs are.