### PR TITLE
Adding known theme issue to release notes.

### DIFF
--- a/site/docs/v1/tech/release-notes.adoc
+++ b/site/docs/v1/tech/release-notes.adoc
@@ -91,6 +91,12 @@ include::docs/v1/tech/__database-migration-warning.adoc[]
 * Add IP address to login success and failed events.
 ** Resolves https://github.com/FusionAuth/fusionauth-issues/issues/1162[GitHub Issue #1162]
 
+=== Known Issues
+* If you have a non default theme for the FusionAuth default tenant, you will see an error when trying to login to the admin UI. You can workaround this by appending `?&bypassTheme=true` to your login URL.
+// ** Resolved in 1.26.1, see https://github.com/FusionAuth/fusionauth-issues/issues/1175[GitHub Issue #1175] for additional details.
+
+=== Changed
+
 [role=release-note]
 
 == Version 1.25.0


### PR DESCRIPTION
Issue discovered today in 1.26, tracking in https://github.com/FusionAuth/fusionauth-issues/issues/1175