### PR TITLE
Tweaks OIDC lambda

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_openid-connect-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_openid-connect-request-body.adoc
@@ -70,11 +70,11 @@ The client authentication method to use with the OpenID Connect identity provide
 
 ifdef::update[]
 [field]#identityProvider.oauth2.emailClaim# [type]#[String]# [required]#Required# [since]#Available since 1.17.3#::
-An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address.
+An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address. The Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
 endif::[]
 ifndef::update[]
 [field]#identityProvider.oauth2.emailClaim# [type]#[String]# [optional]#Optional# [default]#defaults to `email`# [since]#Available since 1.17.3#::
-An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address.
+An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address. The Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
 endif::[]
 
 [field]#identityProvider.oauth2.issuer# [type]#[String]# [optional]#Optional#::

--- a/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
+++ b/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
@@ -26,9 +26,18 @@ This lambda must contain a function named `reconcile` that takes at least three 
 * `user` - the FusionAuth User object
 * `registration` - the FusionAuth UserRegistration object
 * `jwt` - the JSON payload returned from the OpenID Connect Userinfo endpoint
-* `id_token` - the JSON payload returned in the `id_token` when available. This parameter may not always be provided.
+* `id_token` - the JSON payload returned in the `id_token` when available. This parameter may not be provided and will be `undefined` in that case.
 
-The two FusionAuth objects are well documented here in the link:/docs/v1/tech/apis/users/[User API] and link:/docs/v1/tech/apis/registrations/[Registration API] documentation. The JWT object that contains the payload from the Userinfo endpoint may contain well known OpenID Connect registered claims as well as any custom claims defined by the identity provider. The `id_token` will be provided to the Lambda when it is returned by the Identity Provider and it has been signed using the `client_secret` and an HMAC algorithm. If the `id_token` is signed using an asymmetric key-pair it will not be available to the Lambda.
+The two FusionAuth objects are well documented in the link:/docs/v1/tech/apis/users/[User API] and link:/docs/v1/tech/apis/registrations/[Registration API] documentation. 
+
+The JWT object that contains the payload from the Userinfo endpoint. It may contain well known OpenID Connect registered claims as well as any custom claims defined by the Identity Provider. 
+
+The `id_token` will be provided to the Lambda only:
+
+* when it is returned by the Identity Provider and 
+* it has been signed using the `client_secret` and an HMAC algorithm
+
+In particular, if the `id_token` is signed using an asymmetric key-pair, it will not be available to the Lambda.
 
 == Assigning the lambda
 
@@ -44,7 +53,12 @@ include::docs/v1/tech/lambdas/_openid-connect-example-lambda.adoc[]
 
 If the JWT from the OIDC identity provider does not come back with an email claim you can add your own. This claim is `email` by default but may be changed with the `oauth2.emailClaim` as documented in the link:/docs/v1/tech/apis/identity-providers/openid-connect/[API docs].
 
-If the Userinfo response available to you in the lambda has unique user information, you can build a fake email address from it.
+[NOTE.note]
+====
+This capability is available beginning in version `1.31.0`. It was also available from `1.17.3` to `1.28.0`.
+====
+
+If the Userinfo or Id Token available to you in the lambda has unique user information, you can build a fake email address from it.
 
 Here, the `sub` claim is the unique user id, and we're building an email address:
 
@@ -55,7 +69,5 @@ function(user, registration, jwt) {
 }
 ```
 
-Make sure you pick an email address for a domain you control to avoid malicious attacks. This will run your lambda twice.
-
-This capability is available beginning in version `1.31.0`.
+Make sure you pick an email address for a domain you control to avoid malicious attacks. Modifying the username or email address will cause your lambda to be run two times.
 

--- a/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
+++ b/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
@@ -39,17 +39,17 @@ The `id_token` will be provided to the Lambda only:
 
 In particular, if the `id_token` is signed using an asymmetric key-pair, it will not be available to the Lambda.
 
-== Assigning the lambda
+== Assigning the Lambda
 
 Once a lambda is created, you may assign it to one or more OpenID Connect IdPs in the IdP configuration.
 
 Navigate to [breadcrumb]#Settings -> Identity Providers# and select your existing an OpenID Connect configuration or click [breadcrumb]#Add provider# and select OpenID Connect if it has not yet been configured.
 
-== Example lambda
+== Example Lambda
 
 include::docs/v1/tech/lambdas/_openid-connect-example-lambda.adoc[]
 
-=== Workarounds
+== Modifying Email and Username Claims
 
 If the JWT from the OIDC identity provider does not come back with an email claim you can add your own. This claim is `email` by default but may be changed with the `oauth2.emailClaim` as documented in the link:/docs/v1/tech/apis/identity-providers/openid-connect/[API docs].
 
@@ -71,3 +71,4 @@ function(user, registration, jwt) {
 
 Make sure you pick an email address for a domain you control to avoid malicious attacks. Modifying the username or email address will cause your lambda to be run two times.
 
+You can't modify an email claim if the linking strategy is username or the username claim if the linking strategy is email. Modifying the claim that is not being linked on will be ignored because doing so could cause collisions if you were to change the linking strategy later.

--- a/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
+++ b/site/docs/v1/tech/lambdas/openid-connect-response-reconcile.adoc
@@ -69,6 +69,6 @@ function(user, registration, jwt) {
 }
 ```
 
-Make sure you pick an email address for a domain you control to avoid malicious attacks. Modifying the username or email address will cause your lambda to be run two times.
+Make sure you pick an email address for a domain you control to avoid malicious attacks. Modifying the username or email address may cause your lambda to be run two times. It will be run again if you modify the linking strategy claim and an existing user is found that matches.
 
 You can't modify an email claim if the linking strategy is username or the username claim if the linking strategy is email. Modifying the claim that is not being linked on will be ignored because doing so could cause collisions if you were to change the linking strategy later.


### PR DESCRIPTION
Per discussion on slack.

* Makes id token value clearer in docs
* Adds note about how we find email claim (I didn't see the username claim specified?) in both access and id token
* Updated with version info (when you could modify the email/username claim)