### PR TITLE
Added note about minimum memory for advanced threat detection.

### DIFF
--- a/site/docs/v1/tech/installation-guide/system-requirements.adoc
+++ b/site/docs/v1/tech/installation-guide/system-requirements.adoc
@@ -51,7 +51,7 @@ Considerations that may require a larger amount of memory:
 * > 1k Lambdas. Lambdas need to be pre-compiled, cached and sandboxed in their own JavaScript engine for use a runtime. Creating thousands of Lambdas will increase your memory requirements due to what is needed to keep in memory at runtime.
 * > 1k Tenants. There are tasks that require a full traversal of all tenants, when you have 1000's of tenants these tasks may affect performance and will increase your memory requirements.
 * > 1k Applications. There are tasks that require a full traversal of all applications, when you have 1000's of applications these tasks may affect performance and will increase your memory requirements.
-
+* When using the advanced threat detection paid feature, a minimum of 2GB of memory is required.
 
 == Database
 

--- a/site/docs/v1/tech/installation-guide/system-requirements.adoc
+++ b/site/docs/v1/tech/installation-guide/system-requirements.adoc
@@ -51,7 +51,7 @@ Considerations that may require a larger amount of memory:
 * > 1k Lambdas. Lambdas need to be pre-compiled, cached and sandboxed in their own JavaScript engine for use a runtime. Creating thousands of Lambdas will increase your memory requirements due to what is needed to keep in memory at runtime.
 * > 1k Tenants. There are tasks that require a full traversal of all tenants, when you have 1000's of tenants these tasks may affect performance and will increase your memory requirements.
 * > 1k Applications. There are tasks that require a full traversal of all applications, when you have 1000's of applications these tasks may affect performance and will increase your memory requirements.
-* When using the advanced threat detection paid feature, a minimum of 2GB of memory is required.
+* When using the Advanced Threat Detection feature, a minimum of 2GB of memory is required.
 
 == Database
 


### PR DESCRIPTION
This came up in an internal slack message, but wanted to capture this for doc.