### PR TITLE
New `showCaptcha` variable available in themes

### DIFF
--- a/site/docs/v1/tech/themes/index.adoc
+++ b/site/docs/v1/tech/themes/index.adoc
@@ -415,7 +415,7 @@ Navigate to [breadcrumb]#Customizations -> Themes#. Choose your theme, then clic
 
 image::theme-preview-button.png[Preview your theme,width=1200,role=shadowed bottom-cropped]
 
-This will open a new tab. Click on any of the pages you've modifed in the left hand navigation, for example [field]#OAuth register#, and you'll see the page as it would be rendered. 
+This will open a new tab. Click on any of the pages you've modifed in the left hand navigation, for example [field]#OAuth register#, and you'll see the page as it would be rendered.
 
 == Example Code
 
@@ -714,6 +714,9 @@ When `true`, a form input is displayed to allow a user to enter the verification
 [field]#email# [type]#[String]#::
 The current value of the user's email address. This may be useful to indicate to the user which email address was sent a verification code.
 
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
+
 [field]#verificationId# [type]#[String]#::
 The verification id that was included on as a URL parameter. This is the high entropy value that will be paired with the low entropy one time code to complete email verification.
 
@@ -727,6 +730,9 @@ The verification id that was included on as a URL parameter. This is the high en
 ==== Variables
 
 [.api]
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
+
 [field]#verificationId# [type]#[String]#::
 The verification id that was included on as a URL parameter but was invalid. This page does a redirect if the verificationId is valid.
 
@@ -762,6 +768,9 @@ The OAuth v2.0 `response_type` parameter.
 
 [field]#scope# [type]#[String]#::
 The OAuth v2.0 `scope` parameter.
+
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
 
 [field]#showPasswordField# [type]#[Boolean]#::
 A boolean that controls whether or not the `password` field is shown if there are domain-based identity providers. If there are domain based identity providers and the user types in an email address that is not managed by the identity provider, FusionAuth will then re-render this template with this variable set to `true`. This will indicate that the password field should be shown so that the user can complete their login.
@@ -911,6 +920,9 @@ The OAuth v2.0 `response_type` parameter.
 [field]#scope# [type]#[String]#::
 The OAuth v2.0 `scope` parameter.
 
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
+
 [field]#state# [type]#[String]#::
 The OAuth v2.0 `state` parameter.
 
@@ -957,6 +969,9 @@ Whether or not the user must use at least one non-alphabetic character in their 
 
 [field]#passwordValidationRules.requireNumber# [type]#[Boolean]#::
 Whether or not the user must use at least one numeric character in their password.
+
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
 
 
 === OAuth two-factor
@@ -1108,6 +1123,9 @@ Whether or not the user must use at least one non-alphabetic character in their 
 [field]#passwordValidationRules.requireNumber# [type]#[Boolean]#::
 Whether or not the user must use at least one numeric character in their password.
 
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
+
 
 === Change password complete
 
@@ -1127,9 +1145,12 @@ No page specific variables.
 [uri]#/password/forgot#
 --
 
-No page specific variables.
+==== Variables
 
-.{nbsp} +
+[.api]
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
+
 
 === Forgot password sent
 
@@ -1192,6 +1213,9 @@ Available Since Version 1.27.0.
 [field]#collectVerificationCode# [type]#[Boolean]#::
 When `true`, a form input is displayed to allow a user to enter the verification code. This occurs when [field]#Verification strategy# is set to `FormField` under email verification settings on the Application.
 
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
+
 [field]#verificationId# [type]#[String]#::
 The verification id that was included on as a URL parameter. This is the high entropy value that will be paired with the low entropy one time code to complete registration verification.
 
@@ -1206,6 +1230,9 @@ The verification id that was included on as a URL parameter. This is the high en
 ==== Variables
 
 [.api]
+[field]#showCaptcha# [type]#[Boolean]#::
+A boolean that controls whether or not to include captcha scripts and show the captcha challenge (or message for invisible captcha).
+
 [field]#verificationId# [type]#[String]#::
 The verification id that was included on as a URL parameter but was invalid. This page does a redirect if the verificationId is valid.
 
@@ -1237,6 +1264,6 @@ A set of URLs associated with all of the applications the user is registered for
 
 include::docs/v1/tech/themes/_theme-troubleshooting.adoc[]
 
-== Upgrading 
+== Upgrading
 
 include::docs/v1/tech/installation-guide/_theme_upgrade.adoc[]


### PR DESCRIPTION
New variable is available on the following pages:
- /email/verification-required
- /email/verify
- /oauth2/authorize
- /oauth2/passwordless
- /oauth2/register
- /password/change
- /password/forgot
- /registration/verification-required
- /registration/verify