### PR TITLE
Add theme default tenant info

### DIFF
--- a/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
+++ b/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
@@ -3,7 +3,7 @@
 
 === Theme Errors Prevent Login
 
-If you happen to get into a situation where you have edited a template and it is causing errors that are preventing you from logging in, you can override the use of the UI templates to render a login form that lets you log in. To do this: 
+If you have edited a template and it is causing errors preventing you from logging in to FusionAuth, you can override the use of the UI templates. This will render a form allowing you to log in. To do this: 
 
 * Open your browser and access your FusionAuth admin UI. 
 * This will redirect you to the broken `/oauth2/authorize` page. 

--- a/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
+++ b/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
@@ -3,9 +3,14 @@
 
 === Theme Errors Prevent Login
 
-If you happen to get into a situation where you have edited a template and it is causing errors that are preventing you from logging in, you can override the use of the UI templates to render a login form that lets you log in. 
+If you happen to get into a situation where you have edited a template and it is causing errors that are preventing you from logging in, you can override the use of the UI templates to render a login form that lets you log in. To do this: 
 
-To do this, open your browser and access your FusionAuth admin UI. This will redirect you to the broken `/oauth2/authorize` page. Click in your browsers address bar and scroll to the end. Finally, add the String `&bypassTheme=true` to the end of the URL and hit the Enter key. This should render the default login page that ships with FusionAuth and allow you to log in and fix any errors you have.
+* Open your browser and access your FusionAuth admin UI. 
+* This will redirect you to the broken `/oauth2/authorize` page. 
+* Click in your browser's address bar and scroll to the end. 
+* Add the String `&bypassTheme=true` to the end of the URL and hit the Enter key. 
+
+This should render the default login page that ships with FusionAuth and allow you to log in and fix any errors you have.
 
 === Default Theme Used Incorrectly
 

--- a/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
+++ b/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
@@ -1,3 +1,20 @@
+
+// This expects to be brought in under a == heading, otherwise jekyll will complain.
+
+=== Theme Errors Preventing Login
+
 If you happen to get into a situation where you have edited a template and it is causing errors that are preventing you from logging in, you can override the use of the UI templates to render a login form that lets you log in. 
 
 To do this, open your browser and access your FusionAuth admin UI. This will redirect you to the broken `/oauth2/authorize` page. Click in your browsers address bar and scroll to the end. Finally, add the String `&bypassTheme=true` to the end of the URL and hit the Enter key. This should render the default login page that ships with FusionAuth and allow you to log in and fix any errors you have.
+
+=== Expected Default Theme Appearance
+
+Anytime a request is made to a themed page and we are unable to identify the tenant, the default tenant will be used. 
+
+This includes, but is not limited to:
+
+* The root page `/` when a `client_id` or `tenantId` is not provided.
+* Any themed pages such as /password/forgot when a `client_id` is not provided.
+* Edge case error conditions where we have lost the context for the application or tenant.
+
+If you see the default theme unexpectedly, check to make sure you are passing enough information to the page that it can determine the applicable application or tenant.

--- a/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
+++ b/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
@@ -9,9 +9,7 @@ To do this, open your browser and access your FusionAuth admin UI. This will red
 
 === Default Theme Used Incorrectly
 
-Anytime a request is made to a themed page and we are unable to identify the tenant, the default tenant will be used. 
-
-This includes, but is not limited to:
+Anytime a request is made to a themed page and we are unable to identify the tenant, the default tenant will be used. This includes, but is not limited to:
 
 * The root page `/` when a `client_id` or `tenantId` is not provided.
 * Any themed pages such as /password/forgot when a `client_id` is not provided.

--- a/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
+++ b/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
@@ -1,13 +1,13 @@
 
 // This expects to be brought in under a == heading, otherwise jekyll will complain.
 
-=== Theme Errors Preventing Login
+=== Theme Errors Prevent Login
 
 If you happen to get into a situation where you have edited a template and it is causing errors that are preventing you from logging in, you can override the use of the UI templates to render a login form that lets you log in. 
 
 To do this, open your browser and access your FusionAuth admin UI. This will redirect you to the broken `/oauth2/authorize` page. Click in your browsers address bar and scroll to the end. Finally, add the String `&bypassTheme=true` to the end of the URL and hit the Enter key. This should render the default login page that ships with FusionAuth and allow you to log in and fix any errors you have.
 
-=== Expected Default Theme Appearance
+=== Default Theme Used Incorrectly
 
 Anytime a request is made to a themed page and we are unable to identify the tenant, the default tenant will be used. 
 

--- a/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
+++ b/site/docs/v1/tech/themes/_theme-troubleshooting.adoc
@@ -18,6 +18,6 @@ Anytime a request is made to a themed page and we are unable to identify the ten
 
 * The root page `/` when a `client_id` or `tenantId` is not provided.
 * Any themed pages such as /password/forgot when a `client_id` is not provided.
-* Edge case error conditions where we have lost the context for the application or tenant.
+* Edge case error conditions where FusionAuth doesn't have context to determine the application or tenant.
 
-If you see the default theme unexpectedly, check to make sure you are passing enough information to the page that it can determine the applicable application or tenant.
+If you see the default theme unexpectedly, ensure sure you are passing required parameters to the page so that it can determine the applicable application or tenant.

--- a/site/docs/v1/tech/themes/index.adoc
+++ b/site/docs/v1/tech/themes/index.adoc
@@ -30,7 +30,7 @@ Continue reading below to see how to create a theme, how to preview a theme, exa
 * <<Preview a Theme>>
 * <<Example Code>>
 ** <<Example of Customizing the Authorize Page>>
-* <<Handling Failures>>
+* <<Troubleshooting>>
 * <<Upgrading>>
 
 == Create a Theme
@@ -141,7 +141,7 @@ Let's assume you want to change the header and footer across all of the pages in
 
 Once you make these changes, they will take effect on all of the pages listed above.
 
-== Handling Failures
+== Troubleshooting
 
 include::docs/v1/tech/themes/_theme-troubleshooting.adoc[]
 


### PR DESCRIPTION
This helps explain why your theme might not be working. No tenant id or client id? how do we know what theme to show?

Also tweaked the theme troubleshooting section while I was in there.