### PR TITLE
Added in client shadow keys

### DIFF
--- a/site/docs/v1/tech/reference/limitations.adoc
+++ b/site/docs/v1/tech/reference/limitations.adoc
@@ -70,10 +70,14 @@ There are a number of default entities which cannot be removed. Additionally, th
 
 This includes:
 
-* The Default tenant
+* The Default Tenant
 * The FusionAuth application, which resides in the Default tenant. This will always have the Id `3c219e58-ed0e-4b18-ad48-f4f92793ae32`.
 * The Default theme, which is read only. This will always have the Id `75a068fd-e94b-451a-9aeb-3ddb9a3b5987`.
 * The FusionAuth application roles, which may be assigned to users, but are immutable. View the link:/docs/v1/tech/core-concepts/roles/[roles documentation] for the fixed Ids of each role.
+* Three OpenID Connect shadow keys. These may not be modified or removed. When any of these keys are selected as the signing key for the Id Token the client secret defined by the FusionAuth Application will be used to sign the token.
+** SHA-256. This will always have the Id `092dbedc-30af-4149-9c61-b578f2c72f59`. 
+** SHA-384. This will always have the Id `4b8f1c06-518e-45bd-9ac5-d549686ae02a`.
+** SHA-512. This will always have the Id `c753a44d-7f2e-48d3-bc4e-c2c16488a23b`.
 
 == SAML
 


### PR DESCRIPTION
Added these keys to the default section in the limitations doc, since they could be used in kickstart or elsewhere.