### PR TITLE
Fixed header number, which was a copy pasta error

### DIFF
--- a/site/license-faq.html
+++ b/site/license-faq.html
@@ -522,7 +522,7 @@ redirect_from:
       <div class="col-xs-12 col-lg-6">
         <div class="brochure flat-card">
           <div class="content">
-            <h3 id="29">Why isn't FusionAuth open source?</h3>
+            <h3 id="30">Why isn't FusionAuth open source?</h3>
             <p>
 	      The simple answer is that there are pros and cons to making our intellectual property open source. At this point we have chosen a closed source model for the core product but open source many components as well. All of the docs, website, client libraries, jwt library, mvc, and domains are open source.
             </p>


### PR DESCRIPTION
We have two ids of `29` which means the link in the header fails.