### PR TITLE
Small change to the user memberships

### DIFF
--- a/site/docs/v1/tech/apis/_import-users-request-body.adoc
+++ b/site/docs/v1/tech/apis/_import-users-request-body.adoc
@@ -81,7 +81,7 @@ The link:/docs/v1/tech/reference/data-types/#instants[instant] when user was cre
 The User's last name.
 
 [field]#users``[x]``.memberships# [type]#[Array]# [optional]#Optional#::
-The list of memberships for the User.
+The list of group memberships for the User.
 
 [field]#users``[x]``.memberships``[x]``.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the User for this membership that should be persisted.

--- a/site/docs/v1/tech/apis/_user-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-request-body.adoc
@@ -81,9 +81,6 @@ ifeval::["{http_method}" == "POST"]
 [field]#user.memberships# [type]#[Array]# [optional]#Optional#::
 The list of group memberships for the User.
 
-[field]#user.memberships``[x]``.data# [type]#[Object]# [optional]#Optional#::
-An object that can hold any information about the User for this membership that should be persisted.
-
 [field]#user.memberships``[x]``.groupId# [type]#[UUID]# [required]#Required#::
 The Id of the Group of this membership.
 

--- a/site/docs/v1/tech/apis/_user-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-request-body.adoc
@@ -79,7 +79,7 @@ The User's middle name.
 
 ifeval::["{http_method}" == "POST"]
 [field]#user.memberships# [type]#[Array]# [optional]#Optional#::
-The list of memberships for the User.
+The list of group memberships for the User.
 
 [field]#user.memberships``[x]``.data# [type]#[Object]# [optional]#Optional#::
 An object that can hold any information about the User for this membership that should be persisted.

--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -95,7 +95,7 @@ The link:/docs/v1/tech/reference/data-types/#instants[instant] when the User was
 
 ifndef::create_user[]
 [field]#user.memberships# [type]#[Array]#::
-The list of memberships for the User.
+The list of group memberships for the User.
 
 [field]#user.memberships``[x]``.data# [type]#[Object]#::
 An object that can hold any information about the User for this membership that should be persisted.

--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -97,9 +97,6 @@ ifndef::create_user[]
 [field]#user.memberships# [type]#[Array]#::
 The list of group memberships for the User.
 
-[field]#user.memberships``[x]``.data# [type]#[Object]#::
-An object that can hold any information about the User for this membership that should be persisted.
-
 [field]#user.memberships``[x]``.groupId# [type]#[UUID]#::
 The Id of the Group of this membership.
 

--- a/site/docs/v1/tech/apis/_users-response-body.adoc
+++ b/site/docs/v1/tech/apis/_users-response-body.adoc
@@ -60,7 +60,7 @@ The User's last name.
 The last link:/docs/v1/tech/reference/data-types/#instants[instant] when the User was updated. Note: webhooks may be another effective way to track user changes.
 
 [field]#users``[x]``.memberships# [type]#[Array]#::
-The list of memberships for the User.
+The list of group memberships for the User.
 
 [field]#users``[x]``.memberships``[x]``.data# [type]#[Object]#::
 An object that can hold any information about the User for this membership that should be persisted.


### PR DESCRIPTION
- Add a bit of clarity around `user.memberships`.  Specifically, these memberships are to groups.
- Remove references to the memberships[x].data on the user object via API calls
