### PR TITLE
Update generic messenger doc

### DIFF
--- a/site/docs/src/json/messengers/generic-message-request.json
+++ b/site/docs/src/json/messengers/generic-message-request.json
@@ -1,0 +1,5 @@
+{
+  "phoneNumber": "3035551212",
+  "textMessage": "Two Factor Code: 111111",
+  "type": "SMS"
+}

--- a/site/docs/v1/tech/guides/multi-factor-authentication.adoc
+++ b/site/docs/v1/tech/guides/multi-factor-authentication.adoc
@@ -513,6 +513,7 @@ To migrate this functionality:
 If you have other MFA methods that you'd like to use with FusionAuth, you have a few options:
 
 * link:https://fusionauth.io/docs/v1/tech/core-concepts/roadmap/[Check out the roadmap guidance] to see if your desired method is going to be added soon. If not, the roadmap documents various ways you can request a new feature.
+* If you can identify a user using their phone number and can set up a small application to process JSON requests from FusionAuth, you may use a link:/docs/v1/tech/messengers/generic-messenger/[custom Generic Messenger] to send a code as a second factor. This works well with transports like SMS or any other messaging protocol.
 * If you can send a code out of band, you may use step up auth to protect all the pages in your system. As soon as a user logs in, require step up auth. Users don't have to have MFA enabled to use step up.
 * If your additional factor can receive a webhook, configure your webhooks to be transactional and send one on login. The service can then perform the MFA check, perhaps doing something like fingerprint recognition. If any status other than `200` is returned, the login will fail. The downside of this approach is that the message to the end user won't be helpful, and that MFA will be required on every login. Here is an link:/blog/2020/08/13/locking-an-account-with-breached-password/[example of a webhook stopping a login].
 * Use the link:/docs/v1/tech/apis/login/[Login API] and build custom login flows, inserting your custom MFA functionality where needed.

--- a/site/docs/v1/tech/messengers/generic-messenger.adoc
+++ b/site/docs/v1/tech/messengers/generic-messenger.adoc
@@ -84,23 +84,18 @@ You also can test your generic messenger configuration. By hitting `Test generic
 == Writing the Generic Message Receiver
 
 You need to write a server side component, a receiver, which will be deployed at a URL to consume the message sent from FusionAuth. At that point, it can proxy the request to any third party messaging service.
-In other words, a Generic Messenger is a thin coordination layer between FusionAuth and other messaging services with the proper permissions, code and configuration to relay a message.
-This component can be written in any language that can consume a JSON message.
+In other words, a FusionAuth Generic Messenger is a thin coordination layer between FusionAuth and other messaging services. An application with the proper permissions, code and configuration to relay a message must exist at the configured URL.
+This receiver component may be written in any language that can consume a JSON message.
 
 === Request 
 
 The request to your endpoint will be delivered as JSON.
-When your application receives this message from FusionAuth, it should take whatever steps necessary to send the message:
+When your application receives this message from FusionAuth, it should take whatever steps necessary to send the message, such as:
 
 * call into a SDK provided by the third party
-* build an API request to an endpoint
+* make an API request to a vendor provided endpoint
+* call multiple internal APIs
 * anything else that may be required
-
-[source,json]
-.Example Message Payload JSON
-----
-include::docs/src/json/messengers/generic-message-request.json[]
-----
 
 [.api]
 [field]#phoneNumber# [type]#[String]#::
@@ -112,11 +107,17 @@ The message text to send. This is built from the configured link:/https://fusion
 [field]#type# [type]#[String]#::
 The type of the message. This will always be `SMS`.
 
+[source,json]
+.Example Message Payload JSON
+----
+include::docs/src/json/messengers/generic-message-request.json[]
+----
+
 === Response 
 
 If the message was processed successfully, return a status code in the `200` to `299` range. No further processing will be performed by FusionAuth.
 
-If, on the other hand, the receiver is unsuccessful at sending the message, for whatever reason, return a status code outside of that range.
+If the receiver is unsuccessful at sending the message, for whatever reason, return a status code outside of that range.
 
 == Securing the Generic Message Receiver
 

--- a/site/docs/v1/tech/messengers/generic-messenger.adoc
+++ b/site/docs/v1/tech/messengers/generic-messenger.adoc
@@ -83,7 +83,8 @@ You also can test your generic messenger configuration. By hitting `Test generic
 
 == Writing the Generic Message Receiver
 
-You need to write a server side component, a receiver, which will be deployed at a URL and send the actual messages. This component can be written in any language that can consume a JSON message.
+You need to write a server side component, a receiver, which will be deployed at a URL to consume the message sent from FusionAuth. At that point, it can proxy the request to any third party messaging service.
+This component can be written in any language that can consume a JSON message.
 
 === Request 
 
@@ -101,9 +102,13 @@ The components of this message include:
 * [field]#textMessage#, the message to send. It is built from the configured link:/https://fusionauth.io/docs/v1/tech/email-templates/message-templates/[message template] and will be localized.
 * [field]#type#, which is always `SMS`.
 
-When your application receives this message, it should send the notification to the phone number provided. 
+When your application receives this message from FusionAuth, it should take whatever steps necessary to send the message:
 
-After the message is sent, it must return a response. The timeout is configurable.
+* call into a SDK provided by the third party
+* build an API request to an endpoint
+* anything else that may be required
+
+This component must return a response, documented below.
 
 === Response 
 

--- a/site/docs/v1/tech/messengers/generic-messenger.adoc
+++ b/site/docs/v1/tech/messengers/generic-messenger.adoc
@@ -11,16 +11,16 @@ Available since 1.26.0
 
 == Set Up a Generic Messenger
 
-Currently, messengers can only be configured to send messages via a SMS protocol. If you need to connect to an SMS provider other than Twilio, you can use the Generic messenger configuration.
+Currently, built-in messengers can only be configured to send messages via a Twilio. If you need to connect to a provider other than Twilio, whether you want to send SMS messages or any other, you can use the Generic messenger configuration.
 
-The generic messenger allows for a simple JSON REST API integration which allows you to receive a message from FusionAuth and then make an API call to any third party SMS provider you wish.
+The generic messenger allows for a simple JSON REST API integration which allows you to receive a message from FusionAuth to an arbitrary URL. The Generic Message Receiver at this URL may then make an API call to any third party messaging provider.
 
 image::messengers/add-messenger.png[Messenger Home Screen, width=1200]
 
+=== Add Generic Messenger
+
 To create a new generic messenger, navigate to [breadcrumb]#Settings -> Messengers#. +
 Click `Add Generic Messenger`
-
-=== Add Generic Messenger
 
 image::messengers/add-generic-messenger-home-crop.png[Add Generic Messenger Home, role=bottom-cropped, width=1200]
 
@@ -80,3 +80,43 @@ In these fields, you can add custom key and value pairs to augment your headers.
 image::messengers/configuration-test-generic.png[Test Configuration Generic, role=top-cropped, width=1200]
 
 You also can test your generic messenger configuration. By hitting `Test generic configuration` FusionAuth will fire a JSON message to the messenger just created to ensure everything is set up correctly.
+
+== Writing the Generic Message Receiver
+
+You need to write a server side component, a receiver, which will be deployed at a URL and send the actual messages. This component can be written in any language that can consume a JSON message.
+
+=== Request 
+
+The request to your endpoint will be delivered as JSON.
+
+[source,json]
+.Example Request JSON
+----
+include::docs/src/json/messengers/generic-message-request.json[]
+----
+
+The components of this message include:
+
+* [field]#phoneNumber#, the number of the user to which to send the message.
+* [field]#textMessage#, the message to send. It is built from the configured link:/https://fusionauth.io/docs/v1/tech/email-templates/message-templates/[message template] and will be localized.
+* [field]#type#, which is always `SMS`.
+
+When your application receives this message, it should send the notification to the phone number provided. 
+
+After the message is sent, it must return a response. The timeout is configurable.
+
+=== Response 
+
+If sending the message was successful, return a status code in the `200` to `299` range. No further processing will be performed.
+
+If, on the other hand, the receiver application is unsuccessful at sending the message, for whatever reason, return a status code outside of that range.
+
+== Securing the Generic Message Receiver
+
+:request_entity: Generic Message Receiver
+:request_entity_lc: generic-messenger
+:ssl_certificate_sentence: This must be an SSL certificate in PEM format
+include::docs/v1/tech/shared/_securing_http_requests.adoc[]
+:request_entity!:
+:request_entity_lc!:
+

--- a/site/docs/v1/tech/messengers/generic-messenger.adoc
+++ b/site/docs/v1/tech/messengers/generic-messenger.adoc
@@ -84,6 +84,7 @@ You also can test your generic messenger configuration. By hitting `Test generic
 == Writing the Generic Message Receiver
 
 You need to write a server side component, a receiver, which will be deployed at a URL to consume the message sent from FusionAuth. At that point, it can proxy the request to any third party messaging service.
+In other words, a Generic Messenger is a thin coordination layer between FusionAuth and other messaging services with the proper permissions, code and configuration to relay a message.
 This component can be written in any language that can consume a JSON message.
 
 === Request 

--- a/site/docs/v1/tech/messengers/generic-messenger.adoc
+++ b/site/docs/v1/tech/messengers/generic-messenger.adoc
@@ -11,7 +11,7 @@ Available since 1.26.0
 
 == Set Up a Generic Messenger
 
-Currently, built-in messengers can only be configured to send messages via a Twilio. If you need to connect to a provider other than Twilio, whether you want to send SMS messages or any other, you can use the Generic messenger configuration.
+Currently, built-in messengers can only be configured to send messages via a Twilio. If you need to connect to a provider other than Twilio, whether you want to send SMS messages or use a different transport layer such as push notifications, you can use the Generic messenger configuration.
 
 The generic messenger allows for a simple JSON REST API integration which allows you to receive a message from FusionAuth to an arbitrary URL. The Generic Message Receiver at this URL may then make an API call to any third party messaging provider.
 

--- a/site/docs/v1/tech/messengers/generic-messenger.adoc
+++ b/site/docs/v1/tech/messengers/generic-messenger.adoc
@@ -89,32 +89,33 @@ This component can be written in any language that can consume a JSON message.
 === Request 
 
 The request to your endpoint will be delivered as JSON.
-
-[source,json]
-.Example Request JSON
-----
-include::docs/src/json/messengers/generic-message-request.json[]
-----
-
-The components of this message include:
-
-* [field]#phoneNumber#, the number of the user to which to send the message.
-* [field]#textMessage#, the message to send. It is built from the configured link:/https://fusionauth.io/docs/v1/tech/email-templates/message-templates/[message template] and will be localized.
-* [field]#type#, which is always `SMS`.
-
 When your application receives this message from FusionAuth, it should take whatever steps necessary to send the message:
 
 * call into a SDK provided by the third party
 * build an API request to an endpoint
 * anything else that may be required
 
-This component must return a response, documented below.
+[source,json]
+.Example Message Payload JSON
+----
+include::docs/src/json/messengers/generic-message-request.json[]
+----
+
+[.api]
+[field]#phoneNumber# [type]#[String]#::
+The phone number of the user to which this message should be sent.
+
+[field]#textMessage# [type]#[String]#::
+The message text to send. This is built from the configured link:/https://fusionauth.io/docs/v1/tech/email-templates/message-templates/[message template] and is localized.
+
+[field]#type# [type]#[String]#::
+The type of the message. This will always be `SMS`.
 
 === Response 
 
-If sending the message was successful, return a status code in the `200` to `299` range. No further processing will be performed.
+If the message was processed successfully, return a status code in the `200` to `299` range. No further processing will be performed by FusionAuth.
 
-If, on the other hand, the receiver application is unsuccessful at sending the message, for whatever reason, return a status code outside of that range.
+If, on the other hand, the receiver is unsuccessful at sending the message, for whatever reason, return a status code outside of that range.
 
 == Securing the Generic Message Receiver
 


### PR DESCRIPTION
Per comments in this issue: https://github.com/FusionAuth/fusionauth-issues/issues/1566 I need to update the generic messenger doc to reflect how to actually use a generic messenger.