### PR TITLE
User must be registered for an application to get a refresh token.

### DIFF
--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -10,7 +10,7 @@ endif::[]
 [field]#refreshToken# [type]#[String]#::
 The refresh token that can be used to obtain a new access token once the provided one has expired.
 +
-Because a refresh token is per user and per application, this value will only be returned when an [field]#applicationId# was provided on the login request.
+Because a refresh token is per user and per application, this value will only be returned when an [field]#applicationId# was provided on the login request and the user is registered to the application.
 +
 You must explicitly allow generation of refresh tokens when using the Login API. Configure the [field]#application.loginConfiguration.generateRefreshTokens# setting via the API or enable the setting by navigating to the [breadcrumb]#Application -> My Application -> Security# tab.
 


### PR DESCRIPTION
This came out of https://github.com/FusionAuth/fusionauth-issues/issues/782

Internal: I looked at the code in `addTokensToResponse` and it appears that the user must be registered for an application and the application must exist before a refresh token is provided in the response.