### PR TITLE
Updated to have these actions default to JWT authentication

### DIFF
--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -493,14 +493,14 @@ The Id of the user.
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[]
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke a single Refresh Token by Id
+link:/docs/v1/tech/apis/authentication#jwt-key-authentication[icon:id-badge[type=fas]] Revoke a single Refresh Token by Id
 [.endpoint]
 .URI
 --
 [method]#DELETE# [uri]#/api/jwt/refresh/``\{tokenId\}``#
 --
 
-This API may be authenticated using a JWT. If using JWT authentication, the JWT owner and token owner must match. See link:/docs/v1/tech/apis/authentication/[Authentication] for examples of authenticating using a JWT. 
+This API may be authenticated using a JWT or an API key. If using JWT authentication, the JWT owner and token owner must match. See link:/docs/v1/tech/apis/authentication/[Authentication] for examples of authenticating using a JWT. 
 
 ==== Request Parameters
 
@@ -511,14 +511,14 @@ The Id of the refresh token to be revoked.
 When deleting a single token, using this parameter is recommended. Using this parameter does not expose the refresh token.
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Revoke a single Refresh Token by value
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:id-badge[type=fas]] Revoke a single Refresh Token by value
 [.endpoint]
 .URI
 --
 [method]#DELETE# [uri]#/api/jwt/refresh``?token=\{token\}``#
 --
 
-This API may be authenticated using a JWT. If using JWT authentication, the JWT owner and token owner must match. See link:/docs/v1/tech/apis/authentication/[Authentication] for examples of authenticating using a JWT. 
+This API may be authenticated using a JWT or an API key. If using JWT authentication, the JWT owner and token owner must match. See link:/docs/v1/tech/apis/authentication/[Authentication] for examples of authenticating using a JWT. 
 
 ==== Request Parameters
 

--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -493,7 +493,7 @@ The Id of the user.
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[]
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#jwt-key-authentication[icon:id-badge[type=fas]] Revoke a single Refresh Token by Id
+link:/docs/v1/tech/apis/authentication#jwt-authentication[icon:id-badge[type=fas]] Revoke a single Refresh Token by Id
 [.endpoint]
 .URI
 --
@@ -511,7 +511,7 @@ The Id of the refresh token to be revoked.
 When deleting a single token, using this parameter is recommended. Using this parameter does not expose the refresh token.
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:id-badge[type=fas]] Revoke a single Refresh Token by value
+link:/docs/v1/tech/apis/authentication#jwt-authentication[icon:id-badge[type=fas]] Revoke a single Refresh Token by value
 [.endpoint]
 .URI
 --


### PR DESCRIPTION
This is less common. The text makes it clear that you can use either an API key or a JWT.