### PR TITLE
convert all double quotes in titles/desc to single quotes.

### DIFF
--- a/site/_includes/_head.liquid
+++ b/site/_includes/_head.liquid
@@ -2,16 +2,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
 <title>{{ page.title | strip_html }} - FusionAuth</title>
-<meta name="twitter:description" content="{{ page.description | strip_html }}">
+<meta name="twitter:description" content="{{ page.description | strip_html | replace: '"', "'" }}">
 <meta name="twitter:creator" content="@FusionAuth">
 <meta name="twitter:site" content="@FusionAuth">
-<meta name="twitter:title" content="{{ page.title | strip_html }}">
+<meta name="twitter:title" content="{{ page.title | strip_html | replace: '"', "'" }}">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://fusionauth.io/assets/img/{{ page.image }}">
 <meta property="og:site_name" content="FusionAuth">
 <meta property="og:url" content="https://fusionauth.io{{ page.url | remove: '.html' }}">
 <meta property="og:description" content="{{ page.description | strip_html  }}">
-<meta property="og:title" content="{{ page.title | strip_html }}">
+<meta property="og:title" content="{{ page.title | strip_html | replace: '"', "'" }}">
 <meta property="og:type" content="website">
 <meta property="og:locale" content="en_US">
 <meta property="og:image" content="https://fusionauth.io/assets/img/{{ page.image }}">


### PR DESCRIPTION
this resolves the issue where we turn titles and desc into JSON page metadata . Json doesn't like embedded double quotes, and neither does google like broken structured data.