### PR TITLE
Identity provider missing required field

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_samlv2-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_samlv2-request-body.adoc
@@ -51,7 +51,7 @@ The name of the email claim (Attribute in the `Assertion` element) in the SAML r
 Determines if this provider is enabled. If it is false then it will be disabled globally.
 
 ifndef::samlv2_idp_initiated[]
-[field]#identityProvider.idpEndpoint# [type]#[String]# [optional]#Required#::
+[field]#identityProvider.idpEndpoint# [type]#[String]# [required]#Required#::
 The SAML v2 login page of the identity provider. Must be a valid URL.
 endif::[]
 

--- a/site/docs/v1/tech/apis/identity-providers/_samlv2-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_samlv2-request-body.adoc
@@ -51,8 +51,8 @@ The name of the email claim (Attribute in the `Assertion` element) in the SAML r
 Determines if this provider is enabled. If it is false then it will be disabled globally.
 
 ifndef::samlv2_idp_initiated[]
-[field]#identityProvider.idpEndpoint# [type]#[String]# [optional]#Optional#::
-The SAML v2 login page of the identity provider.
+[field]#identityProvider.idpEndpoint# [type]#[String]# [optional]#Required#::
+The SAML v2 login page of the identity provider. Must be a valid URL.
 endif::[]
 
 ifdef::samlv2_idp_initiated[]
@@ -71,7 +71,7 @@ The specified Lambda Id must be of type `SAMLv2Reconcile`.
 include::_identity-provider-linking-strategy-request-parameter.adoc[]
 
 [field]#identityProvider.name# [type]#[String]# [required]#Required#::
-The name of this SAML v2 identity provider. This is only used for display purposes.
+The name of this SAML v2 identity provider. This is only used for display purposes. Must be unique across all identity providers.
 
 ifndef::samlv2_idp_initiated[]
 [field]#identityProvider.postRequest# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.20.0#::


### PR DESCRIPTION
IdpEndpoint is required for saml identity providers. It was marked as optional.