### PR TITLE
Updated api keys to only show enterprise note on request API params.

### DIFF
--- a/DocsDevREADME.md
+++ b/DocsDevREADME.md
@@ -58,7 +58,8 @@ For API docs:
   ```
   This field is required when [field]#theOtherField.enabled# is set to true.
   ```
-- If a feature is only available when using a paid edition, use the `shared/_premium-edition-blurb-api.adoc` fragment for API fields, and `shared/_premium-edition-blurb.adoc` for any other location where the feature is mentioned in docs.
+- If a feature is only available when using a paid edition, use the `shared/_premium-edition-blurb-api.adoc` fragment for API fields, and `shared/_premium-edition-blurb.adoc` for any other location where the feature is mentioned in docs. Only mark the request API fields.
+- If a feature is only available when using a enterprise edition, use the `shared/_enterprise-edition-blurb-api.adoc` fragment for API fields, and `shared/_enterprise-edition-blurb.adoc` for any other location where the feature is mentioned in docs. Only mark the request API fields with this.
 - If you are working in the `/api/identity-providers` folder there is a `README` there to help you understand the structure and layout of the documentation for the Identity Providers API.
 
 For blog posts:

--- a/site/docs/v1/tech/apis/_apikey-create-update-response-body.adoc
+++ b/site/docs/v1/tech/apis/_apikey-create-update-response-body.adoc
@@ -16,8 +16,6 @@ The link:/docs/v1/tech/reference/data-types/#instants[instant] when the API key 
 
 [field]#apiKey.ipAccessControlListId# [type]#[UUID]#::
 The Id of the link:/docs/v1/tech/apis/ip-acl/[IP Access Control List] limiting access to this API key.
-+
-include::../shared/_enterprise-edition-blurb-api.adoc[]
 
 [field]#apiKey.key# [type]#[String]#::
 The API key value, this is the string value you will use in the Authorization header to link:/docs/v1/tech/apis/authentication/[authenticate API] requests.

--- a/site/docs/v1/tech/apis/_apikey-response-body.adoc
+++ b/site/docs/v1/tech/apis/_apikey-response-body.adoc
@@ -9,8 +9,6 @@ The link:/docs/v1/tech/reference/data-types/#instants[instant] when the API key 
 
 [field]#apiKey.ipAccessControlListId# [type]#[UUID]#::
 The Id of the link:/docs/v1/tech/apis/ip-acl/[IP Access Control List] limiting access to this API key.
-+
-include::../shared/_enterprise-edition-blurb-api.adoc[]
 
 [field]#apiKey.key# [type]#[String]#::
 The API key value, this is the string value you will use in the Authorization header to link:/docs/v1/tech/apis/authentication/[authenticate API] requests.


### PR DESCRIPTION
This is what we do on the application api pages, so standardizing.