### PR TITLE
Updated login_hint desc to include URL encoding.

### DIFF
--- a/site/docs/v1/tech/identity-providers/index.adoc
+++ b/site/docs/v1/tech/identity-providers/index.adoc
@@ -96,7 +96,7 @@ Hints currently work with most Identity Providers with the exception of HYPR and
 
 An Identity Provider Id is appended to the Login URL for an application using the `idp_hint` request parameter. For example, to send a user directly to a login page for an OIDC identity provider with the id `44449786-3dff-42a6-aac6-1f1ceecb6c46`, you'd append `&idp_hint=44449786-3dff-42a6-aac6-1f1ceecb6c46`.
 
-An email address or domain may be provided in the `login_hint` request parameter. For example, to send a user directly to the login page of an OIDC IdP configured with a domain of `example.com`, you'd append `&login_hint=example.com` to the application's Login URL. The use of this parameter is up to the Identity Provider, so adding this parameter may or may not be supported by the Identity Provider you are using.
+An email address or domain may be provided in the `login_hint` request parameter. For example, to send a user directly to the login page of an OIDC IdP configured with a domain of `example.com`, you'd append `&login_hint=example.com` to the application's Login URL. This value must be URL encoded. The use of this parameter is up to the Identity Provider, so adding this parameter may or may not be supported by the Identity Provider you are using.
 
 You can read more about the `login_hint` and `idp_hint` parameters in the link:/docs/v1/tech/oauth/endpoints/[OAuth Endpoints documentation].
 

--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -77,6 +77,8 @@ See the link:/docs/v1/tech/themes/localization/[Theme Localization] documentatio
 [field]#login_hint# [type]#[String]# [optional]#Optional# [since]#Available since 1.19.0#::
 An optional email address or top level domain that can allow you to bypass the FusionAuth login page when using managed domains.
 +
+This must be URL encoded. For example, an email address that contains `+` must encode that value as `%2B`.
++
 If using managed domains, adding this request parameter will cause the FusionAuth login page to be skipped, and instead a `302` will be returned with a `Location` header of the IdP login URL. The end result is functionally equivalent to the end entering their email address when using the IdP configuration with managed domains.
 +
 If not using managed domains, providing an email address using this parameter prepopulates the email address in the login page.


### PR DESCRIPTION
`login_hint` must be URL encoded.