### PR TITLE
Added application Id to the email verification docs.

### DIFF
--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -834,7 +834,7 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 
 [.api]
 [field]#applicationId# [type]#[String]# [optional]#Optional# [since]#Available since 1.21.0#::
-The Id of the application. If valid, the email template configured in the application settings will be used and the corresponding Application object will be available to the template.
+The Id of the application. If valid, the email template configured in the Application settings will be used, if present. If not present, the email template configured in the Tenant settings will be used. In either case, the corresponding Application object will be available to the template.
 
 [field]#email# [type]#[String]# [required]#Required#::
 The email address used to uniquely identify the User.
@@ -853,7 +853,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 
 [.api]
 [field]#applicationId# [type]#[String]# [optional]#Optional# [since]#Available since 1.21.0#::
-The Id of the application. If valid, the email template configured in the application settings will be used and the corresponding Application object will be available to the template.
+The Id of the application. If valid, the email template configured in the Application settings will be used, if present. If not present, the email template configured in the Tenant settings will be used. In either case, the corresponding Application object will be available to the template.
 
 [field]#email# [type]#[String]# [required]#Required#::
 The email address used to uniquely identify the User.

--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -818,8 +818,7 @@ include::docs/v1/tech/apis/_standard-put-response-codes.adoc[]
 
 == Resend Verification Email
 
-This API is used to resend the verification email to a User. This API is useful if the User has deleted the email, or the verification Id has
- expired. By default, the verification Id will expire after 24 hours.
+This API is used to resend the verification email to a User. This API is useful if the User has deleted the email, or the verification Id has expired. By default, the verification Id will expire after 24 hours. You can modify this duration in the Tenant settings.
 
 === Request
 
@@ -828,12 +827,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 [.endpoint]
 .URI
 --
-[method]#PUT# [uri]#/api/user/verify-email``?email=\{email\}``#
+[method]#PUT# [uri]#/api/user/verify-email``?applicationId=\{applicationId\}&email=\{email\}``#
 --
 
 ==== Request Parameters
 
 [.api]
+[field]#applicationId# [type]#[String]# [optional]#Optional# [since]#Available since 1.21.0#::
+The Id of the application. If valid, the email template configured in the application settings will be used and the corresponding Application object will be available to the template.
+
 [field]#email# [type]#[String]# [required]#Required#::
 The email address used to uniquely identify the User.
 
@@ -844,19 +846,22 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 [.endpoint]
 .URI
 --
-[method]#PUT# [uri]#/api/user/verify-email``?email=\{email\}&sendVerifyEmail=\{sendVerifyEmail\}``#
+[method]#PUT# [uri]#/api/user/verify-email``?applicationId=\{applicationId\}&email=\{email\}&sendVerifyEmail=\{sendVerifyEmail\}``#
 --
 
 ==== Request Parameters
 
 [.api]
+[field]#applicationId# [type]#[String]# [optional]#Optional# [since]#Available since 1.21.0#::
+The Id of the application. If valid, the email template configured in the application settings will be used and the corresponding Application object will be available to the template.
+
 [field]#email# [type]#[String]# [required]#Required#::
 The email address used to uniquely identify the User.
 
 [field]#sendVerifyEmail# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `true`#::
-If you would only like to generate a new `verificationId` and return it in the JSON body without FusionAuth attempting to send the User an email
+If you would only like to generate a new [field]#verificationId# and return it in the JSON body without FusionAuth attempting to send the User an email
 set this optional parameter to `false`.
-
++
 This may be useful if you need to integrate the Email Verification process using a third party messaging service.
 
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-ambiguous-operation.adoc[]


### PR DESCRIPTION
Wasn't available previously.

Tested and it doesn't work with a request body, only on the URL.