### PR TITLE
Updated event to specify that it only is fired in certain times.

### DIFF
--- a/site/docs/v1/tech/events-webhooks/events/jwt-refresh-token-revoke.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/jwt-refresh-token-revoke.adoc
@@ -12,7 +12,7 @@ This event is generated when a refresh token is revoked. The JSON includes eithe
 The following scenarios will cause this event to be generated:
 
 * A single Refresh Token is revoked
-* All Refresh Tokens owned by a single User are revoked
+* All Refresh Tokens owned by a single User are revoked (if there is at least one valid Refresh Token for this User)
 * All Refresh Tokens for an Application are revoked
 
 


### PR DESCRIPTION
That is, when there is a valid user token found.

This is a doc fix for: https://github.com/FusionAuth/fusionauth-issues/issues/261