### PR TITLE
Corrected link for idp initiated saml provider

### DIFF
--- a/site/docs/v1/tech/identity-providers/index.adoc
+++ b/site/docs/v1/tech/identity-providers/index.adoc
@@ -21,7 +21,7 @@ The following options are currently available.
 * link:/docs/v1/tech/identity-providers/linkedin/[LinkedIn]
 * link:/docs/v1/tech/identity-providers/openid-connect/[OpenID Connect]
 * link:/docs/v1/tech/identity-providers/samlv2/[SAML v2]
-* link:/docs/v1/tech/identity-providers/samlv2IdPInitiated/[SAML v2 IdP Initiated]
+* link:/docs/v1/tech/identity-providers/samlv2-idp-initiated/[SAML v2 IdP Initiated]
 * link:/docs/v1/tech/identity-providers/sony/[Sony]
 * link:/docs/v1/tech/identity-providers/steam/[Steam]
 * link:/docs/v1/tech/identity-providers/twitch/[Twitch]


### PR DESCRIPTION
The index.adoc has the wrong link