### PR TITLE
Fix search console errors may 2021

### DIFF
--- a/site/_posts/2021-05-04-supercharge-development-with-fusionauth.md
+++ b/site/_posts/2021-05-04-supercharge-development-with-fusionauth.md
@@ -7,6 +7,8 @@ image: blogs/supercharge-development/supercharge-development.png
 category: blog
 excerpt_separator: "<!--more-->"
 redirect_to: https://www.hostingadvice.com/blog/streamline-app-development-with-fusionauth/
+sitemap:
+  exclude: 'yes'
 ---
 
 Businesses have begun to acknowledge that the physical health of developers is an asset. As a result, many workstations now come equipped with furniture and devices designed to encourage natural posture, reduce exertion, and function within optimal reach zones. Such tools boost productivity by helping eliminate employee absences caused by repetitive strain injuries. 

--- a/site/docs/v1/tech/tutorials/two-factor/authenticator-app-pre-1-26.adoc
+++ b/site/docs/v1/tech/tutorials/two-factor/authenticator-app-pre-1-26.adoc
@@ -2,6 +2,8 @@
 layout: doc
 title: Two Factor with Google Authenticator
 description: Learn how to complete Two Factor authentication for a User using Google Authenticator
+redirect_from:
+ - /docs/v1/tech/tutorials/two-factor/authenticator-app/
 ---
 
 == Overview

--- a/site/docs/v1/tech/tutorials/two-factor/twilio-push-pre-1-26.adoc
+++ b/site/docs/v1/tech/tutorials/two-factor/twilio-push-pre-1-26.adoc
@@ -2,6 +2,8 @@
 layout: doc
 title: Two Factor with Twilio Push Notifications
 description: Learn how to complete Two Factor authentication for a User using FusionAuth's Twilio push integration
+redirect_from:
+ - /docs/v1/tech/tutorials/two-factor/twilio-push/
 ---
 
 == Overview


### PR DESCRIPTION
A couple of google console search errors.

1. we didn't do redirects properly when we renamed the pre 1.26 push notification stuff.
2. the redirect blog post on 5/4 should be excluded from the sitemap.