### PR TITLE
Add Alternative Authentication Method.

### DIFF
--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -491,7 +491,8 @@ Prior to version `1.3.1` this parameter was always required.
 
 [field]#client_secret# [type]#[String]# [optional]#Optional# [since]#Available since 1.5.0#::
 The client secret.
-This value may optionally be provided in the request body instead of the `Authorization` header documented above.
+This parameter is optional when the `Authorization` header is provided.
+When the `Authorization` header is not provided, this parameter is required.
 
 [field]#code# [type]#[String]# [required]#Required#::
 The authorization code returned on the `/oauth2/authorize` response.
@@ -556,7 +557,8 @@ Prior to version `1.3.1` this parameter was always required.
 
 [field]#client_secret# [type]#[String]# [optional]#Optional# [since]#Available since 1.5.0#::
 The client secret.
-This value may optionally be provided in the request body instead of the `Authorization` header documented above.
+This parameter is optional when the `Authorization` header is provided.
+When the `Authorization` header is not provided, this parameter is required.
 
 [field]#grant_type# [type]#[String]# [required]#Required#::
 The grant type to be used.
@@ -665,7 +667,8 @@ When the `Authorization` header is not provided, this parameter is then required
 
 [field]#client_secret# [type]#[String]# [optional]#Optional#::
 The client secret.
-This value may optionally be provided in the request body instead of the `Authorization` header documented above.
+This parameter is optional when the `Authorization` header is provided.
+When the `Authorization` header is not provided, this parameter is required.
 
 [field]#device_code# [type]#[String]# [required]#Required#::
 
@@ -796,7 +799,8 @@ Prior to version `1.3.1` this parameter was always required.
 
 [field]#client_secret# [type]#[String]# [optional]#Optional# [since]#Available since 1.5.0#::
 The client secret.
-This value may optionally be provided in the request body instead of the `Authorization` header documented above.
+This parameter is optional when the `Authorization` header is provided.
+When the `Authorization` header is not provided, this parameter is required.
 
 [field]#grant_type# [type]#[String]# [required]#Required#::
 The grant type to be used.
@@ -906,7 +910,11 @@ If you will be using the Client Credentials grant, you will make a request to th
 This value must be set to `application/x-www-form-urlencoded`.
 
 [field]#Authorization# [type]#[String]# [required]#Required#::
-You must provide client authentication using the https://tools.ietf.org/html/rfc7617#section-2[Basic Authentication Scheme] authorization header.
+You have two options regarding authorization.
++
+You can send the `client_id` and `client_secret` as a parameter in the request.
++
+Alternatively, you can provide client authentication using the https://tools.ietf.org/html/rfc7617#section-2[Basic Authentication Scheme] authorization header.
 +
 The header value is created by taking the `clientId` and `clientSecret` properties defined in the Entity Configuration and concatenating them together using a `:` character.
 Here is an example of these two values concatenated.
@@ -939,11 +947,12 @@ The unique client identifier.
 The client Id is the Id of the FusionAuth Entity in which you are attempting to authenticate.
 +
 This parameter is optional when the `Authorization` header is provided.
-When the `Authorization` header is not provided, this parameter is then required.
+When the `Authorization` header is not provided, this parameter is required.
 
-[field]#client_secret# [type]#[String]# [optional]#Optional# [since]#Available since 1.5.0#::
+[field]#client_secret# [type]#[String]# [optional]#Optional#::
 The client secret of the Entity.
-This value may optionally be provided in the request body instead of the `Authorization` header documented above.
+This parameter is optional when the `Authorization` header is provided.
+When the `Authorization` header is not provided, this parameter is required.
 
 [field]#grant_type# [type]#[String]# [required]#Required#::
 The grant type to be used.
@@ -1032,7 +1041,6 @@ The value will be `Bearer`.
 ----
 include::docs/v1/tech/oauth/_client_credentials_example_json_response.json[]
 ----
-
 
 == Device
 

--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -934,6 +934,17 @@ Ensure you are sending these parameters as form encoded data in the request body
 Do not send these parameters in a query string or as JSON.
 
 [.api]
+[field]#client_id# [type]#[String]# [optional]#Optional#::
+The unique client identifier.
+The client Id is the Id of the FusionAuth Entity in which you are attempting to authenticate.
++
+This parameter is optional when the `Authorization` header is provided.
+When the `Authorization` header is not provided, this parameter is then required.
+
+[field]#client_secret# [type]#[String]# [optional]#Optional# [since]#Available since 1.5.0#::
+The client secret of the Entity.
+This value may optionally be provided in the request body instead of the `Authorization` header documented above.
+
 [field]#grant_type# [type]#[String]# [required]#Required#::
 The grant type to be used.
 This value must be set to `client_credentials`
@@ -1021,6 +1032,7 @@ The value will be `Bearer`.
 ----
 include::docs/v1/tech/oauth/_client_credentials_example_json_response.json[]
 ----
+
 
 == Device
 


### PR DESCRIPTION
# Summary 

Updates the client credentials grant information with the idea of authenticating with either 
- basic auth 
or
-  with a combined `client id` and `client secret` in a post to the `token` endpoint.

related:
https://fusionauth.io/community/forum/topic/1175/client-credentials-grant-flow-basic-auth-or-client_id-and-client_secret-in-the-body
