### PR TITLE
fixed disjoint list of application scoped events.

### DIFF
--- a/site/docs/v1/tech/events-webhooks/events.adoc
+++ b/site/docs/v1/tech/events-webhooks/events.adoc
@@ -38,8 +38,8 @@ The ability to limit the generation of an event for only certain applications is
 
 These events can be application scoped:
 
-* `jwt.refresh-token.revoke`
 * `jwt.public-key.update`
+* `jwt.refresh-token.revoke`
 * `user.action`
 
 === Tenant Scoped Events

--- a/site/docs/v1/tech/events-webhooks/events.adoc
+++ b/site/docs/v1/tech/events-webhooks/events.adoc
@@ -38,10 +38,9 @@ The ability to limit the generation of an event for only certain applications is
 
 These events can be application scoped:
 
-* `user.action`
 * `jwt.refresh-token.revoke`
-* `jwt.refresh`
 * `jwt.public-key.update`
+* `user.action`
 
 === Tenant Scoped Events
 

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -146,7 +146,6 @@ When the [field]#All applications# is disabled, this field will be exposed. Sele
 +
 Not all events are considered application specific and selecting an application will limit you to only receiving application events. The following events are considered Application events:
 +
-    - `jwt.refresh`
     - `jwt.refresh-token.revoke`
     - `jwt.public-key.update`
     - `user.action`

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -146,8 +146,9 @@ When the [field]#All applications# is disabled, this field will be exposed. Sele
 +
 Not all events are considered application specific and selecting an application will limit you to only receiving application events. The following events are considered Application events:
 +
-    - `jwt.public-key.update`
+    - `jwt.refresh`
     - `jwt.refresh-token.revoke`
+    - `jwt.public-key.update`
     - `user.action`
 +
 In most cases you will want to use the [field]#All applications# configuration.

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -146,8 +146,8 @@ When the [field]#All applications# is disabled, this field will be exposed. Sele
 +
 Not all events are considered application specific and selecting an application will limit you to only receiving application events. The following events are considered Application events:
 +
-    - `jwt.refresh-token.revoke`
     - `jwt.public-key.update`
+    - `jwt.refresh-token.revoke`
     - `user.action`
 +
 In most cases you will want to use the [field]#All applications# configuration.


### PR DESCRIPTION
List was different between the events page and the index page. Index page had 3, events page had 4.

After investigating, determined that `jwt.refresh` could be application scoped so added it.