### PR TITLE
Tweak client lib docs public clients

### DIFF
--- a/site/docs/v1/tech/client-libraries/_public-client-note.adoc
+++ b/site/docs/v1/tech/client-libraries/_public-client-note.adoc
@@ -1,0 +1,6 @@
+You may use this client library in an application that cannot securely store secrets, such as a native mobile application or a single page application running in the browser. 
+
+In this scenario, you should disable [field]#Require authentication# in the FusionAuth Application configuration and use https://tools.ietf.org/html/rfc7636[PKCE] to secure communication with the Token endpoint.
+
+You can use the `exchangeOAuthCodeForAccessTokenUsingPKCE` client method to do so.
+

--- a/site/docs/v1/tech/client-libraries/dart.adoc
+++ b/site/docs/v1/tech/client-libraries/dart.adoc
@@ -38,13 +38,13 @@ void main() async {
 
 include::docs/v1/tech/client-libraries/_public-client-note.adoc[]
 
+++++
+{% capture relatedTag %}client-dart{% endcapture %}
+{% include _doc_related_posts.liquid %}
+++++
+
 === Example Apps
 ++++
 {%capture language %}dart{% endcapture %}
 {% include _example_apps_one_section.liquid %}
-++++
-
-++++
-{% capture relatedTag %}client-dart{% endcapture %}
-{% include _doc_related_posts.liquid %}
 ++++

--- a/site/docs/v1/tech/client-libraries/dart.adoc
+++ b/site/docs/v1/tech/client-libraries/dart.adoc
@@ -34,6 +34,15 @@ void main() async {
   }
 }
 ```
+=== Client Authentication
+
+include::docs/v1/tech/client-libraries/_public-client-note.adoc[]
+
+=== Example Apps
+++++
+{%capture language %}dart{% endcapture %}
+{% include _example_apps_one_section.liquid %}
+++++
 
 ++++
 {% capture relatedTag %}client-dart{% endcapture %}

--- a/site/docs/v1/tech/client-libraries/javascript.adoc
+++ b/site/docs/v1/tech/client-libraries/javascript.adoc
@@ -50,3 +50,7 @@ Here is an example of using the `retrieveUserByEmail` method to retrieve a User 
   </body>
 </html>
 ----
+
+=== Client Authentication
+
+include::docs/v1/tech/client-libraries/_public-client-note.adoc[]

--- a/site/docs/v1/tech/client-libraries/typescript.adoc
+++ b/site/docs/v1/tech/client-libraries/typescript.adoc
@@ -99,13 +99,18 @@ npx browserify example.ts --debug -p tsify -t browserify-shim -o dist/example-br
 
 You can also find this example's link:https://github.com/FusionAuth/fusionauth-typescript-client/tree/master/examples/hybrid-example[source code] in the link:https://github.com/FusionAuth/fusionauth-typescript-client[typescript repo].
 
-++++
-{% capture relatedTag %}client-javascript{% endcapture %}
-{% include _doc_related_posts.liquid %}
-++++
+=== Client Authentication
+
+include::docs/v1/tech/client-libraries/_public-client-note.adoc[]
 
 === Example apps
 ++++
 {%capture language %}javascript{% endcapture %}
 {% include _example_apps_one_section.liquid %}
 ++++
+
+++++
+{% capture relatedTag %}client-javascript{% endcapture %}
+{% include _doc_related_posts.liquid %}
+++++
+

--- a/site/docs/v1/tech/client-libraries/typescript.adoc
+++ b/site/docs/v1/tech/client-libraries/typescript.adoc
@@ -103,14 +103,13 @@ You can also find this example's link:https://github.com/FusionAuth/fusionauth-t
 
 include::docs/v1/tech/client-libraries/_public-client-note.adoc[]
 
-=== Example apps
-++++
-{%capture language %}javascript{% endcapture %}
-{% include _example_apps_one_section.liquid %}
-++++
-
 ++++
 {% capture relatedTag %}client-javascript{% endcapture %}
 {% include _doc_related_posts.liquid %}
 ++++
 
+=== Example apps
+++++
+{%capture language %}javascript{% endcapture %}
+{% include _example_apps_one_section.liquid %}
+++++

--- a/site/docs/v1/tech/core-concepts/applications.adoc
+++ b/site/docs/v1/tech/core-concepts/applications.adoc
@@ -87,7 +87,7 @@ You may optionally regenerate the client secret if you think the secret has been
 [field]#Require authentication# [optional]#Optional#::
 When enabled access to the Token endpoint will require the use of the `client_secret` parameter. In most cases you will not want to disable this setting.
 +
-There may be scenarios where you have a requirement to make a request to the Token endpoint where you cannot safely secure a client secret. In these scenarios you may need to disable client authentication.
+There may be scenarios where you have a requirement to make a request to the Token endpoint where you cannot safely secure a client secret. In these scenarios you may need to disable client authentication. This includes native mobile applications and single page applications (SPAs) running in a browser. In these scenarios it is recommended you use PKCE.
 
 [field]#Generate refresh tokens# [optional]#Optional#::
 When enabled, FusionAuth will return a refresh token when the `offline_access` scope has been requested. When this setting is disabled refresh tokens will not be generated even if the `offline_access` scope is requested.


### PR DESCRIPTION
This changes makes it clear why you would turn off require authentication in the fusionauth app configuration.

Also added example apps for dart.
