### PR TITLE
Clarifying some verbiage.

### DIFF
--- a/site/license-faq.html
+++ b/site/license-faq.html
@@ -176,7 +176,7 @@ heroHeader: true
       <div class="col-xs-12 col-lg-6">
         <div class="brochure flat-card">
           <div class="content">
-            <h3 id="9">My organization requires vendors to use our license agreements, is that possible?</h3>
+            <h3 id="9">My organization requires vendors, such as FusionAuth, to use our license agreements, is that possible?</h3>
             <p>
               Custom contracts and legal reviews require various contract minimums. These include the fees and contract length. In most cases, we require a minimum of a 24-month agreement and fees of $15,000/month. We are happy to discuss your specific needs and figure out what will work in your budget. Feel free to contact our team at <a href="mailto:sales@fusionauth.io">sales@fusionauth.io</a>.
             </p>
@@ -200,7 +200,7 @@ heroHeader: true
       <div class="col-xs-12 col-lg-6">
         <div class="brochure flat-card">
           <div class="content">
-            <h3 id="10">My organization requires vendors to undergo security audits and vendor on-boarding, is that possible?</h3>
+            <h3 id="10">My organization requires vendors, such as FusionAuth, to undergo security audits and vendor on-boarding, is that possible?</h3>
             <p>
               We know that companies often require in-depth on-boarding processes, including security audits. We are happy to work with you to complete these tasks, but we require contract minimums in order to do so. In most cases, we require a minimum of a 24-month agreement and fees of $15,000/month. We are happy to discuss your specific needs and figure out what will work in your budget. Feel free to contact our team at <a href="mailto:sales@fusionauth.io">sales@fusionauth.io</a>.
             </p>


### PR DESCRIPTION
Make it clear in part of the FAQ that vendors apply to FusionAuth, not the purchaser of a license.