### PR TITLE
Tenant Id is not needed any more.

### DIFF
--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -43,7 +43,7 @@ To begin the Authorization Code Grant you will redirect to the Authorization end
 [.endpoint]
 .URI
 --
-[method]#GET# [uri]#/oauth2/authorize``?client_id=\{client_id\}&redirect_uri=\{redirect_uri\}&response_type=code&tenantId=\{tenantId\}``#
+[method]#GET# [uri]#/oauth2/authorize``?client_id=\{client_id\}&redirect_uri=\{redirect_uri\}&response_type=code``#
 --
 
 ==== Request Parameters
@@ -113,9 +113,6 @@ Available scopes:
 
 [field]#state# [type]#[String]# [optional]#Optional#::
 The optional state parameter, this is generally used as a Cross Site Request Forgery (CSRF) token. Any value provided in this field will be returned on a successful redirect. See https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect core] specification for additional information on how this parameter may be utilized.
-
-[field]#tenantId# [type]#[UUID]# [required]#Required#  [since]#Available since 1.8.0#::
-The unique Tenant Id used for applying the proper theme.
 
 [field]#user_code# [type]#[String]# [optional]#Optional# [since]#Available since 1.11.0#::
 The end-user verification code.  This parameter is required on requests implementing the user-interaction of the Device Authorization Grant flow.

--- a/site/docs/v1/tech/oauth/index.adoc
+++ b/site/docs/v1/tech/oauth/index.adoc
@@ -172,7 +172,7 @@ Review the link:/docs/v1/tech/oauth/endpoints/#authorize[Authorization] endpoint
 
 [source]
 ----
-http://localhost:9011/oauth2/authorize?client_id=06494b74-a796-4723-af44-1bdb96b48875&redirect_uri=https://www.piedpiper.com/login&response_type=code&tenantId=78dda1c8-14d4-4c98-be75-0ccef244297d
+http://localhost:9011/oauth2/authorize?client_id=06494b74-a796-4723-af44-1bdb96b48875&redirect_uri=https://www.piedpiper.com/login&response_type=code
 ----
 
 === Consume the authorization code returned from the authorize request


### PR DESCRIPTION
I believe the tenant is determined from the `client_id`.

I looked at the code and couldn't see any place that this parameter was used or even allowed in the Oauth actions. I see it is allowed in BaseThemedAction, but not required by FrontEndResolver if a `client_id` is provided.