### PR TITLE
Fix idp update doc errors

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_oauth-idp-operations.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_oauth-idp-operations.adoc
@@ -69,7 +69,7 @@ include::_oauth-idp-response-body.adoc[]
 There is only one {idp_display_name} Identity Provider, so this Identity Provider may be updated by type or Id.
 
 :capitalized_object_name: {idp_display_name} Identity Provider
-include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
+include::../_generic-update-explanation-fragment.adoc[]
 :capitalized_object_name!:
 
 === Request

--- a/site/docs/v1/tech/apis/identity-providers/_oauth-idp-operations.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_oauth-idp-operations.adoc
@@ -66,11 +66,11 @@ include::_oauth-idp-response-body.adoc[]
 
 == Update the {idp_display_name} Identity Provider
 
-There is only one {idp_display_name} Identity Provider, so this Identity Provider may be updated by type or Id.
-
+:extra_id_verbiage: There is only one {idp_display_name} Identity Provider, so this Identity Provider may be updated by type or Id.
 :capitalized_object_name: {idp_display_name} Identity Provider
 include::../_generic-update-explanation-fragment.adoc[]
 :capitalized_object_name!:
+:extra_id_verbiage!:
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/apple.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/apple.adoc
@@ -80,11 +80,13 @@ include::docs/v1/tech/apis/identity-providers/_apple-response-body.adoc[]
 
 == Update the Apple Identity Provider
 
-There is only one Apple Identity Provider, so this Identity Provider may be updated by type or Id.
 
+
+:extra_id_verbiage: There is only one Apple Identity Provider, so this Identity Provider may be updated by type or Id.
 :capitalized_object_name: Apple Identity Provider
 include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
 :capitalized_object_name!:
+:extra_id_verbiage!:
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/apple.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/apple.adoc
@@ -80,8 +80,6 @@ include::docs/v1/tech/apis/identity-providers/_apple-response-body.adoc[]
 
 == Update the Apple Identity Provider
 
-
-
 :extra_id_verbiage: There is only one Apple Identity Provider, so this Identity Provider may be updated by type or Id.
 :capitalized_object_name: Apple Identity Provider
 include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]

--- a/site/docs/v1/tech/apis/identity-providers/facebook.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/facebook.adoc
@@ -82,11 +82,11 @@ include::docs/v1/tech/apis/identity-providers/_facebook-response-body.adoc[]
 
 == Update the Facebook Identity Provider
 
-There is only one Facebook Identity Provider, so this Identity Provider may be updated by type or Id.
-
+:extra_id_verbiage: There is only one Facebook Identity Provider, so this Identity Provider may be updated by type or Id.
 :capitalized_object_name: Facebook Identity Provider
 include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
 :capitalized_object_name!:
+:extra_id_verbiage!:
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/hypr.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/hypr.adoc
@@ -81,11 +81,11 @@ include::docs/v1/tech/apis/identity-providers/_hypr-response-body.adoc[]
 
 == Update the HYPR Identity Provider
 
-There is only one HYPR Identity Provider, so this Identity Provider may be updated by type or Id.
-
+:extra_id_verbiage: There is only one HYPR Identity Provider, so this Identity Provider may be updated by type or Id.
 :capitalized_object_name: HYPR Identity Provider
 include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
 :capitalized_object_name!:
+:extra_id_verbiage!:
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
@@ -83,8 +83,6 @@ include::docs/v1/tech/apis/identity-providers/_linkedin-response-body.adoc[]
 
 == Update the LinkedIn Identity Provider
 
-There is only one LinkedIn Identity Provider, so this Identity Provider may be updated by type or Id.
-
 :extra_id_verbiage: There is only one LinkedIn Identity Provider, so this Identity Provider may be updated by type or Id.
 :capitalized_object_name: LinkedIn Identity Provider
 include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]

--- a/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
@@ -85,9 +85,11 @@ include::docs/v1/tech/apis/identity-providers/_linkedin-response-body.adoc[]
 
 There is only one LinkedIn Identity Provider, so this Identity Provider may be updated by type or Id.
 
+:extra_id_verbiage: There is only one LinkedIn Identity Provider, so this Identity Provider may be updated by type or Id.
 :capitalized_object_name: LinkedIn Identity Provider
 include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
 :capitalized_object_name!:
+:extra_id_verbiage!:
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/twitter.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/twitter.adoc
@@ -84,11 +84,11 @@ include::docs/v1/tech/apis/identity-providers/_twitter-response-body.adoc[]
 
 == Update the Twitter Identity Provider
 
-There is only one Twitter Identity Provider, so this Identity Provider may be updated by type or Id.
-
+:extra_id_verbiage: There is only one Twitter Identity Provider, so this Identity Provider may be updated by type or Id.
 :capitalized_object_name: Twitter Identity Provider
 include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
 :capitalized_object_name!:
+:extra_id_verbiage!:
 
 === Request
 


### PR DESCRIPTION
Fixed some issues with the idp docs.

* Was incorrectly including the generic update chunk added in https://github.com/FusionAuth/fusionauth-site/pull/814
* Can use the `extra_id_verbiage` parameter to handle the singleton idps more elegantly and correctly.