### PR TITLE
Refresh token response code

### DIFF
--- a/site/docs/v1/tech/apis/_standard-get-response-codes.adoc
+++ b/site/docs/v1/tech/apis/_standard-get-response-codes.adoc
@@ -21,8 +21,14 @@ ifdef::not_registered[]
 endif::[]
 
 ifndef::no_errors[]
+ifndef::errors_message[]
 |400
 |The request was invalid and/or malformed. The response will contain an link:/docs/v1/tech/apis/errors/[Errors] JSON Object with the specific errors.
+endif::[]
+ifdef::errors_message[]
+|400
+|{errors_message}
+endif::[]
 endif::[]
 
 ifndef::no_authorization[]

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -294,11 +294,11 @@ include::docs/src/requests/jwt/refresh-post-request.http[]
 
 === Response
 
-:no_errors:
-:authorization_message: The provided Refresh Token is either expired or has been revoked.
+:no_authorization:
+:errors_message: The provided Refresh Token is either expired, was not found, or has been revoked.
 include::docs/v1/tech/apis/_standard-get-response-codes.adoc[]
-:no_errors!:
-:authorization_message!:
+:errors_message!:
+:no_authorization!:
 
 ==== Response Body
 


### PR DESCRIPTION
This is based on a feedback from a FusionAuth community member.

The refresh JWT request returns a 400 (tested against version 1.24) if the refresh token is malformed (using the API: `/api/jwt/refresh`, I didn't check the cookies, but assume they'd be the same). However the docs specify that it will be a 401 status code.

This code changes things to reflect the current reality of the request returning a 400.