### PR TITLE
Update refresh tokens response

### DIFF
--- a/site/docs/src/json/jwt/refresh-get-response.json
+++ b/site/docs/src/json/jwt/refresh-get-response.json
@@ -12,7 +12,7 @@
           "type": "MOBILE"
         }
       },
-      "startInstant": 1487971808178
+      "startInstant": 1487971808178,
       "token": "xRxGGEpVawiUak6He367W3oeOfh+3irw+1G1h1jc",
       "userId": "858a4b01-62c8-4c2f-bfa7-6d018833bea7"
     }

--- a/site/docs/src/json/jwt/refresh-get-response.json
+++ b/site/docs/src/json/jwt/refresh-get-response.json
@@ -8,12 +8,11 @@
           "description": "Hooli Phone 8GB Work Phone",
           "lastAccessedAddress": "170.152.81.62",
           "lastAccessedInstant": 1487996477628,
-          "name": "Richard's Hooli Phone"
+          "name": "Richard's Hooli Phone",
           "type": "MOBILE"
         }
       },
-      "startInstant": 1631639364896,
-      "tenantId": "30663132-6464-6665-3032-326466613934",
+      "startInstant": 1487971808178
       "token": "xRxGGEpVawiUak6He367W3oeOfh+3irw+1G1h1jc",
       "userId": "858a4b01-62c8-4c2f-bfa7-6d018833bea7"
     }

--- a/site/docs/src/json/jwt/refresh-get-response.json
+++ b/site/docs/src/json/jwt/refresh-get-response.json
@@ -5,11 +5,15 @@
       "insertInstant": 1487971807175,
       "metaData": {
         "device": {
+          "description": "Hooli Phone 8GB Work Phone",
           "lastAccessedAddress": "170.152.81.62",
           "lastAccessedInstant": 1487996477628,
+          "name": "Richard's Hooli Phone"
           "type": "MOBILE"
         }
       },
+      "startInstant": 1631639364896,
+      "tenantId": "30663132-6464-6665-3032-326466613934",
       "token": "xRxGGEpVawiUak6He367W3oeOfh+3irw+1G1h1jc",
       "userId": "858a4b01-62c8-4c2f-bfa7-6d018833bea7"
     }

--- a/site/docs/v1/tech/apis/_device-type-list.adoc
+++ b/site/docs/v1/tech/apis/_device-type-list.adoc
@@ -1,0 +1,10 @@
+* `BROWSER`
+* `DESKTOP`
+* `LAPTOP`
+* `MOBILE`
+* `OTHER`
+* `SERVER`
+* `TABLET`
+* `TV`
+* `UNKNOWN`
+

--- a/site/docs/v1/tech/apis/_login-metadata-device.adoc
+++ b/site/docs/v1/tech/apis/_login-metadata-device.adoc
@@ -12,15 +12,7 @@ A human readable name of the device used.  This meta data is used to describe th
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional#::
 The type of device used. The following types may be specified:
 +
-* `BROWSER`
-* `DESKTOP`
-* `LAPTOP`
-* `MOBILE`
-* `OTHER`
-* `SERVER`
-* `TABLET`
-* `TV`
-* `UNKNOWN`
+include::./_device-type-list.adoc[]
 +
 This meta data is used to describe the refresh token that may be generated for this request.
 

--- a/site/docs/v1/tech/apis/_reconcile-request-body.adoc
+++ b/site/docs/v1/tech/apis/_reconcile-request-body.adoc
@@ -34,15 +34,7 @@ A human readable name of the device represented by the `device` parameter.
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional#::
 The type of device represented by the `device` parameter. The following types may be specified:
 +
-* `BROWSER`
-* `DESKTOP`
-* `LAPTOP`
-* `MOBILE`
-* `OTHER`
-* `SERVER`
-* `TABLET`
-* `TV`
-* `UNKNOWN`
+include::./_device-type-list.adoc[]
 
 [source,json]
 .Example Request JSON

--- a/site/docs/v1/tech/apis/_users-refresh-tokens-request-body.adoc
+++ b/site/docs/v1/tech/apis/_users-refresh-tokens-request-body.adoc
@@ -19,15 +19,7 @@ A human readable name of the device represented by the `device` parameter.
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional#::
 The type of device represented by the `device` parameter. The following types may be specified:
 +
-* `BROWSER`
-* `DESKTOP`
-* `LAPTOP`
-* `MOBILE`
-* `OTHER`
-* `SERVER`
-* `TABLET`
-* `TV`
-* `UNKNOWN`
+include::./_device-type-list.adoc[]
 
 [field]#refreshTokens``[x]``.startInstant# [type]#[String]# [required]#Required#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] of the start of this token. This value will be used to calculate the token expiration.

--- a/site/docs/v1/tech/apis/_users-refresh-tokens-request-body.adoc
+++ b/site/docs/v1/tech/apis/_users-refresh-tokens-request-body.adoc
@@ -13,6 +13,9 @@ A human readable description of the device represented by the `device` parameter
 [field]#metaData.device.lastAccessedAddress# [type]#[String]# [optional]#Optional#::
 The IP address of this login request.
 
+[field]#metaData.device.lastAccessedInstant# [type]#[Long]# [optional]#Optional#::
+The link:/docs/v1/tech/reference/data-types/#instants[instant] of this login request.
+
 [field]#metaData.device.name# [type]#[String]# [optional]#Optional#::
 A human readable name of the device represented by the `device` parameter.
 

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -390,11 +390,17 @@ A unique device identifier to represent the device for which this Refresh Token 
 [field]#refreshTokens``[x]``.insertInstant# [type]#[Long]#::
 The link:/docs/v1/tech/reference/data-types/#instants[instant] this Refresh Token was issued.
 
+[field]#refreshTokens``[x]``.id# [type]#[Long]#::
+The Id of the refresh token to be revoked.
+
 [field]#refreshTokens``[x]``.metaData.device.description# [type]#[String]#::
-A description of the device. For example, `iPhone 6S 32GB Work Phone`.
+A description of the device. For example, `BlackBerry 8GB Work Phone`.
 
 [field]#refreshTokens``[x]``.metaData.device.lastAccessedAddress# [type]#[String]#::
 The IP address of the device when this Refresh Token was last used.
+
+[field]#refreshTokens``[x]``.metaData.device.lastAccessedInstant# [type]#[Long]#::
+The link:/docs/v1/tech/reference/data-types/#instants[instant] this Refresh Token was last used.
 
 [field]#refreshTokens``[x]``.metaData.device.name# [type]#[String]#::
 The name of the device, for example `Mary's iPhone`.
@@ -402,15 +408,7 @@ The name of the device, for example `Mary's iPhone`.
 [field]#refreshTokens``[x]``.metaData.device.type# [type]#[String]#::
 The type of device represented by the `device` parameter. The following are possible types:
 +
-* `BROWSER`
-* `DESKTOP`
-* `LAPTOP`
-* `MOBILE`
-* `OTHER`
-* `SERVER`
-* `TABLET`
-* `TV`
-* `UNKNOWN`
+include::docs/v1/tech/apis/_device-type-list.adoc[]
 
 [field]#refreshTokens``[x]``.token# [type]#[String]#::
 The string representation of the encoded Refresh Token. This value should be kept in some sort of secure storage and treated as sensitive information.

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -93,6 +93,7 @@ include::docs/src/json/jwt/issue-get-response.json[]
 ----
 
 == Reconcile a JWT
+
 The Reconcile API is used to take a JWT issued by a third party identity provider as described by an link:/docs/v1/tech/apis/identity-providers/[Identity Provider]
 configuration and reconcile the User represented by the JWT to FusionAuth.
 
@@ -391,7 +392,7 @@ A unique device identifier to represent the device for which this Refresh Token 
 The link:/docs/v1/tech/reference/data-types/#instants[instant] this Refresh Token was issued.
 
 [field]#refreshTokens``[x]``.id# [type]#[Long]#::
-The Id of the refresh token to be revoked.
+The Id of the Refresh Token.
 
 [field]#refreshTokens``[x]``.metaData.device.description# [type]#[String]#::
 A description of the device. For example, `Hooli Phone 8GB Work Phone`.
@@ -411,17 +412,13 @@ The type of device represented by the `device` parameter. The following are poss
 include::docs/v1/tech/apis/_device-type-list.adoc[]
 
 [field]#refreshTokens``[x]``.startInstant# [type]#[Long]#::
-The link:/docs/v1/tech/reference/data-types/#instants[instant] at which the life of this Refresh Token started.
-
-[field]#refreshTokens``[x]``.tenantId# [type]#[UUID]#::
-Only used internal purposes for the SSO cookie.
+The link:/docs/v1/tech/reference/data-types/#instants[instant] of the start of this Refresh Token. This value will be used to calculate token expiration.
 
 [field]#refreshTokens``[x]``.token# [type]#[String]#::
 The string representation of the encoded Refresh Token. This value should be kept in some sort of secure storage and treated as sensitive information.
 
 [field]#refreshTokens``[x]``.userId# [type]#[UUID]#::
 The User Id of the user for which this Refresh Token was issued.
-
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -10,12 +10,12 @@ JSON Web Tokens (JWTs) are portable identity tokens. A JWT is issued after compl
 
 * <<Issue a JWT>>
 * <<Reconcile a JWT>>
-* <<Refresh a JWT>>
-* <<Validate a JWT>>
-* <<Vend a JWT>>
 * <<Retrieve Public Keys>>
+* <<Refresh a JWT>>
 * <<Retrieve Refresh Tokens>>
 * <<Revoke Refresh Tokens>>
+* <<Validate a JWT>>
+* <<Vend a JWT>>
 
 Here's a presentation discussing how to use JWTs in a microservices architecture:
 

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -394,7 +394,7 @@ The link:/docs/v1/tech/reference/data-types/#instants[instant] this Refresh Toke
 The Id of the refresh token to be revoked.
 
 [field]#refreshTokens``[x]``.metaData.device.description# [type]#[String]#::
-A description of the device. For example, `BlackBerry 8GB Work Phone`.
+A description of the device. For example, `Hooli Phone 8GB Work Phone`.
 
 [field]#refreshTokens``[x]``.metaData.device.lastAccessedAddress# [type]#[String]#::
 The IP address of the device when this Refresh Token was last used.
@@ -403,12 +403,18 @@ The IP address of the device when this Refresh Token was last used.
 The link:/docs/v1/tech/reference/data-types/#instants[instant] this Refresh Token was last used.
 
 [field]#refreshTokens``[x]``.metaData.device.name# [type]#[String]#::
-The name of the device, for example `Mary's iPhone`.
+The name of the device, for example `Richard's Hooli Phone`.
 
 [field]#refreshTokens``[x]``.metaData.device.type# [type]#[String]#::
 The type of device represented by the `device` parameter. The following are possible types:
 +
 include::docs/v1/tech/apis/_device-type-list.adoc[]
+
+[field]#refreshTokens``[x]``.startInstant# [type]#[Long]#::
+The link:/docs/v1/tech/reference/data-types/#instants[instant] at which the life of this Refresh Token started.
+
+[field]#refreshTokens``[x]``.tenantId# [type]#[UUID]#::
+Only used internal purposes for the SSO cookie.
 
 [field]#refreshTokens``[x]``.token# [type]#[String]#::
 The string representation of the encoded Refresh Token. This value should be kept in some sort of secure storage and treated as sensitive information.

--- a/site/docs/v1/tech/apis/passwordless.adoc
+++ b/site/docs/v1/tech/apis/passwordless.adoc
@@ -224,15 +224,7 @@ A human readable name of the device used during login.  This meta data is used t
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional#::
 The type of device used during login. The following types may be specified:
 +
-* `BROWSER`
-* `DESKTOP`
-* `LAPTOP`
-* `MOBILE`
-* `OTHER`
-* `SERVER`
-* `TABLET`
-* `TV`
-* `UNKNOWN`
+include::docs/v1/tech/apis/_device-type-list.adoc[]
 +
 This meta data is used to describe the refresh token that may be generated for this login request.
 


### PR DESCRIPTION
This updates the refresh tokens response. It fixes https://github.com/FusionAuth/fusionauth-site/issues/126

It also abstracts out the device type list to an include file.

It also added a few parameters to the import refresh token json.

Finally, it reordered the TOC of the jwt api doc to be in the same order as the sections are.

Note that I left off `tenantId` from the response as it is only used for internal purposes (SSO implementation details): https://github.com/FusionAuth/fusionauth-java-client/blob/master/src/main/java/io/fusionauth/domain/jwt/RefreshToken.java#L65