### PR TITLE
Add End User UI to Nav

### DIFF
--- a/site/_layouts/doc.liquid
+++ b/site/_layouts/doc.liquid
@@ -286,15 +286,20 @@
                   </ul>
                 </li>
                 <li {% if page.url contains "/account-management/" %} class="open"{% endif %}>
-                  <a href="#" class="sub-menu"><i class="fal fa-fw fa-bullseye"></i> Self Service Account Mgmt<i class="fal fa-chevron-{% if page.url contains "/account-management/" %}up{% else %}down{% endif %} fa-fw"></i></a>
+                  <a href="#" class="sub-menu"><i class="fal fa-fw fa-users"></i> End User UI<i class="fal fa-chevron-{% if page.url contains "/account-management/" %}up{% else %}down{% endif %} fa-fw"></i></a>
                   <ul>
-                    <li {% if page.url == "/docs/v1/tech/account-management/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/" >Overview</a></li>
+                    <li {% if page.url contains "/account-management/" %} class="open"{% endif %}>
+                      <a href="#" class="sub-menu">Multi-Factor Auth (MFA)<i class="fal fa-chevron-{% if page.url contains "/account-management/" %}up{% else %}down{% endif %} fa-fw"></i></a>
+                      <ul>
+                        <li {% if page.url == "/docs/v1/tech/account-management/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/" >Overview</a></li>
+                        <li {% if page.url == "/docs/v1/tech/account-management/authenticator-two-factor/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/authenticator-two-factor/">Add Authenticator Factor</a></li>
+                        <li {% if page.url == "/docs/v1/tech/account-management/email-two-factor/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/email-two-factor/">Add Email Factor</a></li>
+                        <li {% if page.url == "/docs/v1/tech/account-management/sms-two-factor/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/sms-two-factor/">Add SMS Factor </a></li>
+                        <li {% if page.url == "/docs/v1/tech/account-management/customizing-account-management/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/customizing-account-management/">Customizing</a></li>
+                        <li {% if page.url == "/docs/v1/tech/account-management/troubleshooting/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/troubleshooting/">Troubleshooting</a></li>
+                      </ul>
+                    </li>
                     <li {% if page.url == "/docs/v1/tech/account-management/updating-user-data/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/updating-user-data/">Updating User Data & Password</a></li>
-                    <li {% if page.url == "/docs/v1/tech/account-management/totp-two-factor/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/totp-two-factor/">Add TOTP Factor</a></li>
-                    <li {% if page.url == "/docs/v1/tech/account-management/email-two-factor/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/email-two-factor/">Add Email Factor</a></li>
-                    <li {% if page.url == "/docs/v1/tech/account-management/sms-two-factor/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/sms-two-factor/">Add SMS Factor </a></li>
-                    <li {% if page.url == "/docs/v1/tech/account-management/customizing-account-management/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/customizing-account-management/">Customizing</a></li>
-                    <li {% if page.url == "/docs/v1/tech/account-management/troubleshooting/" %}class="active"{% endif %}><a href="/docs/v1/tech/account-management/troubleshooting/">Troubleshooting</a></li>
                   </ul>
                 </li>
                 <li {% if page.url contains "/integrations/" %} class="open"{% endif %}>


### PR DESCRIPTION
# Summary 
- This adds an End User UI section to the Documentation 
- I am not sure that I am nesting `<li>` and other like tags correctly, but if we like this, then I can add/adjust the "open" and "active" classes to make sure the chevrons work correctly.
- My goal was not to make any changes to the URI to showcase this edit. 
     - IE - I think that if we like this, it might make sense to do `/docs/tech/..../user-admin-ui/account-management`
     - OR tags of some kind to add to this section over time (not sure how that works in adoc)

# Related
- https://github.com/FusionAuth/fusionauth-site/pull/661

![image](https://user-images.githubusercontent.com/16090626/119742167-66ff6800-be44-11eb-99bf-3c38124a7683.png)

