### PR TITLE
Added SLA info.

### DIFF
--- a/site/license-faq.html
+++ b/site/license-faq.html
@@ -63,6 +63,7 @@ redirect_from:
         <li><a href="#25">Can you add a VAT number to our invoices?</li>
         <li><a href="#26">Can you change the company name on our invoice?</li>
         <li><a href="#27">Can you change the email address to which our invoice is sent?</li>
+        <li><a href="#28">What kind of SLAs are available?</li>
       </ul>
     </div>
     <div class="row">
@@ -472,6 +473,33 @@ redirect_from:
             <h3 id="27">Can you change the email address to which our invoice is sent?</h3>
             <p>
               Yes. Please <a href="https://account.fusionauth.io/account/support/">open a support ticket</a> with your preferred email address or email addresses and we'll update where the invoice is delivered.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-12 col-lg-6">
+        <div class="brochure flat-card">
+          <div class="content">
+            <h3 id="28">What kind of SLAs are available?</h3>
+            <p>
+	      Service level agreements (SLAs) state the availability of your FusionAuth instance. For full details, please <a href='/license/'>review the license</a>, including Exhibit C, which specifies how credits are applied. In particular, unexpected downtime is counts against the SLA, but scheduled maintenance does not.
+            </p>
+            <p>
+              The applicable SLA depends on how you run FusionAuth.
+            </p>
+            <ul>
+              <li>
+                If you self-host FusionAuth, no FusionAuth provided SLA is available. Please consult with your operations team to determine the appropriate service level agreement.
+              </li>
+              <li>
+	        For FusionAuth HA Cloud with an Enterprise support contract, the SLA is 99.9%. FusionAuth also offers a 99.99% SLA for an additional fee; contact sales@fusionauth.io for more details.
+              </li>
+              <li>
+	        For any other FusionAuth Cloud instance, the SLA is 99.5%.
+              </li>
+            </ul>
+            <p>
+              If you have further questions about SLAs, contact our sales team. They can be reached at <a href="mailto:sales@fusionauth.io">sales@fusionauth.io</a>.
             </p>
           </div>
         </div>

--- a/site/license-faq.html
+++ b/site/license-faq.html
@@ -482,7 +482,7 @@ redirect_from:
           <div class="content">
             <h3 id="28">What kind of SLAs are available?</h3>
             <p>
-	      Service level agreements (SLAs) state the availability of your FusionAuth instance. For full details, please <a href='/license/'>review the license</a>, including Exhibit C, which specifies how credits are applied. In particular, unexpected downtime is counts against the SLA, but scheduled maintenance does not.
+	      Service level agreements (SLAs) document the availability of your FusionAuth instance. For full details, please <a href='/license/'>review the license</a>, including Exhibit C, which specifies how credits are applied. In particular, unexpected downtime is counts against the SLA, but scheduled maintenance does not.
             </p>
             <p>
               The applicable SLA depends on how you run FusionAuth.

--- a/site/license-faq.html
+++ b/site/license-faq.html
@@ -489,13 +489,16 @@ redirect_from:
             </p>
             <ul>
               <li>
+	        For FusionAuth HA Cloud with full database replication enabled and an Enterprise support contract, the SLA is 99.9%. FusionAuth also offers a 99.99% SLA for an additional fee; contact sales@fusionauth.io for more details.
+              </li>
+              <li>
+	        For FusionAuth HA Cloud with full database replication enabled, the SLA is 99.5%.
+              </li>
+              <li>
+	        For any other FusionAuth Cloud instance, there is no SLA available.
+              </li>
+              <li>
                 If you self-host FusionAuth, no FusionAuth provided SLA is available. Please consult with your operations team to determine the appropriate service level agreement.
-              </li>
-              <li>
-	        For FusionAuth HA Cloud with an Enterprise support contract, the SLA is 99.9%. FusionAuth also offers a 99.99% SLA for an additional fee; contact sales@fusionauth.io for more details.
-              </li>
-              <li>
-	        For any other FusionAuth Cloud instance, the SLA is 99.5%.
               </li>
             </ul>
             <p>


### PR DESCRIPTION
I wasn't clear if 99.5% applied to all FusionAuth cloud instances or only those with premium support contracts and HA cloud. The slack discussion was a bit unclear.