### PR TITLE
Update passwordless guide

### DIFF
--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -16,6 +16,15 @@ Here's a video showing the default passwordless process in FusionAuth:
 
 video::hMqxo68ZJlw[youtube,width=560,height=315]
 
+* <<What Is Passwordless>>
+* <<When Does It Make Sense>>
+* <<Setting Up For Passwordless>>
+* <<Using the FusionAuth OAuth Interface>>
+* <<Using the API directly>>
+* <<Two Factor Authentication>>
+* <<Customizing Passwordless>>
+* <<Security>>
+
 == When Does It Make Sense
 
 Passwordless authentication eases a user's sign-in experience. Rather than having to remember which password they used, a user gives their email address and is sent a link. When they click through, they are authenticated.

--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -24,6 +24,7 @@ video::hMqxo68ZJlw[youtube,width=560,height=315]
 * <<Two Factor Authentication>>
 * <<Customizing Passwordless>>
 * <<Security>>
+* <<Troubleshooting>>
 
 == When Does It Make Sense
 
@@ -221,7 +222,7 @@ Configure the tenant email template settings to use your passwordless login temp
 
 image::guides/passwordless/update-tenant-with-new-template.png[Updating the tenant to use the new passwordless email template.,width=1200]
 
-When customizing, you can use any Apache FreeMarker built-ins within the template. Make sure you modify both the HTML and text templates. Here are the default templates:
+When customizing, you can use any Apache FreeMarker built-ins within the template and in the subject. Make sure you modify both the HTML and text templates. Here are the default templates:
 
 .The default passwordless HTML template
 [source,text]
@@ -240,6 +241,18 @@ You can localize the template as well:
 image::guides/passwordless/localization-screen-for-email-template.png[The localization screen for your email templates.,width=1200]
 
 Here is more information about link:/docs/v1/tech/email-templates/[email templates].
+
+==== Customizing the Subject 
+
+Here's an example of how to customize the subject with FreeMarker. The subject below shows how to customize the subject with the time the link expires.
+
+.Customizing the subject
+[source,text]
+----
+[#setting time_zone = (user.timezone)!"US/Denver"]
+[#setting time_format = "h:mm a"]
+Expires at: ${((.now?date?long + timeToLive * 1000)?number_to_time)?string}
+----
 
 === One Time Code Customization
 
@@ -277,3 +290,19 @@ If you use the passwordless API, follow the principle of least privilege, and li
 When FusionAuth is your user datastore, adding a user means you must either provide a password or send them a link to set up their initial password.
 
 If you are only allowing passwordless authentication for your application, don't allow the user to specify a password and instead generate a random series of characters for the password. We recommend generating at least 32 characters in the ascii character set that are completely random to ensure the user's account is secure.
+
+== Troubleshooting
+
+=== Email
+If you are experiencing troubles with email deliverability, review link:/docs/v1/tech/troubleshooting/#troubleshooting-email[the email troubleshooting documentation].
+
+=== Invalid Links
+
+In some cases, email clients will visit links in an email before the user does. In particular, this is known to happen with Outlook "safe links". If the client does this when the email contains a passwordless one time code, that code may be invalid when the user clicks on it, as it has already been "used" by the client.
+
+One option is to consult with your email client adminstrator. It may be possible to add the application's URL to an allow list.
+
+In version 1.27, FusionAuth changed the link processing behavior to remedy this for some situations. Given the wide variety of email client behavior, it may still be present in other scenarios.
+
+If your users' passwordless codes are being expired by an email client, please add details to https://github.com/FusionAuth/fusionauth-issues/issues/629[this GitHub issue].
+

--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -4,7 +4,7 @@ title: Passwordless Authentication
 description: Learn how to create a passwordless experience for your end users.
 ---
 
-== What is passwordless
+== What Is Passwordless
 
 Passwordless authentication allows a user to prove their identity without a password.
 
@@ -16,13 +16,13 @@ Here's a video showing the default passwordless process in FusionAuth:
 
 video::hMqxo68ZJlw[youtube,width=560,height=315]
 
-== When does it make sense
+== When Does It Make Sense
 
 Passwordless authentication eases a user's sign-in experience. Rather than having to remember which password they used, a user gives their email address and is sent a link. When they click through, they are authenticated.
 
 In addition to being easier for users, a passwordless login experience prevents them from reusing the same password across different sites or applications. No longer will you worry about another website's data breach causing illicit access to your system. In addition, password brute forcing is no longer a threat since the codes are one-time use.
 
-== Setting up for passwordless
+== Setting Up For Passwordless
 
 If you are planning to use passwordless, you have two options. The first option you can use is the FusionAuth OAuth interface. FusionAuth's OAuth interface is customizable via themes to make each of the web pages look like your application. The other option is using the passwordless API. Let's look at each in turn.
 
@@ -37,9 +37,9 @@ image::guides/passwordless/turn-on-passwordless.png[Turn on passwordless login,w
 
 Since, by default, passwordless authentication requires email delivery, ensure FusionAuth is correctly configured to send email. One way to test email delivery is by creating a user and sending them a password setup email.
 
-== Using the FusionAuth OAuth interface
+== Using the FusionAuth OAuth Interface
 
-Choose the FusionAuth OAuth interface approach if you want to use the link:/docs/v1/tech/oauth/#example-authorization-code-grant[Authorization Code grant]. Enabling passwordless adds an option for a user to receive a one-time code. Because this is the Authorization Code grant, any library or framework that supports this OAuth grant will work.
+Choose the FusionAuth OAuth interface, or hosted login pages, approach if you want to use the link:/docs/v1/tech/oauth/#example-authorization-code-grant[Authorization Code grant]. Enabling passwordless adds an option for a user to receive a one-time code. Because this is the Authorization Code grant, any library or framework that supports this OAuth grant will work.
 
 To use this option:
 
@@ -131,17 +131,17 @@ include::docs/src/json/passwordless/start-response.json[]
 
 Possession of this one-time code authenticates the end user. Deliver this code to the end user using whatever method you'd like. If you want to use FusionAuth to deliver the code via email, see <<Sending the code using FusionAuth>>. 
 
-==== Sending the code using FusionAuth
+==== Sending the Code Using FusionAuth
 
 This is an optional passwordless API call. If you want to send the passwordless code via the email server configured in FusionAuth, you may use the link:/docs/v1/tech/apis/passwordless#send-passwordless-login[`/api/passwordless/send`] API endpoint. 
 
 Using this API call allows you the benefits of the FusionAuth locale-aware email templates and email delivery capabilities without requiring you to use the FusionAuth login forms.
 
-==== The user enters the code
+==== The User Enters the Code
 
 Once the user possesses the code, they must provide it to your application. You must build an interface for them to do so. 
 
-==== Completing the login
+==== Completing the Login
 
 When the user provides the code to you, call the link:/docs/v1/tech/apis/passwordless#complete-a-passwordless-login[`/api/passwordless/login`] endpoint. You can pass other information such as IP address, but the code is required.
 
@@ -161,27 +161,27 @@ include::docs/src/json/users/passwordless-login-response.json[]
 
 The user is now authenticated. Your application has user data, pre-existing state if provided, and a JWT which can be used to represent the user to other resources. If you want to send the JWT to a client as a cookie, you can now do so.
 
-===== Additional passwordless login parameters
+===== Additional Passwordless Login Parameters
 
 JWTs are typically passed to other systems like an API server to enable access to protected resources (link:/learn/expert-advice/tokens/[more about JWTs]). If you are using passwordless authentication and are not using the JWT, you can turn off its generation. Creating and signing the JWT requires server resources; turning JWT generation off will improve performance. 
 
 To do so, set the `noJWT` parameter to true when you call the complete API endpoint. 
 
-==== Common failure paths
+==== Common Failure Paths
 
 Every time you start a passwordless login for a given user, all other codes for that user are marked invalid. Codes are also invalid after a configurable time limit. 
 
 If a user provides a code that is invalid, if their account is locked, or if there is any other issue in the request, a status code in the 400 range will be returned. Please consult the link:/docs/v1/tech/apis/passwordless#response-3[passwordless API reference docs] for more details about return status codes.
 
-== Two factor authentication
+== Two Factor Authentication
 
-You can use FusionAuth passwordless authentication in combination with two-factor authentication.
+You can use FusionAuth passwordless authentication in combination with two-factor authentication (also called multi-factor authentication or MFA).
 
 When two-factor authentication is enabled for a user, after the one-time code has been provided they are prompted to provide an additional two-factor verification code. 
 
-Learn more about setting up link:/docs/v1/tech/tutorials/two-factor/[two-factor authentication].
+Learn more about setting up link:/docs/v1/tech/guides/multi-factor-authentication/[two-factor authentication].
 
-=== Two factor authentication with the API
+=== Two Factor Authentication With the API
 
 Two factor authentication also works when <<Using the API directly,using the api>>. In that case, when you complete the passwordless authentication, instead of getting the user data, you'll get a `twoFactorId`:
 
@@ -194,7 +194,7 @@ Your application must then prompt the user for their two-factor code, from SMS o
 
 If a user has previously completed a two-factor authentication and has decided to trust the device, you may have a `twoFactorTrustId` value. This can be passed to the link:/docs/v1/tech/apis/passwordless#complete-a-passwordless-login[`/api/passwordless/login`] endpoint. If valid, this will skip the two-factor challenge.
 
-== Customizing passwordless
+== Customizing Passwordless
 
 You can configure the FusionAuth passwordless implementation to meet your application's needs in a number of ways.
 
@@ -232,7 +232,7 @@ image::guides/passwordless/localization-screen-for-email-template.png[The locali
 
 Here is more information about link:/docs/v1/tech/email-templates/[email templates].
 
-=== One time code customization
+=== One Time Code Customization
 
 You can modify the lifetime of the code delivered to users. By default it is 180 seconds; change this in the tenant settings:
 
@@ -263,7 +263,7 @@ If someone tries to log in with an email that is not present in the FusionAuth u
 
 If you use the passwordless API, follow the principle of least privilege, and limit the calls to which the API key has access. If you are using the API key only for passwordless login, then don't give this key any other permissions.
 
-=== What about user's passwords
+=== What About Users' Passwords
 
 When FusionAuth is your user datastore, adding a user means you must either provide a password or send them a link to set up their initial password.
 

--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -49,7 +49,12 @@ Since, by default, passwordless authentication requires email delivery, ensure F
 
 == Using the FusionAuth OAuth Interface
 
-Choose the FusionAuth OAuth interface, or hosted login pages, approach if you want to use the link:/docs/v1/tech/oauth/#example-authorization-code-grant[Authorization Code grant]. Enabling passwordless adds an option for a user to receive a one-time code. Because this is the Authorization Code grant, any library or framework that supports this OAuth grant will work.
+[NOTE]
+====
+The FusionAuth OAuth Interface is also known as "hosted login pages" because FusionAuth hosts all the login pages.
+====
+
+Choose the FusionAuth OAuth interface approach if you want to use the link:/docs/v1/tech/oauth/#example-authorization-code-grant[Authorization Code grant]. Enabling passwordless adds an option for a user to receive a one-time code. Because this is the Authorization Code grant, any library or framework that supports this OAuth grant will work.
 
 To use this option:
 


### PR DESCRIPTION
Brought this up to current standards (in terms of verbiage, headline casing, toc).

Also added a small section on customizing the email subject.

And added a troubleshooting section and included notes about the safe links issue.