### PR TITLE
Remove Ghost Link

### DIFF
--- a/site/enterprise-sales-faq.html
+++ b/site/enterprise-sales-faq.html
@@ -142,11 +142,6 @@ heroHeader: true
         </p>
       </div>
     </div>
-    <div class="row">
-      <div class="col-xs text">
-        <a href="https://ghost.org/enterprise/">Inspired by Ghost</a>
-      </div>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
# Summary 
Remove Ghost Link from the enterprise sales faq page.  Sadly, Ghost is no longer lovingly quip on their enterprise/pricing page.

Ghosted by Ghost! 🙂 