### PR TITLE
Add default entity info as include for kickstart

### DIFF
--- a/site/docs/v1/tech/installation-guide/kickstart.adoc
+++ b/site/docs/v1/tech/installation-guide/kickstart.adoc
@@ -25,7 +25,7 @@ If you'd like to run a Kickstart file in a Docker container, please check out th
 ** <<Using Environment Variables>>
 ** <<Adding API Requests>>
 * <<Advanced Concepts>>
-** <<Referencing Default Entities>>
+** <<Referencing Defaults>>
 ** <<Modify the Default Tenant Id>>
 ** <<Set Your License Id>>
 ** <<Settings>>
@@ -277,15 +277,15 @@ In this example we will modify the restricted API key example from above to furt
 
 == Advanced Concepts
 
-=== Referencing Default Entities
+=== Referencing Defaults
 
-There are some entities in FusionAuth with fixed Ids, such as the default theme or FusionAuth application.
+There are some items in FusionAuth with default, fixed Ids, such as the default theme or the FusionAuth application.
 
-Here are the default entities and their Ids:
+Here are the default items and their Ids:
 
 include::docs/v1/tech/shared/_default-entities.adoc[]
 
-With the default entity Id, you can build other entities in your Kickstart file. For example, you may copy the default theme and modify the copy.
+With the known Id, you can build other configuration in your Kickstart file that depend on or copy them. For example, you may copy the default theme and modify the copied theme via Kicstart, or you may create a new tenant but set the tenant Id token signing key to one of the shadow keys.
 
 === Modify the Default Tenant Id
 

--- a/site/docs/v1/tech/installation-guide/kickstart.adoc
+++ b/site/docs/v1/tech/installation-guide/kickstart.adoc
@@ -279,9 +279,13 @@ In this example we will modify the restricted API key example from above to furt
 
 === Referencing Default Entities
 
-Review the link:https://fusionauth.io/docs/v1/tech/reference/limitations/#default-entities[default entities] documentation for entities with fixed Ids such as the default theme or FusionAuth application. 
+There are some entities in FusionAuth with fixed Ids, such as the default theme or FusionAuth application.
 
-With that Id, you can then, for example, copy the default theme and modify the copied theme with Kickstart.
+Here are the default entities and their Ids:
+
+include::docs/v1/tech/shared/_default-entities.adoc[]
+
+With the default entity Id, you can build other entities in your Kickstart file. For example, you may copy the default theme and modify the copy.
 
 === Modify the Default Tenant Id
 

--- a/site/docs/v1/tech/reference/limitations.adoc
+++ b/site/docs/v1/tech/reference/limitations.adoc
@@ -67,9 +67,7 @@ See the link:/docs/v1/tech/apis/keys/[Keys API] for more, including supported al
 
 == Default Configuration
 
-There are a number of default, previously configured items in FusionAuth which cannot be removed. Additionally, there are limits to modifying them.
-
-These defaults include:
+There are a number of items in FusionAuth created by default and which cannot be removed. Additionally, there are sometimes limits to modifying them. These defaults include:
 
 include::docs/v1/tech/shared/_default-entities.adoc[]
 

--- a/site/docs/v1/tech/reference/limitations.adoc
+++ b/site/docs/v1/tech/reference/limitations.adoc
@@ -14,7 +14,7 @@ FusionAuth has the following known limits.
 * <<Field Lengths>>
 * <<API Keys>>
 * <<Minimum Key Lengths>>
-* <<Default Entities>>
+* <<Default Configuration>>
 * <<SAML>>
 * <<Identifiers>>
 * <<Data Type Changes In 'data' Fields>>
@@ -65,11 +65,11 @@ For ECC keys, the minimum length is 256.
 
 See the link:/docs/v1/tech/apis/keys/[Keys API] for more, including supported algorithms and lengths.
 
-== Default Entities
+== Default Configuration
 
-There are a number of default entities which cannot be removed. Additionally, there are limits to modifying these entities. 
+There are a number of default, previously configured items in FusionAuth which cannot be removed. Additionally, there are limits to modifying them.
 
-These default entities include:
+These defaults include:
 
 include::docs/v1/tech/shared/_default-entities.adoc[]
 

--- a/site/docs/v1/tech/reference/limitations.adoc
+++ b/site/docs/v1/tech/reference/limitations.adoc
@@ -67,18 +67,11 @@ See the link:/docs/v1/tech/apis/keys/[Keys API] for more, including supported al
 
 == Default Entities
 
-There are a number of default entities which cannot be removed. Additionally, there are limits to modifying these entities.
+There are a number of default entities which cannot be removed. Additionally, there are limits to modifying these entities. 
 
-This includes:
+These default entities include:
 
-* The Default Tenant
-* The FusionAuth application, which resides in the Default tenant. This will always have the Id `3c219e58-ed0e-4b18-ad48-f4f92793ae32`.
-* The Default theme, which is read only. This will always have the Id `75a068fd-e94b-451a-9aeb-3ddb9a3b5987`.
-* The FusionAuth application roles, which may be assigned to users, but are immutable. View the link:/docs/v1/tech/core-concepts/roles/[roles documentation] for the fixed Ids of each role.
-* Three OpenID Connect shadow keys. These may not be modified or removed. When any of these keys are selected as the signing key for the Id Token the client secret defined by the FusionAuth Application will be used to sign the token.
-** SHA-256. This will always have the Id `092dbedc-30af-4149-9c61-b578f2c72f59`. 
-** SHA-384. This will always have the Id `4b8f1c06-518e-45bd-9ac5-d549686ae02a`.
-** SHA-512. This will always have the Id `c753a44d-7f2e-48d3-bc4e-c2c16488a23b`.
+include::docs/v1/tech/shared/_default-entities.adoc[]
 
 == SAML
 

--- a/site/docs/v1/tech/shared/_default-entities.adoc
+++ b/site/docs/v1/tech/shared/_default-entities.adoc
@@ -1,0 +1,11 @@
+* The Default Tenant
+* The FusionAuth application, which resides in the Default tenant. This will always have the Id `3c219e58-ed0e-4b18-ad48-f4f92793ae32`.
+* The Default theme, which is read only. This will always have the Id `75a068fd-e94b-451a-9aeb-3ddb9a3b5987`.
+* The FusionAuth application roles, which may be assigned to users, but are immutable. View the link:/docs/v1/tech/core-concepts/roles/[roles documentation] for the fixed Ids of each role.
+* Three OpenID Connect shadow keys. These may not be modified or removed. When any of these keys are selected as the signing key for the Id Token the client secret defined by the FusionAuth Application will be used to sign the token.
+** SHA-256. This will always have the Id `092dbedc-30af-4149-9c61-b578f2c72f59`. 
+** SHA-384. This will always have the Id `4b8f1c06-518e-45bd-9ac5-d549686ae02a`.
+** SHA-512. This will always have the Id `c753a44d-7f2e-48d3-bc4e-c2c16488a23b`.
+
+== SAML
+

--- a/site/docs/v1/tech/shared/_default-entities.adoc
+++ b/site/docs/v1/tech/shared/_default-entities.adoc
@@ -1,9 +1,10 @@
-* The Default Tenant
+* The Default tenant, which will always exist.
 * The FusionAuth application, which resides in the Default tenant. This will always have the Id `3c219e58-ed0e-4b18-ad48-f4f92793ae32`.
-* The Default theme, which is read only. This will always have the Id `75a068fd-e94b-451a-9aeb-3ddb9a3b5987`.
-* The FusionAuth application roles, which may be assigned to users, but are immutable. View the link:/docs/v1/tech/core-concepts/roles/[roles documentation] for the fixed Ids of each role.
-* Three OpenID Connect shadow keys. These may not be modified or removed. When any of these keys are selected as the signing key for the Id Token the client secret defined by the FusionAuth Application will be used to sign the token.
+* The Default theme, which is always read only. This will always have the Id `75a068fd-e94b-451a-9aeb-3ddb9a3b5987`.
+* The FusionAuth application roles, which may be assigned to users, but are read only. View the link:/docs/v1/tech/core-concepts/roles/[roles documentation] for the immutable Ids of each role.
+* Three OpenID Connect shadow keys. These may not be modified or removed. When any of these keys are selected as the signing key for the Id Token, the Client Secret defined by the FusionAuth application will be used to sign the token. This is per https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.10.1[section 10.1 of the OIDC specification].
 ** SHA-256. This will always have the Id `092dbedc-30af-4149-9c61-b578f2c72f59`. 
 ** SHA-384. This will always have the Id `4b8f1c06-518e-45bd-9ac5-d549686ae02a`.
 ** SHA-512. This will always have the Id `c753a44d-7f2e-48d3-bc4e-c2c16488a23b`.
 * The FusionAuth connector. This will always have the Id `e3306678-a53a-4964-9040-1c96f36dda72`.
+

--- a/site/docs/v1/tech/shared/_default-entities.adoc
+++ b/site/docs/v1/tech/shared/_default-entities.adoc
@@ -7,5 +7,3 @@
 ** SHA-384. This will always have the Id `4b8f1c06-518e-45bd-9ac5-d549686ae02a`.
 ** SHA-512. This will always have the Id `c753a44d-7f2e-48d3-bc4e-c2c16488a23b`.
 
-== SAML
-


### PR DESCRIPTION
This is a fix for https://github.com/FusionAuth/fusionauth-issues/issues/459

Also, I included the default entity ids rather than pointing a link.

Reviewed other defaults (grepping for static constants in the java-client, looking at Kickstart java).