### PR TITLE
updating docs to make it clear you can't modify jwt headers.

### DIFF
--- a/site/docs/v1/tech/lambdas/jwt-populate.adoc
+++ b/site/docs/v1/tech/lambdas/jwt-populate.adoc
@@ -31,12 +31,11 @@ This lambda must contain a function named `populate` that takes three parameters
 
 The two FusionAuth objects are well documented here in the link:/docs/v1/tech/apis/users/[User API] and link:/docs/v1/tech/apis/registrations/[Registration API] documentation. The JWT object is a JavaScript object containing the JWT payload. See link:/docs/v1/tech/oauth/tokens/[OpenID Connect & OAuth 2.0 Token].
 
-You may add or modify anything in the `jwt` object, however FusionAuth protects certain reserved claims. The following claims are considered reserved and modifications or removal will not be reflected in the final JWT payload:
+You may add or modify anything in the `jwt` object. However, you may not modify the header keys or values of the JWT. FusionAuth also protects certain reserved claims. The following claims are considered reserved and modifications or removal will not be reflected in the final JWT payload:
 
 - `exp`
 - `iat`
 - `sub`
-
 
 Prior to version 1.14.0 the following claims were considered reserved.
 


### PR DESCRIPTION
Had a question in the forum about adding a JKU header: https://fusionauth.io/community/forum/topic/948/jku-in-jwt-header

Wanted to make it clear that headers are immutable.

I did notice that fusionauth-jwt had a way to modify JWT headers, so if there's community support for it, might be possible to implement in a lambda.