### PR TITLE
Updated to reflect location of FusionAuth community.

### DIFF
--- a/site/jobs/sales-engineer.md
+++ b/site/jobs/sales-engineer.md
@@ -26,7 +26,7 @@ Your responsibilities will include:
 * Engage with prospective customers through demonstrations, design sessions, architecture reviews, workshops, and on-boarding sessions
 * Assistance prospective customers with FusionAuth configuration, implementation, and deployment
 * Engage with technical and non-technical employees of prospective customers and various levels and build a strong value proposition for FusionAuth
-* Engage with the FusionAuth Slack community and StackOverflow community
+* Engage with the FusionAuth community in Slack, StackOverflow and elsewhere
 * Attend various meetups, conferences, and other events that developers attend to promote and sell FusionAuth   
 * Work directly with the FusionAuth marketing and engineering teams to build sales campaigns that target developers
 

--- a/site/jobs/sales-executive.md
+++ b/site/jobs/sales-executive.md
@@ -32,7 +32,7 @@ Your responsibilities will include:
 * Demonstrate a clear understanding of the FusionAuth sales process
 * "Live" in HubSpot and implement prospecting strategies while providing accurate forecasts to the team
 * Engage with technical and non-technical employees of prospective customers at various levels and build a strong value proposition for FusionAuth
-* Engage with the FusionAuth Slack community and StackOverflow community
+* Engage with the FusionAuth community in Slack, StackOverflow and elsewhere
 * Work directly with the FusionAuth marketing and engineering teams to build sales campaigns that target developers
 
 ### Requirements


### PR DESCRIPTION
Previously it was referencing slack and stackoverflow, but we also have community in the forums and on github.

Changed to make it more general.