### PR TITLE
1.30: Users API Updates

### DIFF
--- a/site/docs/src/json/user-registrations/combined-request.json
+++ b/site/docs/src/json/user-registrations/combined-request.json
@@ -23,6 +23,7 @@
     "username": "johnny123",
     "usernameStatus": "ACTIVE"
   },
+  "disableDomainBlock": false,
   "sendSetPasswordEmail": false,
   "skipVerification": false,
   "user": {

--- a/site/docs/src/json/users/change-password-request-api-key.json
+++ b/site/docs/src/json/users/change-password-request-api-key.json
@@ -1,4 +1,5 @@
 {
+  "applicationId": "18cec3c9-003b-433f-8412-6e31afca5bcf",
   "currentPassword": "too many secrets",
   "loginId": "cosmo@playtronics.com",
   "password": "Setec Astronomy"

--- a/site/docs/src/json/users/create-request.json
+++ b/site/docs/src/json/users/create-request.json
@@ -1,4 +1,6 @@
 {
+  "application": "368994e6-ba8a-49b5-8446-7b99ab1fffdf",
+  "disableDomainBlock": false,
   "user": {
     "birthDate": "1976-05-30",
     "data": {

--- a/site/docs/src/json/users/recent-logins-response.json
+++ b/site/docs/src/json/users/recent-logins-response.json
@@ -8,7 +8,6 @@
       "location": {
         "city": "Seattle",
         "country": "US",
-        "displayString": "Seattle, WA, US",
         "latitude": 47.60621,
         "longitude": -122.33207,
         "region": "WA"
@@ -24,7 +23,6 @@
       "location": {
         "city": "Denver",
         "country": "US",
-        "displayString": "Denver, CO, US",
         "latitude": 39.73913,
         "longitude": -104.9845,
         "region": "CO"
@@ -40,7 +38,6 @@
       "location": {
         "city": "Dhaka",
         "country": "BD",
-        "displayString": "Dhaka, 81, BD",
         "latitude": 23.7104,
         "longitude": 90.40744,
         "region": "81"

--- a/site/docs/src/json/users/recent-logins-response.json
+++ b/site/docs/src/json/users/recent-logins-response.json
@@ -5,6 +5,14 @@
       "applicationName": "PiedPiper",
       "instant": 1549493410058,
       "ipAddress": "42.42.42.42",
+      "location": {
+        "city": "Seattle",
+        "country": "US",
+        "displayString": "Seattle, WA, US",
+        "latitude": 47.60621,
+        "longitude": -122.33207,
+        "region": "WA"
+      },
       "loginId": "jared@piedpiper.com",
       "userId": "4469bea7-8b10-4ad3-94f2-bc8df962b489"
     },
@@ -13,6 +21,14 @@
       "applicationName": "Acme Corp.",
       "instant": 1549485962036,
       "ipAddress": "42.42.42.42",
+      "location": {
+        "city": "Denver",
+        "country": "US",
+        "displayString": "Denver, CO, US",
+        "latitude": 39.73913,
+        "longitude": -104.9845,
+        "region": "CO"
+      },
       "loginId": "admin@acme.com",
       "userId": "4469bea7-8b10-4ad3-94f2-bc8df962b489"
     },
@@ -21,6 +37,14 @@
       "applicationName": "Support Portal",
       "instant": 1549387234024,
       "ipAddress": "42.42.42.42",
+      "location": {
+        "city": "Dhaka",
+        "country": "BD",
+        "displayString": "Dhaka, 81, BD",
+        "latitude": 23.7104,
+        "longitude": 90.40744,
+        "region": "81"
+      },
       "loginId": "bob@gmail.com",
       "userId": "6a802b03-17e3-404f-830f-ea5c30ca50df"
     }

--- a/site/docs/src/json/users/update-request.json
+++ b/site/docs/src/json/users/update-request.json
@@ -1,4 +1,6 @@
 {
+  "application": "368994e6-ba8a-49b5-8446-7b99ab1fffdf",
+  "disableDomainBlock": false,
   "user": {
     "active": true,
     "birthDate": "1976-05-30",

--- a/site/docs/v1/tech/apis/_user-registration-combined-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-registration-combined-request-body.adoc
@@ -5,6 +5,9 @@ This request requires that you specify both the User object and the User Registr
 :set_password_field_config_blurb: configured in the Application, or, if that is not configured, the same field in the Tenant
 
 [.api]
+[field]#disableDomainBlock# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
+If `true`, blocked domains that have been configured on the tenant will be ignored when creating or updating a User.
+
 [field]#generateAuthenticationToken# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 Determines if FusionAuth should generate an Authentication Token for this registration.
 

--- a/site/docs/v1/tech/apis/_user-registration-combined-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-registration-combined-request-body.adoc
@@ -6,7 +6,9 @@ This request requires that you specify both the User object and the User Registr
 
 [.api]
 [field]#disableDomainBlock# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
-If `true`, blocked domains that have been configured on the tenant will be ignored when creating or updating a User.
+A tenant has the option to configure one or more email domains to be blocked in order to restrict email domains during user create or update.
++
+Setting this property equal to `true` will override the tenant configuration. See [field]#tenant.registrationConfiguration.blockedDomains# in the link:../tenants[Tenant API].
 
 [field]#generateAuthenticationToken# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 Determines if FusionAuth should generate an Authentication Token for this registration.

--- a/site/docs/v1/tech/apis/_user-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-request-body.adoc
@@ -8,10 +8,14 @@ You must specify either the **email** or the **username** or both for the User. 
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.30.0#::
-The Id of the Application that is used for email templates.
+An optional Application Id. When this value is provided, it will be used to resolve an application specific email template if you have configured transactional emails such as setup password, email verification and others.
++
+If not provided, only the tenant configuration will be used when resolving email templates.
 
 [field]#disableDomainBlock# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
-If `true`, blocked domains that have been configured on the tenant will be ignored when creating or updating a User.
+A tenant has the option to configure one or more email domains to be blocked in order to restrict email domains during user create or update.
++
+Setting this property equal to `true` will override the tenant configuration. See [field]#tenant.registrationConfiguration.blockedDomains# in the link:../tenants[Tenant API].
 
 ifeval::["{http_method}" == "POST"]
 include::_user-send-set-password-email.adoc[]

--- a/site/docs/v1/tech/apis/_user-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-request-body.adoc
@@ -7,6 +7,12 @@ You must specify either the **email** or the **username** or both for the User. 
 
 
 [.api]
+[field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.30.0#::
+The Id of the Application that is used for email templates.
+
+[field]#disableDomainBlock# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
+If `true`, blocked domains that have been configured on the tenant will be ignored when creating or updating a User.
+
 ifeval::["{http_method}" == "POST"]
 include::_user-send-set-password-email.adoc[]
 endif::[]

--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -1101,6 +1101,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-ambiguous-operation.ad
 ==== Request Body
 
 [.api]
+[field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.30.0#::
+The Id of the Application used in the context of this request.
+
 [field]#currentPassword# [type]#[String]# [optional]#Optional#::
 The User's current password. When this parameter is provided the current password will be verified to be correct.
 

--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -764,21 +764,51 @@ The IP address if provided during the login request.
 
 [field]#logins``[x]``.location.city# [type]#[String]# [since]#Available since 1.30.0#::
 The city where the login request originated.
++
+:premium_feature: login location
+include::docs/v1/tech/shared/_premium-edition-blurb-api.adoc[]
++
+:premium_feature!:
 
 [field]#logins``[x]``.location.country# [type]#[String]# [since]#Available since 1.30.0#::
 The country where the login request originated.
++
+:premium_feature: login location
+include::docs/v1/tech/shared/_premium-edition-blurb-api.adoc[]
++
+:premium_feature!:
 
 [field]#logins``[x]``.location.latitude# [type]#[Double]# [since]#Available since 1.30.0#::
 The latitude where the login request originated.
++
+:premium_feature: login location
+include::docs/v1/tech/shared/_premium-edition-blurb-api.adoc[]
++
+:premium_feature!:
 
 [field]#logins``[x]``.location.longitude# [type]#[Double]# [since]#Available since 1.30.0#::
 The longitude where the login request originated.
++
+:premium_feature: login location
+include::docs/v1/tech/shared/_premium-edition-blurb-api.adoc[]
++
+:premium_feature!:
 
 [field]#logins``[x]``.location.region# [type]#[String]# [since]#Available since 1.30.0#::
 The geographic location where the login request originated.
++
+:premium_feature: login location
+include::docs/v1/tech/shared/_premium-edition-blurb-api.adoc[]
++
+:premium_feature!:
 
 [field]#logins``[x]``.location.zipcode# [type]#[String]# [since]#Available since 1.30.0#::
 The zipcode where the login request originated.
++
+:premium_feature: login location
+include::docs/v1/tech/shared/_premium-edition-blurb-api.adoc[]
++
+:premium_feature!:
 
 [field]#logins``[x]``.loginId# [type]#[String]#::
 The User's email address or username at the time of the login request.
@@ -1120,7 +1150,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-ambiguous-operation.ad
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.30.0#::
-The Id of the Application used in the context of this request.
+An optional Application Id. When this value is provided, it will be used to resolve an application specific email template if you have configured transactional emails such as setup password, email verification and others.
++
+If not provided, only the tenant configuration will be used when resolving email templates.
 
 [field]#currentPassword# [type]#[String]# [optional]#Optional#::
 The User's current password. When this parameter is provided the current password will be verified to be correct.

--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -762,6 +762,24 @@ The link:/docs/v1/tech/reference/data-types/#instants[instant] this login occurr
 [field]#logins``[x]``.ipAddress# [type]#[String]#::
 The IP address if provided during the login request.
 
+[field]#logins``[x]``.location.city# [type]#[String]# [since]#Available since 1.30.0#::
+The city where the login request originated.
+
+[field]#logins``[x]``.location.country# [type]#[String]# [since]#Available since 1.30.0#::
+The country where the login request originated.
+
+[field]#logins``[x]``.location.latitude# [type]#[Double]# [since]#Available since 1.30.0#::
+The latitude where the login request originated.
+
+[field]#logins``[x]``.location.longitude# [type]#[Double]# [since]#Available since 1.30.0#::
+The longitude where the login request originated.
+
+[field]#logins``[x]``.location.region# [type]#[String]# [since]#Available since 1.30.0#::
+The geographic location where the login request originated.
+
+[field]#logins``[x]``.location.zipcode# [type]#[String]# [since]#Available since 1.30.0#::
+The zipcode where the login request originated.
+
 [field]#logins``[x]``.loginId# [type]#[String]#::
 The User's email address or username at the time of the login request.
 

--- a/site/docs/v1/tech/core-concepts/roles.adoc
+++ b/site/docs/v1/tech/core-concepts/roles.adoc
@@ -89,30 +89,30 @@ Below are all the roles available in FusionAuth. Please note the additional expl
 | Name | Id | Description
 
 | `admin` | `631ecd9d-8d40-4c13-8277-80cedb8236e2` | Can manage everything, including creating new users with administrator privileges.
-| `acl_manager` | `631ecd9d-8d40-4c13-8277-80cedb823712` | Can add and edit IP access control lists. Available since 1.30.
-| `acl_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823711` | Can delete IP access control lists. Available since 1.30.
+| `acl_manager` | `631ecd9d-8d40-4c13-8277-80cedb823712` | Can add and edit IP access control lists. Available since 1.30.0.
+| `acl_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823711` | Can delete IP access control lists. Available since 1.30.0.
 | `api_key_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236e3` | Can add and edit API keys.
 | `application_deleter` | `631ecd9d-8d40-4c13-8277-80cedb8236e4` | Can delete applications.
 | `application_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236e5` | Can add and edit applications.
 | `audit_log_viewer` | `631ecd9d-8d40-4c13-8277-80cedb8236e6` | Can view audit logs.
-| `connector_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823700` | Can delete Connectors. Available since 1.18.
-| `connector_manager` | `631ecd9d-8d40-4c13-8277-80cedb823701` | Can add and edit Connectors. Available since 1.18.
+| `connector_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823700` | Can delete Connectors. Available since 1.18.0.
+| `connector_manager` | `631ecd9d-8d40-4c13-8277-80cedb823701` | Can add and edit Connectors. Available since 1.18.0.
 | `consent_deleter` | `631ecd9d-8d40-4c13-8277-80cedb8236fc` | Can delete consents.
 | `consent_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236fd` | Can add and edit consents.
 | `email_template_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236e7` | Can add and edit email templates.
-| `entity_manager` | `631ecd9d-8d40-4c13-8277-80cedb823706` | Can add and edit entities. Available since 1.26.
+| `entity_manager` | `631ecd9d-8d40-4c13-8277-80cedb823706` | Can add and edit entities. Available since 1.26.0.
 | `event_log_viewer` | `631ecd9d-8d40-4c13-8277-80cedb8236fa` | Can view the event log.
-| `form_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823702` | Can delete forms and form fields. Available since 1.18.
-| `form_manager` | `631ecd9d-8d40-4c13-8277-80cedb823703` | Can add and edit forms and form fields. Available since 1.18.
+| `form_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823702` | Can delete forms and form fields. Available since 1.18.0.
+| `form_manager` | `631ecd9d-8d40-4c13-8277-80cedb823703` | Can add and edit forms and form fields. Available since 1.18.0.
 | `group_deleter` | `631ecd9d-8d40-4c13-8277-80cedb8236f6` | Can delete groups.
 | `group_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236f5` | Can add and edit groups.
 | `key_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236fb` | Can add and edit keys.
 | `lambda_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236f9` | Can add and edit lambdas.
-| `message_template_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823709` | Can delete message templates. Available since 1.26.
-| `message_template_manager` | `631ecd9d-8d40-4c13-8277-80cedb823710` | Can add and edit message templates. Available since 1.26.
-| `messenger_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823707` | Can delete messengers. Available since 1.26.
-| `messenger_manager` | `631ecd9d-8d40-4c13-8277-80cedb823708` | Can add and edit messengers. Available since 1.26.
-| `reactor_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236ff` | Can add and edit reactor settings. Available since 1.15.
+| `message_template_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823709` | Can delete message templates. Available since 1.26.0.
+| `message_template_manager` | `631ecd9d-8d40-4c13-8277-80cedb823710` | Can add and edit message templates. Available since 1.26.0.
+| `messenger_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823707` | Can delete messengers. Available since 1.26.0.
+| `messenger_manager` | `631ecd9d-8d40-4c13-8277-80cedb823708` | Can add and edit messengers. Available since 1.26.0.
+| `reactor_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236ff` | Can add and edit reactor settings. Available since 1.15.0.
 | `report_viewer` | `631ecd9d-8d40-4c13-8277-80cedb8236e8` | Can view reports.
 | `system_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236e9` | Can add and edit system configuration.
 | `tenant_deleter` | `631ecd9d-8d40-4c13-8277-80cedb8236f8` | Can delete tenants.
@@ -122,8 +122,8 @@ Below are all the roles available in FusionAuth. Please note the additional expl
 | `user_action_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236f1` | Can add and edit user actions.
 | `user_deleter` | `631ecd9d-8d40-4c13-8277-80cedb8236f2` | Can delete users.
 | `user_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236f3` | Can add and edit users.
-| `user_support_manager` | `631ecd9d-8d40-4c13-8277-80cedb823704` | Allows for a limited scope of user management. See below. Available since 1.23.
-| `user_support_viewer` | `631ecd9d-8d40-4c13-8277-80cedb823705` | Can view user information. Available since 1.23.
+| `user_support_manager` | `631ecd9d-8d40-4c13-8277-80cedb823704` | Allows for a limited scope of user management. See below. Available since 1.23.0.
+| `user_support_viewer` | `631ecd9d-8d40-4c13-8277-80cedb823705` | Can view user information. Available since 1.23.0.
 | `webhook_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236f4` | Can add or edit webhooks.
 |===
 

--- a/site/docs/v1/tech/core-concepts/roles.adoc
+++ b/site/docs/v1/tech/core-concepts/roles.adoc
@@ -89,6 +89,8 @@ Below are all the roles available in FusionAuth. Please note the additional expl
 | Name | Id | Description
 
 | `admin` | `631ecd9d-8d40-4c13-8277-80cedb8236e2` | Can manage everything, including creating new users with administrator privileges.
+| `acl_manager` | `631ecd9d-8d40-4c13-8277-80cedb823712` | Can add and edit IP access control lists. Available since 1.30.
+| `acl_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823711` | Can delete IP access control lists. Available since 1.30.
 | `api_key_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236e3` | Can add and edit API keys.
 | `application_deleter` | `631ecd9d-8d40-4c13-8277-80cedb8236e4` | Can delete applications.
 | `application_manager` | `631ecd9d-8d40-4c13-8277-80cedb8236e5` | Can add and edit applications.


### PR DESCRIPTION
## Users API updates

### Updates
* Request objects update:
  * `disableDomainBlock` added
  * `applicationId` added for email templates.
 * `DisplayableRawLogin` updated to include `Location`.  Response Body and example JSON updated for `api/user/recent-login`.
* (Not User API related but made it into this commit anyway) New roles added for `acl_manager` and `acl_deleter