### PR TITLE
Add `pendingIdPLinkId` field to identity provider (API) login response doc.

### DIFF
--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -4,7 +4,7 @@
 ifdef::login_response,passwordless_login_response[]
 ifdef::idp_response[]
 [field]#pendingIdPLinkId# [type]#[String]# [since]#Available since 1.28.0#::
-The pending identity provider link Id. This value is created when logging in with an identity provider configured with a linking strategy of `Create a pending link`. It will only be included on the response body when this strategy is set. It is used in conjunction with the link:/docs/v1/tech/apis/identity-providers/links.adoc[Link APIs] to complete a pending link.
+The pending identity provider link Id. This value is created when logging in with an identity provider configured with a linking strategy of `Create a pending link`. It will only be included in the response body when this strategy is configured and a link does not yet exist for the user. It is used in conjunction with the link:/docs/v1/tech/apis/identity-providers/links.adoc[Link APIs] to complete a pending link.
 endif::[]
 
 [field]#refreshToken# [type]#[String]#::

--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -2,8 +2,10 @@
 
 [.api]
 ifdef::login_response,passwordless_login_response[]
+ifdef::idp_response[]
 [field]#pendingIdPLinkId# [type]#[String]# [since]#Available since 1.28.0#::
-The pending identity provider link Id. This value is created when logging in with an identity provider configured with a linking strategy of `Create a pending link`. It is used in conjunction with the link:/docs/v1/tech/apis/identity-providers/links.adoc[Link APIs] to complete a pending link.
+The pending identity provider link Id. This value is created when logging in with an identity provider configured with a linking strategy of `Create a pending link`. It will only be included on the response body when this strategy is set. It is used in conjunction with the link:/docs/v1/tech/apis/identity-providers/links.adoc[Link APIs] to complete a pending link.
+endif::[]
 
 [field]#refreshToken# [type]#[String]#::
 The refresh token that can be used to obtain a new access token once the provide one has expired.

--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -2,6 +2,9 @@
 
 [.api]
 ifdef::login_response,passwordless_login_response[]
+[field]#pendingIdPLinkId# [type]#[String]# [since]#Available since 1.28.0#::
+The pending identity provider link Id. This value is created when logging in with an identity provider configured with a linking strategy of `Create a pending link`. It is used in conjunction with the link:/docs/v1/tech/apis/identity-providers/links.adoc[Link APIs] to complete a pending link.
+
 [field]#refreshToken# [type]#[String]#::
 The refresh token that can be used to obtain a new access token once the provide one has expired.
 +

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc
@@ -69,7 +69,9 @@ include::../../../../src/json/login/login-prevented-response.json[]
 |===
 
 :login_response:
+:idp_response:
 include::../_user-response-body.adoc[]
+:idp_response!:
 :login_response!:
 
 ==== Response Cookies


### PR DESCRIPTION
## Issue/Card
https://github.com/orgs/FusionAuth/projects/4#card-61597576

Note: 
Currently, all `apis/identity-provider/<idp name>` documentation includes shared file `_identity-provider-login-response-body.adoc` of which includes `_user-response-body.adoc` for the response body. 

I added the field to this section, but was thinking we might want to create a section that is specific to identity providers?  Thoughts?