### PR TITLE
Add note that the identity provider must exist.

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -36,7 +36,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 
 [.api]
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::
-The Id of the identity provider.
+The Id of the identity provider. This identity provider must exist.
 
 [field]#identityProviderUserId# [type]#[String]# [required]#Required#::
 The Id for the User that is provided by the identity provider. This is the value that will allow FusionAuth to link this user on future logins. It is expected to be immutable.


### PR DESCRIPTION
I got caught up because I used one of the identity providers with a fixed id (google) but hadn't created the identity provider in FusionAuth. I was getting an error message about the identity provider being absent.