### PR TITLE
Update token notes

### DIFF
--- a/site/docs/v1/tech/apis/_user-registration-combined-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-registration-combined-response-body.adoc
@@ -41,7 +41,7 @@ A map that contains tokens returned from identity providers.
 +
 For example, if this user has authenticated using the Facebook Identity Provider, the Facebook access token will be available in this map, keyed by name `Facebook`. For an OpenID Connect Identity provider, or other generic providers, if a token is stored it will be keyed by the Identity Provider unique Id.
 +
-[deprecated]#Removed in 1.2.8.0#
+[deprecated]#Removed in 1.28.0#
 +
 The token returned and stored from the Identity Provider is now stored in the IdP link and is retrievable using the Identity Provider Link API.
 

--- a/site/docs/v1/tech/apis/_user-registration-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-registration-response-body.adoc
@@ -41,7 +41,7 @@ A map that contains tokens returned from identity providers.
 +
 For example, if this user has authenticated using the Facebook Identity Provider, the Facebook access token will be available in this map, keyed by name `Facebook`. For an OpenID Connect Identity provider, or other generic providers, if a token is stored it will be keyed by the Identity Provider unique Id.
 +
-[deprecated]#Removed in 1.2.8.0#
+[deprecated]#Removed in 1.28.0#
 +
 The token returned and stored from the Identity Provider is now stored in the IdP link and is retrievable using the Identity Provider Link API.
 

--- a/site/docs/v1/tech/release-notes.adoc
+++ b/site/docs/v1/tech/release-notes.adoc
@@ -52,6 +52,7 @@ include::docs/v1/tech/__database-migration-warning.adoc[]
 * IdP Linking options
 ** Each Identity Provider may now be configured with a linking strategy. The strategies will include linking by email, username, anonymous or a link to an existing user.
 ** Linking by username is now supported. There is a higher risk of account takeover using this strategy, you should use caution when using this feature.
+** Tokens from identity providers should now be retrieved from the link, rather than the registration.
 * Email Send API allows an email address in the To field instead of only allowing FusionAuth userIds
 ** See the Email Send API for additional details.
 * SAML Identity Provider can now be configured to use any NameID format. Previously only the Email NameID format was utilized.


### PR DESCRIPTION
* The version where this was deprecated was incorrect
* Added note to release notes about tokens living in links.