### PR TITLE
Fix formatting issue where '+' signs show up

### DIFF
--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -261,7 +261,7 @@ ifdef::login_response[]
 include::../../../src/json/users/login-response.json[]
 ----
 endif::[]
-+
+
 ifdef::passwordless_login_response[]
 [source,json]
 .Example Response JSON
@@ -269,7 +269,7 @@ ifdef::passwordless_login_response[]
 include::../../../src/json/users/passwordless-login-response.json[]
 ----
 endif::[]
-+
+
 ifndef::login_response,passwordless_login_response[]
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/passwordless.adoc
+++ b/site/docs/v1/tech/apis/passwordless.adoc
@@ -244,6 +244,7 @@ include::docs/v1/tech/apis/_login-response-codes.adoc[]
 include::docs/v1/tech/apis/_user-response-body.adoc[]
 :passwordless_login_response!:
 
+
 ==== Response Cookies
 
 [.api]


### PR DESCRIPTION
There are some erroneous + signs on these pages:

https://fusionauth.io/docs/v1/tech/apis/login/ 
https://fusionauth.io/docs/v1/tech/apis/identity-providers/samlv2/
https://fusionauth.io/docs/v1/tech/apis/passwordless/

All near the 'response cookies' section.

This PR takes care of them.