### PR TITLE
Add core concepts search jto

### DIFF
--- a/DocsDevREADME.md
+++ b/DocsDevREADME.md
@@ -57,6 +57,9 @@ For blog posts:
 - For field names, use double quotes: "Login Identifier Attribute".
 - For values, use back ticks: `userPrincipalName`.
 
+For documentation posts:
+- Headers should be title-case.  (see https://titlecase.com/ to check if you would like. No caps on articles 👍)
+
 For lists:
 - Capitalize the first word.
 - Have a period on the end if it is a sentence, otherwise don't.

--- a/site/_layouts/doc.liquid
+++ b/site/_layouts/doc.liquid
@@ -35,6 +35,7 @@
                   <ul>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/">Overview</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/users/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/users/">Users</a></li>
+                    <li {% if page.url == "/docs/v1/tech/core-concepts/search/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/search/">Search</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/roles/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/roles/">Roles</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/groups/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/groups/">Groups</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/registrations/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/registrations/">Registrations</a></li>
@@ -328,7 +329,7 @@
             {% else %}
               {{ content }}
             {% endif %}
-            
+
             {% if page.skipFeedback != 1 %}
             <div>
               <h3>Feedback</h3>

--- a/site/_layouts/doc.liquid
+++ b/site/_layouts/doc.liquid
@@ -35,13 +35,13 @@
                   <ul>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/">Overview</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/users/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/users/">Users</a></li>
-                    <li {% if page.url == "/docs/v1/tech/core-concepts/search/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/search/">Search</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/roles/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/roles/">Roles</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/groups/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/groups/">Groups</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/registrations/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/registrations/">Registrations</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/applications/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/applications/">Applications</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/tenants/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/tenants/">Tenants</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/identity-providers/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/identity-providers/">Identity Providers</a></li>
+                    <li {% if page.url == "/docs/v1/tech/core-concepts/search/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/search/">Search</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/authentication-authorization/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/authentication-authorization/">Authentication and Authorization</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/integration-points/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/integration-points/">Integration Points</a></li>
                     <li {% if page.url == "/docs/v1/tech/core-concepts/localization-and-internationalization/" %}class="active"{% endif %}><a href="/docs/v1/tech/core-concepts/localization-and-internationalization/">Localization and Internationalization</a></li>

--- a/site/docs/v1/tech/core-concepts/index.adoc
+++ b/site/docs/v1/tech/core-concepts/index.adoc
@@ -19,6 +19,7 @@ You may or may not have a use for Groups or Tenants at present, but it will be h
 Finally, FusionAuth is under active development and the roadmap guidance is helpful for knowing where the application is headed.
 
 * link:/docs/v1/tech/core-concepts/users/[Users]
+* link:/docs/v1/tech/core-concepts/search/[Search]
 * link:/docs/v1/tech/core-concepts/roles/[Roles]
 * link:/docs/v1/tech/core-concepts/groups/[Groups]
 * link:/docs/v1/tech/core-concepts/registrations/[Registrations]

--- a/site/docs/v1/tech/core-concepts/index.adoc
+++ b/site/docs/v1/tech/core-concepts/index.adoc
@@ -19,12 +19,13 @@ You may or may not have a use for Groups or Tenants at present, but it will be h
 Finally, FusionAuth is under active development and the roadmap guidance is helpful for knowing where the application is headed.
 
 * link:/docs/v1/tech/core-concepts/users/[Users]
-* link:/docs/v1/tech/core-concepts/search/[Search]
 * link:/docs/v1/tech/core-concepts/roles/[Roles]
 * link:/docs/v1/tech/core-concepts/groups/[Groups]
 * link:/docs/v1/tech/core-concepts/registrations/[Registrations]
 * link:/docs/v1/tech/core-concepts/applications/[Applications]
 * link:/docs/v1/tech/core-concepts/tenants/[Tenants]
+* link:/docs/v1/tech/core-concepts/identity-providers/[Identity Providers]
+* link:/docs/v1/tech/core-concepts/search/[Search]
 * link:/docs/v1/tech/core-concepts/authentication-authorization/[Authentication and Authorization]
 * link:/docs/v1/tech/core-concepts/integration-points/[Integration Points]
 * link:/docs/v1/tech/core-concepts/localization-and-internationalization/[Localization and Internationalization]

--- a/site/docs/v1/tech/core-concepts/search.adoc
+++ b/site/docs/v1/tech/core-concepts/search.adoc
@@ -10,8 +10,10 @@ description: Search options within FusionAuth
 
 FusionAuth ships with two options for search: a simple search via the database search engine and the Elasticsearch database engine.
 
-* <<Using the database search engine>>
-* <<Using the Elasticsearch search engine>>
+== Using the Search Engine
+
+* <<Using the Database Search Engine>>
+* <<Using the Elasticsearch Search Engine>>
 
 == Configuration
 
@@ -20,45 +22,33 @@ FusionAuth ships with two options for search: a simple search via the database s
 
 As of version 1.16.0, FusionAuth ships with a database search engine as the default.
 
-By selecting the appropriate link:/docs/v1/tech/installation-guide/fast-path[Fast Path installation], one can easily download a configuration with Elasticsearch pre-enabled.
+By selecting the appropriate link:/docs/v1/tech/installation-guide/[installation guide], one can easily create a configuration with Elasticsearch pre-enabled.
 
 ====
 
-==== Configuration Reference
+=== Configuration Reference
 
-See link:/docs/v1/tech/reference/configuration/[Configuration Reference] for details on configuring the search engine and (optional) Elasticsearch integration.
+The relevant properties which control the configuration of the search engine include `search.type` which specifies the search engine type. For the database search engine, there is no other configuration needed. All other settings referencing `search` apply to the Elasticsearch search engine only. Please see the link:/docs/v1/tech/reference/configuration/[Configuration Reference] for more details.
 
-Highlighted here:
+==== Switch Engine Types
 
-_Properties_
-
-- [field]#fusionauth-app.search-engine-type#
-- [field]#fusionauth-app.search-servers#
-
-_Environment variables_
-
-- `FUSIONAUTH_SEARCH_ENGINE_TYPE`
-- `FUSIONAUTH_SEARCH_SERVERS`
-
-==== Switch engine types
-
-You may also link:/docs/v1/tech/tutorials/switch-search-engines/[switch between the different search engines].
+You may link:/docs/v1/tech/tutorials/switch-search-engines/[switch between the different search engines].
 
 ==== Docker
 If you are running FusionAuth in a Docker environment, see the link:/docs/v1/tech/installation-guide/docker/[Using FusionAuth on Docker] documentation for an example configuring Elasticsearch as the user search engine.
 
 
-==== View current configuration
+==== View Current Configuration
 
-You may view the configured search engine type in the FusionAuth admin UI by navigating to [breadcrumb]#System -> About#.
+You may view the configured search engine type in the FusionAuth admin UI by navigating to [breadcrumb]#System -> About#.  As you can see below, this system is configured to use the database search engine.
 
 image::about-search-engine-type.png[About - Search Engine Type,width=1200,role=shadowed top-cropped]
 
-== Using the database search engine
+== Using the Database Search Engine
 
 This configuration is lightweight, simplifies installation and system complexity, but comes with the trade offs of limited search capabilities and performance implications.
 
-The database search engine is appropriate for systems that are not dependent on the FusionAuth API's, are not expected to have a large number of search results, and may be running in an embedded environment.
+The database search engine is appropriate for systems that are not dependent on the FusionAuth APIs, are not expected to have a large number of search results, or are running in an embedded environment.
 
 If you don't need advanced searching capabilities, you may be able to use the database search engine for large installations. This is not a use case FusionAuth tests, so ensure you provision your database with enough resources and benchmark your typical use cases.
 
@@ -70,13 +60,13 @@ All search terms are converted to lowercase and compared with lowercase values.
 
 Regular expressions, ranges, and other complicated queries can not be used.
 
-== Using the Elasticsearch search engine
+== Using the Elasticsearch Search Engine
 
-Leveraging Elasticsearch, enables advanced search capabilities on more numerous and granular data and a performance improvement.
+Leveraging Elasticsearch enables advanced search capabilities on more numerous and granular data. It also provides a performance improvement.
 
-The Elasticsearch search engine is appropriate for systems that are dependent on the FusionAuth API's (such as link:/docs/v1/tech/apis/users#search-for-users[users]), are expected to have a large number of results, and requires a more tactical search than is provided by the database search engine.
+The Elasticsearch search engine is appropriate for systems that are dependent on the FusionAuth APIs (such as link:/docs/v1/tech/apis/users#search-for-users[user search]), are expected to have a large number of results, or require more granularity in search than is provided by the standard database search engine.
 
-=== Reindex
+=== Reindexing Elasticsearch
 
 [WARNING]
 ====

--- a/site/docs/v1/tech/core-concepts/search.adoc
+++ b/site/docs/v1/tech/core-concepts/search.adoc
@@ -1,0 +1,61 @@
+---
+layout: doc
+title: Search
+description: Search optins within FusionAuth
+---
+
+:sectnumlevels: 0
+
+== Overview
+
+FusionAuth ships with two options for search: a simple search via the database search engine and Elasticsearch database engine.
+
+* <<Simple search>>
+* <<Elasticsearch search engine>>
+
+== Simple search
+
+As of version 1.16.0, FusionAuth ships with a database search engine as the default.
+
+=== Configuration
+
+See the [field]#fusionauth-app.search-engine-type# and [field]#fusionauth-app.search-servers# properties, as well as the `FUSIONAUTH_SEARCH_ENGINE_TYPE` and `FUSIONAUTH_SEARCH_SERVERS` environment variables definitions of the link:/docs/v1/tech/reference/configuration/[Configuration Reference] for details on configuring the search engine and (optional) Elasticsearch integration.
+
+If you are running FusionAuth in a Docker environment, see the link:/docs/v1/tech/installation-guide/docker/[Using FusionAuth on Docker] documentation for an example configuring Elasticsearch as the user search engine.
+
+You may view the configured search engine type in the FusionAuth admin UI by navigating to [breadcrumb]#System -> About#.
+
+image::about-search-engine-type.png[About - Search Engine Type,width=1200,role=shadowed top-cropped]
+
+You may also link:/docs/v1/tech/tutorials/switch-search-engines/[switch between the different search engines].
+
+=== Using the database search engine
+
+This configuration is lightweight, simplifies installation and system complexity, but comes with the trade offs of limited search capabilities and performance implications.
+
+The database search engine is appropriate for systems that are not dependent on the FusionAuth API's, is not expected to have a large number of search results, and may be running in an embedded environment.
+
+If you don't need advanced searching capabilities, you may be able to use the database search engine for large installations. This is not a use case FusionAuth tests, so ensure you provision your database with enough resources and benchmark your typical use cases.
+
+==== Limitations
+
+You may add a `*` character to wildcard match any character, including none. So `*piedpiper` will match `piedpiper` and `thepiedpiper`. You may put the wildcard at any location in a search string.
+
+All search terms are converted to lowercase and compared with lowercase values.
+
+Regular expressions, ranges and other complicated queries can not be used.
+
+=== Elasticsearch search engine
+
+Leveraging Elasticsearch, enables advanced search capabilities on more numerous and granular data and a performance improvement.
+
+The Elasticsearch search engine is appropriate for systems that are dependent on the FusionAuth API's (such as link:/docs/v1/tech/apis/users#search-for-users[users]), are expected to have a large number of results, and requires a more tactical search than is provided by the database search engine.
+
+==== Reindex
+
+It is possible, though rare, for an Elasticsearch index to become out of sync with the database. If you stand up FusionAuth with a database dump and restore, you may need to run this operation. You may also be instructed to do so by FusionAuth support.
+
+However, in general, even if a temporary outage occurs with Elasticsearch, the index will be sync up automatically. Reindexing is an expensive operation, especially if your system has a large number of users, so it should not be run unless necessary.
+
+If you do need to run this, navigate to [breadcrumb]#System -> Reindex# in the FusionAuth admin UI to initiate a reindex of all users. This navigation item will only be displayed when the search engine is Elasticsearch.
+

--- a/site/docs/v1/tech/core-concepts/search.adoc
+++ b/site/docs/v1/tech/core-concepts/search.adoc
@@ -1,61 +1,92 @@
 ---
 layout: doc
 title: Search
-description: Search optins within FusionAuth
+description: Search options within FusionAuth
 ---
 
 :sectnumlevels: 0
 
 == Overview
 
-FusionAuth ships with two options for search: a simple search via the database search engine and Elasticsearch database engine.
+FusionAuth ships with two options for search: a simple search via the database search engine and the Elasticsearch database engine.
 
-* <<Simple search>>
-* <<Elasticsearch search engine>>
+* <<Using the database search engine>>
+* <<Using the Elasticsearch search engine>>
 
-== Simple search
+== Configuration
+
+[NOTE.since]
+====
 
 As of version 1.16.0, FusionAuth ships with a database search engine as the default.
 
-=== Configuration
+By selecting the appropriate link:/docs/v1/tech/installation-guide/fast-path[Fast Path installation], one can easily download a configuration with Elasticsearch pre-enabled.
 
-See the [field]#fusionauth-app.search-engine-type# and [field]#fusionauth-app.search-servers# properties, as well as the `FUSIONAUTH_SEARCH_ENGINE_TYPE` and `FUSIONAUTH_SEARCH_SERVERS` environment variables definitions of the link:/docs/v1/tech/reference/configuration/[Configuration Reference] for details on configuring the search engine and (optional) Elasticsearch integration.
+====
 
+==== Configuration Reference
+
+See link:/docs/v1/tech/reference/configuration/[Configuration Reference] for details on configuring the search engine and (optional) Elasticsearch integration.
+
+Highlighted here:
+
+_Properties_
+
+- [field]#fusionauth-app.search-engine-type#
+- [field]#fusionauth-app.search-servers#
+
+_Environment variables_
+
+- `FUSIONAUTH_SEARCH_ENGINE_TYPE`
+- `FUSIONAUTH_SEARCH_SERVERS`
+
+==== Switch engine types
+
+You may also link:/docs/v1/tech/tutorials/switch-search-engines/[switch between the different search engines].
+
+==== Docker
 If you are running FusionAuth in a Docker environment, see the link:/docs/v1/tech/installation-guide/docker/[Using FusionAuth on Docker] documentation for an example configuring Elasticsearch as the user search engine.
+
+
+==== View current configuration
 
 You may view the configured search engine type in the FusionAuth admin UI by navigating to [breadcrumb]#System -> About#.
 
 image::about-search-engine-type.png[About - Search Engine Type,width=1200,role=shadowed top-cropped]
 
-You may also link:/docs/v1/tech/tutorials/switch-search-engines/[switch between the different search engines].
-
-=== Using the database search engine
+== Using the database search engine
 
 This configuration is lightweight, simplifies installation and system complexity, but comes with the trade offs of limited search capabilities and performance implications.
 
-The database search engine is appropriate for systems that are not dependent on the FusionAuth API's, is not expected to have a large number of search results, and may be running in an embedded environment.
+The database search engine is appropriate for systems that are not dependent on the FusionAuth API's, are not expected to have a large number of search results, and may be running in an embedded environment.
 
 If you don't need advanced searching capabilities, you may be able to use the database search engine for large installations. This is not a use case FusionAuth tests, so ensure you provision your database with enough resources and benchmark your typical use cases.
 
-==== Limitations
+=== Limitations
 
 You may add a `*` character to wildcard match any character, including none. So `*piedpiper` will match `piedpiper` and `thepiedpiper`. You may put the wildcard at any location in a search string.
 
 All search terms are converted to lowercase and compared with lowercase values.
 
-Regular expressions, ranges and other complicated queries can not be used.
+Regular expressions, ranges, and other complicated queries can not be used.
 
-=== Elasticsearch search engine
+== Using the Elasticsearch search engine
 
 Leveraging Elasticsearch, enables advanced search capabilities on more numerous and granular data and a performance improvement.
 
 The Elasticsearch search engine is appropriate for systems that are dependent on the FusionAuth API's (such as link:/docs/v1/tech/apis/users#search-for-users[users]), are expected to have a large number of results, and requires a more tactical search than is provided by the database search engine.
 
-==== Reindex
+=== Reindex
+
+[WARNING]
+====
+Reindexing is an expensive operation, especially if your system has a large number of users, so it should not be run unless necessary.
+====
 
 It is possible, though rare, for an Elasticsearch index to become out of sync with the database. If you stand up FusionAuth with a database dump and restore, you may need to run this operation. You may also be instructed to do so by FusionAuth support.
 
-However, in general, even if a temporary outage occurs with Elasticsearch, the index will be sync up automatically. Reindexing is an expensive operation, especially if your system has a large number of users, so it should not be run unless necessary.
+In general, even if a temporary outage occurs with Elasticsearch, the index will be sync up automatically.
+
 
 If you do need to run this, navigate to [breadcrumb]#System -> Reindex# in the FusionAuth admin UI to initiate a reindex of all users. This navigation item will only be displayed when the search engine is Elasticsearch.
 

--- a/site/docs/v1/tech/core-concepts/users.adoc
+++ b/site/docs/v1/tech/core-concepts/users.adoc
@@ -47,9 +47,9 @@ include::docs/v1/tech/shared/_login_events.adoc[]
 
 As of version 1.16.0, FusionAuth ships with a database search engine as the default.
 
-By selecting the appropriate link:/docs/v1/tech/installation-guide/fast-path[Fast Path installation], one can easily download a configuration with Elasticsearch pre-enabled.
+By selecting the appropriate link:/docs/v1/tech/installation-guide/fast-path[installation guide], one can easily create a configuration with Elasticsearch pre-enabled.
 
-You can read more in our link:/docs/v1/tech/core-concepts/search[search core concept]
+You can read more about the database and other search engines in the link:/docs/v1/tech/core-concepts/search[search core concepts section].
 
 ====
 
@@ -58,7 +58,7 @@ User search requests may be made through the link:/docs/v1/tech/apis/users#searc
 === Configuration
 
 
-Please see our link:/docs/v1/tech/core-concepts/search[search core concept] for additional information on basic configuration.  The remainder of this section will cover specifics as it relates to users and search.
+Please see our link:/docs/v1/tech/core-concepts/search[search core concepts section] for additional information on basic configuration.  The remainder of this section will cover specifics as it relates to users and search.
 
 === Database Search Engine
 
@@ -73,6 +73,8 @@ The database search engine enables fuzzy search against the following fields of 
 * `username`
 
 image::user-search-database.png[User Search with Database Search Engine,width=1200,role=shadowed bottom-cropped]
+
+To learn more about the database search engine in general, view the link:/docs/v1/tech/core-concepts/search[search core concepts section].
 
 === Elasticsearch Search Engine
 
@@ -95,3 +97,5 @@ When searching for users by application or any fields on an application, it is n
 The following screenshot shows an Elasticsearch JSON query being constructed to search for users that match the email pattern `*@fusionauth.io`, are registered to the `Pied Piper` application, and are assigned the `admin` role:
 
 image::user-search-json-query.png[User Search by JSON Query,width=1200,role=shadowed top-cropped]
+
+To learn more about the Elasticsearch search engine in general, view the link:/docs/v1/tech/core-concepts/search[search core concepts section].

--- a/site/docs/v1/tech/core-concepts/users.adoc
+++ b/site/docs/v1/tech/core-concepts/users.adoc
@@ -10,7 +10,7 @@ description: An overview of Users
 
 FusionAuth is all about users, and it is helpful to fully understand how FusionAuth understands users to fully leverage all of the features FusionAuth offers.
 
-The User itself is easy enough to understand, it represents your end user, your employee or your client.
+The User itself is easy enough to understand, it represents your end user, your employee, or your client.
 
 * <<User Scope>>
 * <<What Makes a User Active>>
@@ -42,16 +42,25 @@ include::docs/v1/tech/shared/_login_events.adoc[]
 
 == User Search
 
-User search requests may be made through the link:/docs/v1/tech/apis/users#search-for-users[User Search API] or within the FusionAuth admin UI under [breadcrumb]#Users#.
+[NOTE.since]
+====
 
 As of version 1.16.0, FusionAuth ships with a database search engine as the default.
+
+By selecting the appropriate link:/docs/v1/tech/installation-guide/fast-path[Fast Path installation], one can easily download a configuration with Elasticsearch pre-enabled.
+
+You can read more in our link:/docs/v1/tech/core-concepts/search[search core concept]
+
+====
+
+User search requests may be made through the link:/docs/v1/tech/apis/users#search-for-users[User Search API] or within the FusionAuth admin UI under [breadcrumb]#Users#.
 
 === Configuration
 
 
-Please see our link:/docs/v1/tech/core-concepts/[search section] for additional information on basic configuration.  The remainder of this section will cover specifics as it relates to users and search.
+Please see our link:/docs/v1/tech/core-concepts/search[search core concept] for additional information on basic configuration.  The remainder of this section will cover specifics as it relates to users and search.
 
-=== Database Search Engine - Users
+=== Database Search Engine
 
 This configuration is lightweight, simplifies installation and system complexity, but comes with the trade offs of limited search capabilities and performance implications.
 
@@ -65,9 +74,9 @@ The database search engine enables fuzzy search against the following fields of 
 
 image::user-search-database.png[User Search with Database Search Engine,width=1200,role=shadowed bottom-cropped]
 
-=== Elasticsearch Search Engine - Users
+=== Elasticsearch Search Engine
 
-Leveraging Elasticsearch for the user search engine, enables advanced search capabilities on more numerous and granular data and a performance improvement for user search.
+Leveraging Elasticsearch for the user search engine enables advanced search capabilities on more numerous and granular data and a performance improvement for user search.
 
 ==== Advanced Search UI
 

--- a/site/docs/v1/tech/core-concepts/users.adoc
+++ b/site/docs/v1/tech/core-concepts/users.adoc
@@ -10,7 +10,7 @@ description: An overview of Users
 
 FusionAuth is all about users, and it is helpful to fully understand how FusionAuth understands users to fully leverage all of the features FusionAuth offers.
 
-The User itself is easy enough to understand, it represents your end user, your employee or your client. 
+The User itself is easy enough to understand, it represents your end user, your employee or your client.
 
 * <<User Scope>>
 * <<What Makes a User Active>>
@@ -30,7 +30,7 @@ A User is scoped to a Tenant.  A User existing within a Tenant can be registered
 FusionAuth includes reporting on the number of daily and monthly active users. What makes a User active during a time period is any of these events:
 
 * A User is created.
-* A User logs in. 
+* A User logs in.
 * The link:/docs/v1/tech/apis/login/#update-login-instant[Login Ping API] is used.
 * A JWT is refreshed using a Refresh Token.
 * SSO is used; this calls the login ping.
@@ -48,21 +48,12 @@ As of version 1.16.0, FusionAuth ships with a database search engine as the defa
 
 === Configuration
 
-See the [field]#fusionauth-app.search-engine-type# and [field]#fusionauth-app.search-servers# properties, as well as the `FUSIONAUTH_SEARCH_ENGINE_TYPE` and `FUSIONAUTH_SEARCH_SERVERS` environment variables definitions of the link:/docs/v1/tech/reference/configuration/[Configuration Reference] for details on configuring the search engine and (optional) Elasticsearch integration.
 
-If you are running FusionAuth in a Docker environment, see the link:/docs/v1/tech/installation-guide/docker/[Using FusionAuth on Docker] documentation for an example configuring Elasticsearch as the user search engine.
+Please see our link:/docs/v1/tech/core-concepts/[search section] for additional information on basic configuration.  The remainder of this section will cover specifics as it relates to users and search.
 
-You may view the configured search engine type in the FusionAuth admin UI by navigating to [breadcrumb]#System -> About#.
-
-image::about-search-engine-type.png[About - Search Engine Type,width=1200,role=shadowed top-cropped]
-
-You may also link:/docs/v1/tech/tutorials/switch-search-engines/[switch between the different search engines].
-
-=== Database Search Engine
+=== Database Search Engine - Users
 
 This configuration is lightweight, simplifies installation and system complexity, but comes with the trade offs of limited search capabilities and performance implications.
-
-The database search engine is appropriate for systems that are not dependent on the link:/docs/v1/tech/apis/users#search-for-users[User Search APIs], is not expected to have a large number of active users, and may be running in an embedded environment. 
 
 The database search engine enables fuzzy search against the following fields of the user:
 
@@ -74,21 +65,9 @@ The database search engine enables fuzzy search against the following fields of 
 
 image::user-search-database.png[User Search with Database Search Engine,width=1200,role=shadowed bottom-cropped]
 
-If you don't need advanced searching capabilities, you may be able to use the database search engine for large installations. This is not a use case FusionAuth tests, so ensure you provision your database with enough resources and benchmark your typical use cases.
-
-==== Limitations
-
-You may add a `*` character to wildcard match any character, including none. So `*piedpiper` will match `piedpiper` and `thepiedpiper`. You may put the wildcard at any location in a search string.
-
-All search terms are converted to lowercase and compared with lowercase values.
-
-Regular expressions, ranges and other complicated queries can not be used.
-
-=== Elasticsearch Search Engine
+=== Elasticsearch Search Engine - Users
 
 Leveraging Elasticsearch for the user search engine, enables advanced search capabilities on more numerous and granular data and a performance improvement for user search.
-
-The Elasticsearch search engine is appropriate for systems that are dependent on the link:/docs/v1/tech/apis/users#search-for-users[User Search APIs], are expected to have a large number of active users, and requires a more tactical search than is provided by the database search engine.
 
 ==== Advanced Search UI
 
@@ -107,12 +86,3 @@ When searching for users by application or any fields on an application, it is n
 The following screenshot shows an Elasticsearch JSON query being constructed to search for users that match the email pattern `*@fusionauth.io`, are registered to the `Pied Piper` application, and are assigned the `admin` role:
 
 image::user-search-json-query.png[User Search by JSON Query,width=1200,role=shadowed top-cropped]
-
-==== Reindex
-
-It is possible, though rare, for an Elasticsearch index to become out of sync with the database. If you stand up FusionAuth with a database dump and restore, you may need to run this operation. You may also be instructed to do so by FusionAuth support. 
-
-However, in general, even if a temporary outage occurs with Elasticsearch, the index will be sync up automatically. Reindexing is an expensive operation, especially if your system has a large number of users, so it should not be run unless necessary.
-
-If you do need to run this, navigate to [breadcrumb]#System -> Reindex# in the FusionAuth admin UI to initiate a reindex of all users. This navigation item will only be displayed when the search engine is Elasticsearch.
-


### PR DESCRIPTION
# Summary
- Add Search to core concepts
- Most of the content was divorced/broken-out from the `Users Core Concept`
- Keeps our documentation `D.R.Y` (avoid duplication of documentation under `Entities` as they will have search functionality as well)