### PR TITLE
Add recovery codes API's to two-factor documentation

### DIFF
--- a/site/docs/v1/tech/apis/two-factor.adoc
+++ b/site/docs/v1/tech/apis/two-factor.adoc
@@ -26,6 +26,8 @@ include::docs/v1/tech/shared/_premium-edition-blurb.adoc[]
 * <<Send a Multi-Factor Code During Login or Step Up>>
 * <<Send a Multi-Factor Code When Enabling MFA>>
 * <<Send a Multi-Factor Code When Disabling MFA>>
+* <<Generate Recovery Codes>>
+* <<Retrieve Recovery Codes>>
 
 [NOTE.info]
 ====
@@ -451,4 +453,82 @@ include::docs/v1/tech/apis/_standard-post-response-codes.adoc[]
 :success_code!:
 :success_message!:
 
+== Generate Recovery Codes
 
+This API is used to generate a list of Recovery Codes. When creating new codes, any existing Recovery Codes will be cleared and the new set will become the current values.
+
+=== Request
+
+[.api-authentication]
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Create Recovery Codes
+[.endpoint]
+.URI
+--
+[method]#POST# [uri]#/api/recovery-codes/`\{userId\}`#
+--
+
+==== Request Parameters
+
+[.api]
+[field]#userId# [type]#[UUID]# [required]#Required#::
+The unique Id of the user to assign the generated Recovery Codes to.
+
+=== Response
+
+The response for this API contains an array of size 10 of Recovery Codes that were created.
+
+:never_search_error:
+include::docs/v1/tech/apis/_standard-post-response-codes.adoc[]
+:never_search_error!:
+
+==== Response Body
+
+[.api]
+[field]#recoveryCodes# [type]#[Array<String>]#::
+The array of Recovery Codes.
+
+[source,json]
+.Example Response JSON
+----
+include::docs/src/json/two-factor/response-with-recovery-codes.json[]
+----
+
+== Retrieve Recovery Codes
+
+This API is used to retrieve Recovery Codes for a User.
+
+=== Request
+
+[.api-authentication]
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Retrieve Recovery Codes
+[.endpoint]
+.URI
+--
+[method]#GET# [uri]#/api/recovery-codes/`\{userId\}`#
+--
+
+==== Request Parameters
+
+[.api]
+[field]#userId# [type]#[UUID]# [required]#Required#::
+The Id of the User to retrieve Recovery Codes for.
+
+=== Response
+
+The response for this API contains the remaining Recovery Codes that are assigned to the User. Each time one is used it is removed, so this response will contain between 0 and 10 codes.
+
+:never_search_error:
+include::docs/v1/tech/apis/_standard-post-response-codes.adoc[]
+:never_search_error!:
+
+==== Response Body
+
+[.api]
+[field]#recoveryCodes# [type]#[Array<String>]#::
+The array of Recovery Codes.
+
+[source,json]
+.Example Response JSON
+----
+include::docs/src/json/two-factor/response-with-recovery-codes.json[]
+----


### PR DESCRIPTION
This PR essentially copies over the work done in [#597](https://github.com/FusionAuth/fusionauth-site/pull/597) relocating it under the two-factor documentation.