### PR TITLE
1.30: Audit Tenant fields

### DIFF
--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -7,7 +7,7 @@ The optional Id of an existing Tenant to make a copy of. If present, the [field]
 [field]#tenant.connectorPolicies# [type]#[Array]# [optional]#Optional# [since]#Available since 1.18.0#::
 A list of Connector policies. Users will be authenticated against Connectors in order. Each Connector can be included in this list at most once and must exist.
 
-[field]#tenant.connectorPolicies``[x]``.connectorId# [type]#[UUID]# [required]#Required# [since]#Available since 1.18.0#::
+[field]#tenant.connectorPolicies``[x]``.connectorId# [type]#[UUID]# [optional]#Optional# [default]#defaults to FusionAuth connector Id# [since]#Available since 1.18.0#::
 The identifier of the Connector to which this policy refers.
 
 [field]#tenant.connectorPolicies``[x]``.domains# [type]#[Array<String>]# [optional]#Optional# [default]#defaults to `["*"]`# [since]#Available since 1.18.0#::
@@ -35,16 +35,16 @@ The default From Name used in sending emails when a from name is not provided on
 [field]#tenant.emailConfiguration.forgotPasswordEmailTemplateId# [type]#[UUID]# [optional]#Optional#::
 The Id of the Email Template that is used when a user is sent a forgot password email.
 
-[field]#tenant.emailConfiguration.host# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.emailConfiguration.host# [type]#[String]# [optional]#Optional# [default]#defaults to `localhost`# [since]#Available since 1.8.0#::
 The host name of the SMTP server that FusionAuth will use.
 
 [field]#tenant.emailConfiguration.password# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::
 An optional password FusionAuth will use to authenticate with the SMTP server.
 
-[field]#tenant.emailConfiguration.passwordlessEmailTemplateId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.8.0#::
+[field]#tenant.emailConfiguration.passwordlessEmailTemplateId# [type]#[UUID]# [optional]#Optional# [default]#defaults to `25`# [since]#Available since 1.8.0#::
 The Id of the Passwordless Email Template.
 
-[field]#tenant.emailConfiguration.port# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.emailConfiguration.port# [type]#[Integer]# [optional]#Optional# [since]#Available since 1.8.0#::
 The port of the SMTP server that FusionAuth will use.
 
 [field]#tenant.emailConfiguration.properties# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::
@@ -100,12 +100,12 @@ The transaction type that FusionAuth uses when sending these types of events to 
 +
 include::_transaction-types.adoc[]
 
-[field]#tenant.externalIdentifierConfiguration.authorizationGrantIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.authorizationGrantIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# #defaults to `30`# [since]#Available since 1.8.0#::
 The time in seconds until a OAuth authorization code in no longer valid to be exchanged for an access token. This is essentially the time allowed between the start of an Authorization request during the Authorization code grant and when you request an access token using this authorization code on the Token endpoint.
 +
 Value must be greater than 0 and less than or equal to 600.
 
-[field]#tenant.externalIdentifierConfiguration.changePasswordIdGenerator.length# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.changePasswordIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `32`# [since]#Available since 1.8.0#::
 +
 :generator_type: changePasswordIdGenerator
 :generator_display_name: change password Id
@@ -114,19 +114,19 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.changePasswordIdGenerator.type# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.changePasswordIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 +
 :generator_display_name: change password Id
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.changePasswordIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.changePasswordIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `600`# [since]#Available since 1.8.0#::
 The time in seconds until a change password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
 
-[field]#tenant.externalIdentifierConfiguration.deviceCodeTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.11.0#::
+[field]#tenant.externalIdentifierConfiguration.deviceCodeTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.11.0#::
 The time in seconds until a device code Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
 
-[field]#tenant.externalIdentifierConfiguration.deviceUserCodeIdGenerator.length# [type]#[Integer]# [required]#Required# [since]#Available since 1.11.0#::
+[field]#tenant.externalIdentifierConfiguration.deviceUserCodeIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.11.0#::
 +
 :generator_type: deviceCodeTimeToLiveInSeconds
 :generator_display_name: device code Id
@@ -135,13 +135,13 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.deviceUserCodeIdGenerator.type# [type]#[String]# [required]#Required# [since]#Available since 1.11.0#::
+[field]#tenant.externalIdentifierConfiguration.deviceUserCodeIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.11.0#::
 +
 :generator_display_name: device code Id
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.emailVerificationIdGenerator.length# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.emailVerificationIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.8.0#::
 +
 :generator_type: emailVerificationIdGenerator
 :generator_display_name: the email verification Id
@@ -150,13 +150,13 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.emailVerificationIdGenerator.type# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.emailVerificationIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 +
 :generator_display_name: email verification Id
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.emailVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.emailVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86400`# [since]#Available since 1.8.0#::
 The time in seconds until a email verification Id is no longer valid and cannot be used by the Verify Email API. Value must be greater than 0.
 
 [field]#tenant.externalIdentifierConfiguration.emailVerificationOneTimeCodeGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.27.0#::
@@ -175,13 +175,13 @@ include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.externalAuthenticationIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.12.0#::
+[field]#tenant.externalIdentifierConfiguration.externalAuthenticationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.12.0#::
 The time in seconds until an external authentication Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
 
-[field]#tenant.externalIdentifierConfiguration.oneTimePasswordTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.oneTimePasswordTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.8.0#::
 The time in seconds until a One Time Password is no longer valid and cannot be used by the Login API. Value must be greater than 0.
 
-[field]#tenant.externalIdentifierConfiguration.passwordlessLoginGenerator.length# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.passwordlessLoginGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `32`# [since]#Available since 1.8.0#::
 +
 :generator_type: passwordlessLoginGenerator
 :generator_display_name: passwordless login
@@ -190,16 +190,16 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.passwordlessLoginGenerator.type# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.passwordlessLoginGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 +
 :generator_display_name: passwordless login
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.passwordlessLoginTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.passwordlessLoginTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `180`# [since]#Available since 1.8.0#::
 The time in seconds until a passwordless code is no longer valid and cannot be used by the Passwordless API. Value must be greater than 0.
 
-[field]#tenant.externalIdentifierConfiguration.registrationVerificationIdGenerator.length# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.registrationVerificationIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `32`# [since]#Available since 1.8.0#::
 +
 :generator_type: registrationVerificationIdGenerator
 :generator_display_name: registration verification Id
@@ -208,7 +208,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.registrationVerificationIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.registrationVerificationIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 
 Note: Prior to version 1.28.0 this value was required.
 +
@@ -216,7 +216,7 @@ Note: Prior to version 1.28.0 this value was required.
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86400`# [since]#Available since 1.8.0#::
 The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
 
 
@@ -229,7 +229,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.registrationVerificationOneTimeCodeGenerator.type# [type]#[String]# [required]#Required# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.27.0#::
+[field]#tenant.externalIdentifierConfiguration.registrationVerificationOneTimeCodeGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.27.0#::
 +
 :generator_display_name: registration verification one time code
 include::_tenant-generator-type-config-rules.adoc[]
@@ -239,7 +239,7 @@ include::_tenant-generator-type-config-rules.adoc[]
 [field]#tenant.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.19.0#::
 The time in seconds that a SAML AuthN request Id returned by the Start SAML v2 Login Request API will be eligible to be used to complete a SAML v2 Login request.
 
-[field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.length# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `32`# [since]#Available since 1.8.0#::
 +
 :generator_type: setupPasswordIdGenerator
 :generator_display_name: setup password Id
@@ -248,16 +248,16 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.type# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 +
 :generator_display_name: setup password Id
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.setupPasswordIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.setupPasswordIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86400`# [since]#Available since 1.8.0#::
 The time in seconds until a setup password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
 
-[field]#tenant.externalIdentifierConfiguration.twoFactorIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.twoFactorIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.8.0#::
 The time in seconds until a two factor Id is no longer valid and cannot be used by the Two Factor Login API. Value must be greater than 0.
 
 [field]#tenant.externalIdentifierConfiguration.twoFactorOneTimeCodeIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.27.0#::
@@ -269,29 +269,29 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_display_name!:
 +
 
-[field]#tenant.externalIdentifierConfiguration.twoFactorOneTimeCodeIdGenerator.type# [type]#[String]# [required]#Required# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.27.0#::
+[field]#tenant.externalIdentifierConfiguration.twoFactorOneTimeCodeIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.27.0#::
 +
 :generator_display_name: two factor one time code Id
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.twoFactorTrustIdTimeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.twoFactorTrustIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `2,592,000`# [default]#defaults to `2,592,000`# [since]#Available since 1.8.0#::
 The time in seconds until an issued Two Factor trust Id is no longer valid and the User will be required to complete Two Factor authentication
 during the next authentication attempt. Value must be greater than 0.
 
-[field]#tenant.failedAuthenticationConfiguration.actionDuration# [type]#[Long]# [required]#Required# [default]#defaults to `3`# [since]#Available since 1.8.0#::
+[field]#tenant.failedAuthenticationConfiguration.actionDuration# [type]#[Long]# [optional]#Optional# [default]#defaults to `3`# [since]#Available since 1.8.0#::
 The duration of the User Action. This value along with the `actionDurationUnit` will be used to set the duration of the User Action. Value must be greater than 0.
 
-[field]#tenant.failedAuthenticationConfiguration.actionDurationUnit# [type]#[String]# [required]#Required# [default]#defaults to `"MINUTES"`# [since]#Available since 1.8.0#::
+[field]#tenant.failedAuthenticationConfiguration.actionDurationUnit# [type]#[String]# [optional]#Optional# [default]#defaults to `"MINUTES"`# [since]#Available since 1.8.0#::
 
 include::_expiry_unit.adoc[]
 
-[field]#tenant.failedAuthenticationConfiguration.resetCountInSeconds# [type]#[Integer]# [required]#Required# [default]#defaults to `60`# [since]#Available since 1.8.0#::
+[field]#tenant.failedAuthenticationConfiguration.resetCountInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.8.0#::
 The length of time in seconds before the failed authentication count will be reset. Value must be greater than 0.
 +
 For example, if `tooManyAttempts` is set to `5` and you fail to authenticate `4` times in a row, waiting for the duration specified here will cause your fifth attempt to start back at `1`.
 
-[field]#tenant.failedAuthenticationConfiguration.tooManyAttempts# [type]#[Integer]# [required]#Required# [default]#defaults to `5`# [since]#Available since 1.8.0#::
+[field]#tenant.failedAuthenticationConfiguration.tooManyAttempts# [type]#[Integer]# [optional]#Optional# [default]#defaults to `5`# [since]#Available since 1.8.0#::
 The number of failed attempts considered to be too many. Once this threshold is reached the specified User Action will be applied to the user for the duration specified. Value must be greater than 0.
 
 [field]#tenant.failedAuthenticationConfiguration.userActionId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.8.0#::
@@ -340,13 +340,13 @@ include::../shared/_premium-edition-blurb-api.adoc[]
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#defaults to `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
 
-[field]#tenant.issuer# [type]#[String]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.issuer# [type]#[String]# [optional]#Optional# [default]#defaults to `fusionauth.io` [since]#Available since 1.8.0#::
 The named issuer used to sign tokens, this is generally your public fully qualified domain.
 
-[field]#tenant.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [default]#defaults to key value of FusionAuth application# [since]#Available since 1.8.0#::
 The unique id of the signing key used to sign the access token.
 
-[field]#tenant.jwtConfiguration.idTokenKeyId# [type]#[UUID]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.jwtConfiguration.idTokenKeyId# [type]#[UUID]# [optional]#Optional# [default]#defaults to key value of FusionAuth application# [since]#Available since 1.8.0#::
 The unique id of the signing key used to sign the Id token.
 
 [field]#tenant.jwtConfiguration.refreshTokenExpirationPolicy# [type]#[String]# [optional]#Optional# [default]#defaults to `Fixed`# [since]#Available since 1.17.0#::
@@ -362,16 +362,16 @@ When enabled, the refresh token will be revoked when a user action, such as lock
 
 When enabled, the refresh token will be revoked when a user changes their password.
 
-[field]#tenant.jwtConfiguration.refreshTokenTimeToLiveInMinutes# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.jwtConfiguration.refreshTokenTimeToLiveInMinutes# [type]#[Integer]# [optional]#Optional# [default]#defaults to `43200`# [since]#Available since 1.8.0#::
 The length of time in minutes a Refresh Token is valid from the time it was issued. Value must be greater than 0.
 
-[field]#tenant.jwtConfiguration.refreshTokenUsagePolicy# [type]#[String]# [optional]#Optional# [since]#Available since 1.17.0#::
+[field]#tenant.jwtConfiguration.refreshTokenUsagePolicy# [type]#[String]# [optional]#Optional# [default]#defaults to `Reusable`# [since]#Available since 1.17.0#::
 The refresh token usage policy. The following are valid values:
 
 * `Reusable` - the token does not change after it was issued.
 * `OneTimeUse` - the token value will be changed each time the token is used to refresh a JWT. The client must store the new value after each usage.
 
-[field]#tenant.jwtConfiguration.timeToLiveInSeconds# [type]#[Integer]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.jwtConfiguration.timeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `3600`# [since]#Available since 1.8.0#::
 The length of time in seconds this JWT is valid from the time it was issued. Value must be greater than 0.
 
 [field]#tenant.logoutURL# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::
@@ -446,10 +446,10 @@ The behavior when detecting breaches at time of user login. The following are va
 * `NotifyUser` Notify the end user via email
 * `RequireChange` Require immediate password change
 
-[field]#tenant.passwordValidationRules.maxLength# [type]#[Integer]# [required]#Required# [default]#defaults to `256`# [since]#Available since 1.8.0#::
+[field]#tenant.passwordValidationRules.maxLength# [type]#[Integer]# [optional]#Optional# [default]#defaults to `256`# [since]#Available since 1.8.0#::
 The maximum length of a password when a new user is created or a user requests a password change.
 
-[field]#tenant.passwordValidationRules.minLength# [type]#[Integer]# [required]#Required# [default]#defaults to `8`# [since]#Available since 1.8.0#::
+[field]#tenant.passwordValidationRules.minLength# [type]#[Integer]# [optional]#Optional# [default]#defaults to `8`# [since]#Available since 1.8.0#::
 The minimum length of a password when a new user is created or a user requests a password change.
 
 [field]#tenant.passwordValidationRules.rememberPreviousPasswords.count# [type]#[Integer]# [optional]#Optional# [since]#Available since 1.8.0#::
@@ -470,7 +470,7 @@ Whether to force the user to use at least one number.
 [field]#tenant.passwordValidationRules.validateOnLogin# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.15.0#::
 When enabled the user's password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
 
-[field]#tenant.themeId# [type]#[UUID]# [required]#Required# [since]#Available since 1.8.0#::
+[field]#tenant.themeId# [type]#[UUID]# [optional]#Optional# [default]#defaults to the default tenant theme Id# [since]#Available since 1.8.0#::
 The unique Id of the theme to be used to style the login page and other end user templates.
 
 [field]#tenant.userDeletePolicy.unverified.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.13.0#::

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -7,7 +7,7 @@ The optional Id of an existing Tenant to make a copy of. If present, the [field]
 [field]#tenant.connectorPolicies# [type]#[Array]# [optional]#Optional# [since]#Available since 1.18.0#::
 A list of Connector policies. Users will be authenticated against Connectors in order. Each Connector can be included in this list at most once and must exist.
 
-[field]#tenant.connectorPolicies``[x]``.connectorId# [type]#[UUID]# [optional]#Optional# [default]#defaults to FusionAuth connector Id# [since]#Available since 1.18.0#::
+[field]#tenant.connectorPolicies``[x]``.connectorId# [type]#[UUID]# [optional]#Optional# [default]#defaults to the FusionAuth connector Id# [since]#Available since 1.18.0#::
 The identifier of the Connector to which this policy refers.
 
 [field]#tenant.connectorPolicies``[x]``.domains# [type]#[Array<String>]# [optional]#Optional# [default]#defaults to `["*"]`# [since]#Available since 1.18.0#::
@@ -41,10 +41,10 @@ The host name of the SMTP server that FusionAuth will use.
 [field]#tenant.emailConfiguration.password# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::
 An optional password FusionAuth will use to authenticate with the SMTP server.
 
-[field]#tenant.emailConfiguration.passwordlessEmailTemplateId# [type]#[UUID]# [optional]#Optional# [default]#defaults to `25`# [since]#Available since 1.8.0#::
+[field]#tenant.emailConfiguration.passwordlessEmailTemplateId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.8.0#::
 The Id of the Passwordless Email Template.
 
-[field]#tenant.emailConfiguration.port# [type]#[Integer]# [optional]#Optional# [since]#Available since 1.8.0#::
+[field]#tenant.emailConfiguration.port# [type]#[Integer]# [optional]#Optional# [default]#defaults to `25`# [since]#Available since 1.8.0#::
 The port of the SMTP server that FusionAuth will use.
 
 [field]#tenant.emailConfiguration.properties# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::
@@ -100,7 +100,7 @@ The transaction type that FusionAuth uses when sending these types of events to 
 +
 include::_transaction-types.adoc[]
 
-[field]#tenant.externalIdentifierConfiguration.authorizationGrantIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# #defaults to `30`# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.authorizationGrantIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `30`# [since]#Available since 1.8.0#::
 The time in seconds until a OAuth authorization code in no longer valid to be exchanged for an access token. This is essentially the time allowed between the start of an Authorization request during the Authorization code grant and when you request an access token using this authorization code on the Token endpoint.
 +
 Value must be greater than 0 and less than or equal to 600.
@@ -156,7 +156,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.emailVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86400`# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.emailVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86,400`# [since]#Available since 1.8.0#::
 The time in seconds until a email verification Id is no longer valid and cannot be used by the Verify Email API. Value must be greater than 0.
 
 [field]#tenant.externalIdentifierConfiguration.emailVerificationOneTimeCodeGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.27.0#::
@@ -216,7 +216,7 @@ Note: Prior to version 1.28.0 this value was required.
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86400`# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86,400`# [since]#Available since 1.8.0#::
 The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
 
 
@@ -254,7 +254,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.setupPasswordIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86400`# [since]#Available since 1.8.0#::
+[field]#tenant.externalIdentifierConfiguration.setupPasswordIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86,400`# [since]#Available since 1.8.0#::
 The time in seconds until a setup password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
 
 [field]#tenant.externalIdentifierConfiguration.twoFactorIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.8.0#::
@@ -340,13 +340,13 @@ include::../shared/_premium-edition-blurb-api.adoc[]
 [field]#tenant.httpSessionMaxInactiveInterval# [type]#[Integer]# [optional]#Optional# [default]#defaults to `3600`# [since]#Available since 1.8.0#::
 Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
 
-[field]#tenant.issuer# [type]#[String]# [optional]#Optional# [default]#defaults to `fusionauth.io` [since]#Available since 1.8.0#::
+[field]#tenant.issuer# [type]#[String]# [optional]#Optional# [default]#defaults to `fusionauth.io`# [since]#Available since 1.8.0#::
 The named issuer used to sign tokens, this is generally your public fully qualified domain.
 
-[field]#tenant.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [default]#defaults to key value of FusionAuth application# [since]#Available since 1.8.0#::
+[field]#tenant.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [default]#defaults to key value of the FusionAuth application# [since]#Available since 1.8.0#::
 The unique id of the signing key used to sign the access token.
 
-[field]#tenant.jwtConfiguration.idTokenKeyId# [type]#[UUID]# [optional]#Optional# [default]#defaults to key value of FusionAuth application# [since]#Available since 1.8.0#::
+[field]#tenant.jwtConfiguration.idTokenKeyId# [type]#[UUID]# [optional]#Optional# [default]#defaults to key value of the FusionAuth application# [since]#Available since 1.8.0#::
 The unique id of the signing key used to sign the Id token.
 
 [field]#tenant.jwtConfiguration.refreshTokenExpirationPolicy# [type]#[String]# [optional]#Optional# [default]#defaults to `Fixed`# [since]#Available since 1.17.0#::
@@ -362,7 +362,7 @@ When enabled, the refresh token will be revoked when a user action, such as lock
 
 When enabled, the refresh token will be revoked when a user changes their password.
 
-[field]#tenant.jwtConfiguration.refreshTokenTimeToLiveInMinutes# [type]#[Integer]# [optional]#Optional# [default]#defaults to `43200`# [since]#Available since 1.8.0#::
+[field]#tenant.jwtConfiguration.refreshTokenTimeToLiveInMinutes# [type]#[Integer]# [optional]#Optional# [default]#defaults to `43,200`# [since]#Available since 1.8.0#::
 The length of time in minutes a Refresh Token is valid from the time it was issued. Value must be greater than 0.
 
 [field]#tenant.jwtConfiguration.refreshTokenUsagePolicy# [type]#[String]# [optional]#Optional# [default]#defaults to `Reusable`# [since]#Available since 1.17.0#::
@@ -371,7 +371,7 @@ The refresh token usage policy. The following are valid values:
 * `Reusable` - the token does not change after it was issued.
 * `OneTimeUse` - the token value will be changed each time the token is used to refresh a JWT. The client must store the new value after each usage.
 
-[field]#tenant.jwtConfiguration.timeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `3600`# [since]#Available since 1.8.0#::
+[field]#tenant.jwtConfiguration.timeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `3,600`# [since]#Available since 1.8.0#::
 The length of time in seconds this JWT is valid from the time it was issued. Value must be greater than 0.
 
 [field]#tenant.logoutURL# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -7,7 +7,7 @@ The optional Id of an existing Tenant to make a copy of. If present, the [field]
 [field]#tenant.connectorPolicies# [type]#[Array]# [optional]#Optional# [since]#Available since 1.18.0#::
 A list of Connector policies. Users will be authenticated against Connectors in order. Each Connector can be included in this list at most once and must exist.
 
-[field]#tenant.connectorPolicies``[x]``.connectorId# [type]#[UUID]# [optional]#Optional# [default]#defaults to the FusionAuth connector Id# [since]#Available since 1.18.0#::
+[field]#tenant.connectorPolicies``[x]``.connectorId# [type]#[UUID]# [optional]#Optional# [default]#defaults to the FusionAuth connector Id of `e3306678-a53a-4964-9040-1c96f36dda72`# [since]#Available since 1.18.0#::
 The identifier of the Connector to which this policy refers.
 
 [field]#tenant.connectorPolicies``[x]``.domains# [type]#[Array<String>]# [optional]#Optional# [default]#defaults to `["*"]`# [since]#Available since 1.18.0#::
@@ -17,6 +17,8 @@ A value of `["*"]` indicates this connector applies to all users.
 
 [field]#tenant.connectorPolicies``[x]``.migrate# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.18.0#::
 If true, the user's data will be migrated to FusionAuth at first successful authentication; subsequent authentications will occur against the FusionAuth datastore. If false, the Connector's source will be treated as authoritative.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the Tenant that should be persisted.
@@ -37,6 +39,8 @@ The Id of the Email Template that is used when a user is sent a forgot password 
 
 [field]#tenant.emailConfiguration.host# [type]#[String]# [optional]#Optional# [default]#defaults to `localhost`# [since]#Available since 1.8.0#::
 The host name of the SMTP server that FusionAuth will use.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.emailConfiguration.password# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::
 An optional password FusionAuth will use to authenticate with the SMTP server.
@@ -46,6 +50,8 @@ The Id of the Passwordless Email Template.
 
 [field]#tenant.emailConfiguration.port# [type]#[Integer]# [optional]#Optional# [default]#defaults to `25`# [since]#Available since 1.8.0#::
 The port of the SMTP server that FusionAuth will use.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.emailConfiguration.properties# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::
 Additional Email Configuration in a properties file formatted String.
@@ -104,6 +110,8 @@ include::_transaction-types.adoc[]
 The time in seconds until a OAuth authorization code in no longer valid to be exchanged for an access token. This is essentially the time allowed between the start of an Authorization request during the Authorization code grant and when you request an access token using this authorization code on the Token endpoint.
 +
 Value must be greater than 0 and less than or equal to 600.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.changePasswordIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `32`# [since]#Available since 1.8.0#::
 +
@@ -112,7 +120,9 @@ Value must be greater than 0 and less than or equal to 600.
 include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
+
 +
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.changePasswordIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 +
@@ -120,11 +130,19 @@ include::_tenant-generator-length-config-rules.adoc[]
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
+
++
+Prior to version 1.28.0 this value was required.
+
 [field]#tenant.externalIdentifierConfiguration.changePasswordIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `600`# [since]#Available since 1.8.0#::
 The time in seconds until a change password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.deviceCodeTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.11.0#::
 The time in seconds until a device code Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.deviceUserCodeIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.11.0#::
 +
@@ -134,6 +152,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.deviceUserCodeIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.11.0#::
 +
@@ -141,7 +160,11 @@ include::_tenant-generator-length-config-rules.adoc[]
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
-[field]#tenant.externalIdentifierConfiguration.emailVerificationIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.8.0#::
+
++
+Prior to version 1.28.0 this value was required.
+
+[field]#tenant.externalIdentifierConfiguration.emailVerificationIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `32`# [since]#Available since 1.8.0#::
 +
 :generator_type: emailVerificationIdGenerator
 :generator_display_name: the email verification Id
@@ -149,6 +172,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.emailVerificationIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 +
@@ -156,8 +180,14 @@ include::_tenant-generator-length-config-rules.adoc[]
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
+
++
+Prior to version 1.28.0 this value was required.
+
 [field]#tenant.externalIdentifierConfiguration.emailVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86,400`# [since]#Available since 1.8.0#::
 The time in seconds until a email verification Id is no longer valid and cannot be used by the Verify Email API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.emailVerificationOneTimeCodeGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.27.0#::
 +
@@ -177,9 +207,13 @@ include::_tenant-generator-type-config-rules.adoc[]
 
 [field]#tenant.externalIdentifierConfiguration.externalAuthenticationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.12.0#::
 The time in seconds until an external authentication Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.oneTimePasswordTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.8.0#::
 The time in seconds until a One Time Password is no longer valid and cannot be used by the Login API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.passwordlessLoginGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `32`# [since]#Available since 1.8.0#::
 +
@@ -189,6 +223,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.passwordlessLoginGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 +
@@ -196,8 +231,14 @@ include::_tenant-generator-length-config-rules.adoc[]
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
+
++
+Prior to version 1.28.0 this value was required.
+
 [field]#tenant.externalIdentifierConfiguration.passwordlessLoginTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `180`# [since]#Available since 1.8.0#::
 The time in seconds until a passwordless code is no longer valid and cannot be used by the Passwordless API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.registrationVerificationIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `32`# [since]#Available since 1.8.0#::
 +
@@ -207,17 +248,22 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.registrationVerificationIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
-
-Note: Prior to version 1.28.0 this value was required.
 +
 :generator_display_name: registration verification Id
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
+
++
+Prior to version 1.28.0 this value was required.
+
 [field]#tenant.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86,400`# [since]#Available since 1.8.0#::
 The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 
 [field]#tenant.externalIdentifierConfiguration.registrationVerificationOneTimeCodeGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.27.0#::
@@ -228,6 +274,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.registrationVerificationOneTimeCodeGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.27.0#::
 +
@@ -235,6 +282,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 +
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.19.0#::
 The time in seconds that a SAML AuthN request Id returned by the Start SAML v2 Login Request API will be eligible to be used to complete a SAML v2 Login request.
@@ -247,6 +295,7 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.setupPasswordIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomBytes`# [since]#Available since 1.8.0#::
 +
@@ -254,11 +303,19 @@ include::_tenant-generator-length-config-rules.adoc[]
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
+
++
+Prior to version 1.28.0 this value was required.
+
 [field]#tenant.externalIdentifierConfiguration.setupPasswordIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `86,400`# [since]#Available since 1.8.0#::
 The time in seconds until a setup password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.twoFactorIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `300`# [since]#Available since 1.8.0#::
 The time in seconds until a two factor Id is no longer valid and cannot be used by the Two Factor Login API. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.externalIdentifierConfiguration.twoFactorOneTimeCodeIdGenerator.length# [type]#[Integer]# [optional]#Optional# [default]#defaults to `6`# [since]#Available since 1.27.0#::
 +
@@ -268,16 +325,23 @@ include::_tenant-generator-length-config-rules.adoc[]
 :generator_type!:
 :generator_display_name!:
 +
+Prior to version 1.28.0 this value was required.
 
-[field]#tenant.externalIdentifierConfiguration.twoFactorOneTimeCodeIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomAlphaNumeric`# [since]#Available since 1.27.0#::
+[field]#tenant.externalIdentifierConfiguration.twoFactorOneTimeCodeIdGenerator.type# [type]#[String]# [optional]#Optional# [default]#defaults to `randomDigits`# [since]#Available since 1.27.0#::
 +
 :generator_display_name: two factor one time code Id
 include::_tenant-generator-type-config-rules.adoc[]
 :generator_display_name!:
 
+
++
+Prior to version 1.28.0 this value was required.
+
 [field]#tenant.externalIdentifierConfiguration.twoFactorTrustIdTimeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `2,592,000`# [default]#defaults to `2,592,000`# [since]#Available since 1.8.0#::
 The time in seconds until an issued Two Factor trust Id is no longer valid and the User will be required to complete Two Factor authentication
 during the next authentication attempt. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.failedAuthenticationConfiguration.actionDuration# [type]#[Long]# [optional]#Optional# [default]#defaults to `3`# [since]#Available since 1.8.0#::
 The duration of the User Action. This value along with the `actionDurationUnit` will be used to set the duration of the User Action. Value must be greater than 0.
@@ -342,12 +406,18 @@ Time in seconds until an inactive session will be invalidated. Used when creatin
 
 [field]#tenant.issuer# [type]#[String]# [optional]#Optional# [default]#defaults to `fusionauth.io`# [since]#Available since 1.8.0#::
 The named issuer used to sign tokens, this is generally your public fully qualified domain.
++
+Prior to version 1.30.0 this value was required.
 
 [field]#tenant.jwtConfiguration.accessTokenKeyId# [type]#[UUID]# [optional]#Optional# [default]#defaults to key value of the FusionAuth application# [since]#Available since 1.8.0#::
 The unique id of the signing key used to sign the access token.
++
+Prior to version 1.30.0 this value was required.
 
 [field]#tenant.jwtConfiguration.idTokenKeyId# [type]#[UUID]# [optional]#Optional# [default]#defaults to key value of the FusionAuth application# [since]#Available since 1.8.0#::
 The unique id of the signing key used to sign the Id token.
++
+Prior to version 1.30.0 this value was required.
 
 [field]#tenant.jwtConfiguration.refreshTokenExpirationPolicy# [type]#[String]# [optional]#Optional# [default]#defaults to `Fixed`# [since]#Available since 1.17.0#::
 The refresh token expiration policy. The following are valid values:
@@ -364,6 +434,8 @@ When enabled, the refresh token will be revoked when a user changes their passwo
 
 [field]#tenant.jwtConfiguration.refreshTokenTimeToLiveInMinutes# [type]#[Integer]# [optional]#Optional# [default]#defaults to `43,200`# [since]#Available since 1.8.0#::
 The length of time in minutes a Refresh Token is valid from the time it was issued. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.jwtConfiguration.refreshTokenUsagePolicy# [type]#[String]# [optional]#Optional# [default]#defaults to `Reusable`# [since]#Available since 1.17.0#::
 The refresh token usage policy. The following are valid values:
@@ -371,8 +443,13 @@ The refresh token usage policy. The following are valid values:
 * `Reusable` - the token does not change after it was issued.
 * `OneTimeUse` - the token value will be changed each time the token is used to refresh a JWT. The client must store the new value after each usage.
 
++
+Prior to version 1.28.0 this value was required.
+
 [field]#tenant.jwtConfiguration.timeToLiveInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `3,600`# [since]#Available since 1.8.0#::
 The length of time in seconds this JWT is valid from the time it was issued. Value must be greater than 0.
++
+Prior to version 1.28.0 this value was required.
 
 [field]#tenant.logoutURL# [type]#[String]# [optional]#Optional# [since]#Available since 1.8.0#::
 The logout redirect URL when sending the user's browser to the `/oauth2/logout` URI of the FusionAuth Front End. This value is only used when a logout URL is not defined in your Application.
@@ -470,8 +547,10 @@ Whether to force the user to use at least one number.
 [field]#tenant.passwordValidationRules.validateOnLogin# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.15.0#::
 When enabled the user's password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
 
-[field]#tenant.themeId# [type]#[UUID]# [optional]#Optional# [default]#defaults to the default tenant theme Id# [since]#Available since 1.8.0#::
+[field]#tenant.themeId# [type]#[UUID]# [optional]#Optional# [default]#defaults to the default tenant theme Id of `75a068fd-e94b-451a-9aeb-3ddb9a3b5987`# [since]#Available since 1.8.0#::
 The unique Id of the theme to be used to style the login page and other end user templates.
++
+Prior to version 1.30.0 this value was required.
 
 [field]#tenant.userDeletePolicy.unverified.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.13.0#::
 Indicates that users without a verified email address will be permanently deleted after [field]#tenant.userDeletePolicy.unverified.numberOfDaysToRetain# days.


### PR DESCRIPTION
## Audit and document fields on the Tenant object

There are now fewer required fields as the majority of them are defaulted.  The only remaining required field should be `name`.