### PR TITLE
Update discord domain

### DIFF
--- a/site/docs/v1/tech/identity-providers/openid-connect/discord.adoc
+++ b/site/docs/v1/tech/identity-providers/openid-connect/discord.adoc
@@ -8,15 +8,15 @@ description: Login using Discord as an OpenID Connect Identity Provider
 
 == Configure OpenID Connect with Discord
 
-Once you have completed this configuration you may enable an OpenID Connect "Login with Discord" button for one or more FusionAuth Applications. See link:https://discordapp.com/developers/docs/topics/oauth2/[Discord - OAuth2] for an additional reference.
+Once you have completed this configuration you may enable an OpenID Connect "Login with Discord" button for one or more FusionAuth Applications. See link:https://discord.com/developers/docs/topics/oauth2/[Discord - OAuth2] for an additional reference.
 
 image::identity-providers/discord-openid-connect-login.png[Login with Discord,width=1200,role=shadowed]
 
 === Register a Discord OAuth2 Application
 
-You will first need to log in to link:https://discordapp.com/developers/applications/[Discord].
+You will first need to log in to link:https://discord.com/developers/applications/[Discord].
 
-Once logged in, navigate to link:https://discordapp.com/developers/applications/[https://discordapp.com/developers/applications/] and create a new application.
+Once logged in, navigate to link:https://discord.com/developers/applications/[https://discord.com/developers/applications/] and create a new application.
 
 image::identity-providers/discord-openid-connect-client-id-secret.png[Discord Client ID and Secret,width=1200,role=shadowed]
 
@@ -36,9 +36,9 @@ This will take you to the `Add OpenID Connect` screen, and you'll fill out the r
 
 Discord has not implemented a well-known configuration endpoint, so you will need to disable the [field]#Discover endpoints# field and specify the endpoints manually.  The values for these fields are:
 
-* `Authorization endpoint` - `https://discordapp.com/api/oauth2/authorize`
-* `Token endpoint` - `https://discordapp.com/api/oauth2/token`
-* `Userinfo endpoint` - `https://discordapp.com/api/users/@me`
+* `Authorization endpoint` - `https://discord.com/api/oauth2/authorize`
+* `Token endpoint` - `https://discord.com/api/oauth2/token`
+* `Userinfo endpoint` - `https://discord.com/api/users/@me`
 
 You will need to specify the scopes `identify` and `email` in the [field]#Scope# field for your application.
 


### PR DESCRIPTION
Discord moved from `discordapp.com` to `discord.com`. https://support.discord.com/hc/en-us/articles/360042987951-Discordapp-com-is-now-Discord-com