### PR TITLE
Add refresh token userid appid call

### DIFF
--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -475,6 +475,12 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 [method]#DELETE# [uri]#/api/jwt/refresh``?applicationId=\{applicationId\}&userId=\{userId\}``#
 --
 
+[NOTE.since]
+====
+Available Since Version 1.19.0
+====
+
+
 ==== Request Parameters
 
 [.api]

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -468,7 +468,7 @@ The Id of the user to revoke issued Refresh Tokens.
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[]
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke all Refresh Tokens for one User for an Application
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke all Refresh Tokens issued to a User for an Application
 [.endpoint]
 .URI
 --
@@ -485,14 +485,6 @@ The Id of the application.
 The Id of the user.
 
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[]
-
-[.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke all Refresh Tokens issued to a User
-[.endpoint]
-.URI
---
-[method]#DELETE# [uri]#/api/jwt/refresh``?userId=\{userId\}``#
---
 
 [.api-authentication]
 link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke a single Refresh Token by Id

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -468,6 +468,33 @@ The Id of the user to revoke issued Refresh Tokens.
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[]
 
 [.api-authentication]
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke all Refresh Tokens for one User for an Application
+[.endpoint]
+.URI
+--
+[method]#DELETE# [uri]#/api/jwt/refresh``?applicationId=\{applicationId\}&userId=\{userId\}``#
+--
+
+==== Request Parameters
+
+[.api]
+[field]#applicationId# [type]#[UUID]# [required]#Required#::
+The Id of the application.
+
+[field]#userId# [type]#[UUID]# [required]#Required#::
+The Id of the user.
+
+include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[]
+
+[.api-authentication]
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke all Refresh Tokens issued to a User
+[.endpoint]
+.URI
+--
+[method]#DELETE# [uri]#/api/jwt/refresh``?userId=\{userId\}``#
+--
+
+[.api-authentication]
 link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke a single Refresh Token by Id
 [.endpoint]
 .URI

--- a/site/docs/v1/tech/events-webhooks/events/jwt-refresh-token-revoke.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/jwt-refresh-token-revoke.adoc
@@ -13,6 +13,7 @@ The following scenarios will cause this event to be generated:
 
 * A single Refresh Token is revoked
 * All Refresh Tokens owned by a single User are revoked
+* All Refresh Tokens owned by a single User for an Application are revoked
 * All Refresh Tokens for an Application are revoked
 
 


### PR DESCRIPTION
We didn't document that you could provide both the userId and applicationId and revoke tokens at the intersection.