### PR TITLE
Fix event name for "user.two-factor.method.remove"

### DIFF
--- a/site/docs/v1/tech/apis/_event-types.adoc
+++ b/site/docs/v1/tech/apis/_event-types.adoc
@@ -66,7 +66,7 @@ include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
 include::../shared/_enterprise-edition-blurb-api.adoc[]
 
-* ``user.two-factor-method.remove`` - When a user has removed a two-factor method [since]#Available since 1.30.0#
+* ``user.two-factor.method.remove`` - When a user has removed a two-factor method [since]#Available since 1.30.0#
 +
 include::../shared/_enterprise-edition-blurb-api.adoc[]
 


### PR DESCRIPTION
This was incorrectly referenced as "user.two-factor-method.remove", but using that name causes a validation error when invoking the API.