### PR TITLE
Added load testing section

### DIFF
--- a/site/docs/v1/tech/installation-guide/monitor.adoc
+++ b/site/docs/v1/tech/installation-guide/monitor.adoc
@@ -79,3 +79,16 @@ You can also enable JMX metrics as outlined in the link:/docs/v1/tech/troublesho
 ==== Prometheus Endpoint
 
 The default system metrics are also available in a Prometheus compatible form. link:/docs/v1/tech/tutorials/prometheus[This tutorial explains how to set up Prometheus to scrape the FusionAuth metrics].
+
+=== Load Testing
+
+You can load test FusionAuth to determine if its performance will meet your calculated needs. The FusionAuth team tests the performance of FusionAuth regularly, but every situation is different and running your own load tests on your instance provides useful information.
+
+There is an https://github.com/FusionAuth/fusionauth-load-tests/[open source project] which provides some useful scripts for load testing. Scenarios currently supported include:
+
+* Creating tenants
+* Creating applications
+* Registering users for applications
+* Logging users in using the Login API
+* Beginning the Authorization Code grant
+

--- a/site/docs/v1/tech/installation-guide/monitor.adoc
+++ b/site/docs/v1/tech/installation-guide/monitor.adoc
@@ -86,7 +86,7 @@ You can load test FusionAuth to determine if its performance will meet your calc
 
 You may use your own load testing tool. Any tool which can make HTTP requests, such as gatling or jmeter, will work.
 
-There is an https://github.com/FusionAuth/fusionauth-load-tests/[open source project] which provides some useful scripts for load testing. This is a work in progress, so use at your own risk. Scenarios currently supported include:
+There is an https://github.com/FusionAuth/fusionauth-load-tests/[open source project] which provides some useful scripts for load testing. This is a specialized library and primarily used for internal purposes, so use at your own risk. Scenarios currently supported include:
 
 * Creating tenants
 * Creating applications

--- a/site/docs/v1/tech/installation-guide/monitor.adoc
+++ b/site/docs/v1/tech/installation-guide/monitor.adoc
@@ -84,7 +84,9 @@ The default system metrics are also available in a Prometheus compatible form. l
 
 You can load test FusionAuth to determine if its performance will meet your calculated needs. The FusionAuth team tests the performance of FusionAuth regularly, but every situation is different and running your own load tests on your instance provides useful information.
 
-There is an https://github.com/FusionAuth/fusionauth-load-tests/[open source project] which provides some useful scripts for load testing. Scenarios currently supported include:
+You may use your own load testing tool. Any tool which can make HTTP requests, such as gatling or jmeter, will work.
+
+There is an https://github.com/FusionAuth/fusionauth-load-tests/[open source project] which provides some useful scripts for load testing. This is a work in progress, so use at your own risk. Scenarios currently supported include:
 
 * Creating tenants
 * Creating applications


### PR DESCRIPTION
Monitor might not be perfect.

Probably need to create an 'operations' section eventually, and put monitoring under it.

In fact, probably best to plan for a massive doc restructuring (esp now that we have easy redirect capabilities with jekyll):

* developer guide
* operator guide
* user guide
* APIs

But maybe not right now.