### PR TITLE
Updates to Scope and Authentication Type on page https://fusionauth.io/docs/v1/tech/oauth/tokens/

### DIFF
--- a/site/docs/v1/tech/oauth/_authentication_type_claim_values.adoc
+++ b/site/docs/v1/tech/oauth/_authentication_type_claim_values.adoc
@@ -1,5 +1,6 @@
     * `APPLE` - The User was authenticated using Apple. [since]#Available since 1.17.0#
     * `APPLICATION_TOKEN` - The User was authenticated using an link:/docs/v1/tech/tutorials/application-authentication-tokens/[Application Authentication Token].
+    * `EpicGames` -The User was authenticated using Epic Games. &nbsp; [since]#Available since 1.28.0#
     * `FACEBOOK` - The User was authenticated using Facebook. &nbsp; [since]#Available since 1.1.0#
     * `FEDERATED_JWT` - The User was authenticated using a JWT from an external Identity Provider.
     * `GENERIC_CONNECTOR` - The user was authenticated using a generic connector.  &nbsp; [since]#Available since 1.18.0#
@@ -8,13 +9,19 @@
     * `JWT_SSO` - A valid JWT authorized to one Application was exchanged for another JWT authorized to a different Application.
     * `LDAP_CONNECTOR` -  The user was authenticated using an LDAP connector.  &nbsp; [since]#Available since 1.18.0#
     * `LINKEDIN` -  The user was authenticated using LinkedIn.  &nbsp; [since]#Available since 1.23.0#
+//    * `Nintendo` - The User was authenticated using Nintendo. &nbsp; [since]#Available since 1.28.0#
     * `ONE_TIME_PASSWORD` The User was authenticated using a one time password. &nbsp; [since]#Available since 1.5.0#
     * `OPENID_CONNECT` - The User was authenticated using an external OpenID Connect provider. [since]#Available since 1.1.0#
     * `PASSWORD` - The User was authenticated using a loginId and password combination.
     * `PASSWORDLESS` - The user was authenticated using a passwordless login link. &nbsp; [since]#Available since 1.5.0#
     * `PING` - The user was authenticated using the PING API w/ a valid JWT.
-    * `REGISTRATION` - The user was created using the Registration API.  &nbsp; [since]#Available since 1.16.0#
     * `REFRESH_TOKEN` - The User requested a new JWT using a Refresh Token.
+    * `REGISTRATION` - The user was created using the Registration API.  &nbsp; [since]#Available since 1.16.0#
     * `SAMLv2` - The User was authenticated using an external SAMLv2 provider. [since]#Available since 1.6.0#
+    * `SAMLv2IdpInitiated` - The User was authenticated using an external SAMLv2 provider using an IdP Initiated login. [since]#Available since 1.28.0#
+    * `SonyPSN` - The User was authenticated using Sony [since]#Available since 1.28.0#
+    * `Steam` - The User was authenticated using Steam [since]#Available since 1.28.0#
     * `TWITTER` - The User was authenticated using Twitter. [since]#Available since 1.1.0#
+    * `Twitch` - The User was authenticated using Twitch [since]#Available since 1.28.0#
     * `USER_CREATE` - The user was created using the User API. &nbsp; [since]#Available since 1.16.0#
+    * `Xbox` - The User was authenticated using Xbox [since]#Available since 1.28.0#

--- a/site/docs/v1/tech/oauth/tokens.adoc
+++ b/site/docs/v1/tech/oauth/tokens.adoc
@@ -104,8 +104,10 @@ https://tools.ietf.org/html/rfc7519#section-4.1.1[RFC 7519 Section 4.1.1].
 The permission granted to the recipient Entity by the target Entity. This claim is only present if permissions are associated with the grant and any requested permissions are found in the grant.
 
 [field]#scope# [type]#[String]#::
-The scope of the Access token. See scope defined by
+The scope of the Access token. This meaning of this field is specified by
 https://datatracker.ietf.org/doc/html/rfc6749#section-3.3[RFC 6749 Section 3.3] and referenced in Client Credentials Grant https://datatracker.ietf.org/doc/html/rfc6749#section-4.4[RFC 6749 Section 4.4]
++
+Valid scopes are described in the link:https://fusionauth.io/docs/v1/tech/oauth/#client-credentials-scopes[client credentials scopes section].
 
 [field]#sub# [type]#[UUID]#::
 The subject of the access token. This value is equal to the recipient Entity's unique Id in FusionAuth. This registered claim is defined by https://tools.ietf.org/html/rfc7519#section-4.1.2[RFC 7519 Section 4.1.2].

--- a/site/docs/v1/tech/oauth/tokens.adoc
+++ b/site/docs/v1/tech/oauth/tokens.adoc
@@ -103,6 +103,10 @@ https://tools.ietf.org/html/rfc7519#section-4.1.1[RFC 7519 Section 4.1.1].
 [field]#permissions# [type]#[Array<String>]#::
 The permission granted to the recipient Entity by the target Entity. This claim is only present if permissions are associated with the grant and any requested permissions are found in the grant.
 
+[field]#scope# [type]#[String]#::
+The scope of the Access token. See scope defined by
+https://datatracker.ietf.org/doc/html/rfc6749#section-3.3[RFC 6749 Section 3.3] and referenced in Client Credentials Grant https://datatracker.ietf.org/doc/html/rfc6749#section-4.4[RFC 6749 Section 4.4]
+
 [field]#sub# [type]#[UUID]#::
 The subject of the access token. This value is equal to the recipient Entity's unique Id in FusionAuth. This registered claim is defined by https://tools.ietf.org/html/rfc7519#section-4.1.2[RFC 7519 Section 4.1.2].
 


### PR DESCRIPTION
# Summary 

Updates to OAuth Token page - add scope in client credentials grant  and AuthenticationType (for newer Idps) 

# Related Issues 

closes https://github.com/FusionAuth/fusionauth-site/issues/784
closes https://github.com/FusionAuth/fusionauth-site/issues/783
