### PR TITLE
Audit identity providers, no tokens in user registrations after 1.28

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_token-storage-note.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_token-storage-note.adoc
@@ -1,0 +1,11 @@
+FusionAuth will also store the {idp_display_name} {token_name} returned from the {return_text} in the `identityProviderLink` object. This object is accessible using the link:/docs/v1/tech/apis/identity-providers/links[Link API].
+
+The `identityProviderLink` object stores tokens so that you can use them in your application to call {idp_display_name} APIs on behalf of the user if desired.
+
+ifndef::hide_token_map_deprecation[]
+[NOTE.note]
+====
+Prior to version 1.28, the {token_name} was stored in the `UserRegistration` object, in the `tokens` Map.
+====
+endif::[]
+ 

--- a/site/docs/v1/tech/apis/identity-providers/_token-storage-note.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_token-storage-note.adoc
@@ -1,6 +1,6 @@
 FusionAuth will also store the {idp_display_name} {token_name} returned from the {return_text} in the `identityProviderLink` object. This object is accessible using the link:/docs/v1/tech/apis/identity-providers/links[Link API].
 
-The `identityProviderLink` object stores tokens so that you can use them in your application to call {idp_display_name} APIs on behalf of the user if desired.
+The `identityProviderLink` object stores the token so that you can use it in your application to call {idp_display_name} APIs on behalf of the user if desired.
 
 ifndef::hide_token_map_deprecation[]
 [NOTE.note]

--- a/site/docs/v1/tech/apis/identity-providers/_token-storage-note.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_token-storage-note.adoc
@@ -5,7 +5,7 @@ The `identityProviderLink` object stores tokens so that you can use them in your
 ifndef::hide_token_map_deprecation[]
 [NOTE.note]
 ====
-Prior to version 1.28, the {token_name} was stored in the `UserRegistration` object, in the `tokens` Map.
+Prior to version 1.28, the token was stored in the `UserRegistration` object, in the `tokens` Map.
 ====
 endif::[]
  

--- a/site/docs/v1/tech/apis/identity-providers/apple.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/apple.adoc
@@ -14,7 +14,16 @@ This API has been available since 1.17.0
 
 The Apple identity provider type will use the Sign in with Apple APIs and will provide a `Sign with Apple` button on FusionAuth's login page that will either redirect to an Apple sign in page or leverage native controls when using Safari on macOS or iOS. Additionally, this identity provider will call Apple's `/auth/token` API to load additional details about the user and store them in FusionAuth.
 
-FusionAuth will also store the Apple `refresh_token` that is returned from the `/auth/token` endpoint in the `UserRegistration` object inside the `tokens` Map. This Map stores the tokens from the various identity providers so that you can use them in your application to call their APIs.
+
+:idp_display_name: Apple
+:token_name: pass:normal[`refresh_token`]
+:return_text: pass:normal[`/auth/token` endpoint]
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
 
 === Operations
 

--- a/site/docs/v1/tech/apis/identity-providers/epicgames.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/epicgames.adoc
@@ -17,7 +17,17 @@ The Epic Games identity provider type will use the Epic Games OAuth login API. I
 
 This identity provider will call Epic Games' API to load the Epic Games user's `displayName` and use that as `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider.  However, Epic Games does not allow access to user emails, so neither email linking strategy can be used and user’s will not be able to login or be created.
 
-FusionAuth will also store the Epic Games `refresh_token` that is returned from the Epic Games login in the link between the user and the identity provider. This token can be used by an application to make further requests to Epic Games APIs on behalf of the user.
+:idp_display_name: Epic Games
+:token_name: pass:normal[`refresh_token`]
+:return_text: the Epic Games login 
+:hide_token_map_deprecation: true
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
+:hide_token_map_deprecation!:
 
 :idp_display_name: Epic Games
 :idp_id: 1b932b19-61a8-47c7-9e81-27dbf9011dad

--- a/site/docs/v1/tech/apis/identity-providers/external-jwt.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/external-jwt.adoc
@@ -16,6 +16,16 @@ This is a special type of identity provider that is only used via the link:/docs
 
 In order for this identity provider to use the JWT, it also needs the public key or HMAC secret that the JWT was signed with. FusionAuth will verify that the JWT is valid and has not expired. Once the JWT has been validated, FusionAuth will reconcile it to ensure that the User exists and is up-to-date.
 
+:idp_display_name: 
+:token_name: pass:normal[token provided in the `refresh_token` field]
+:return_text: request
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
+
 === Operations
 
 * <<Create an External JWT Identity Provider>>

--- a/site/docs/v1/tech/apis/identity-providers/facebook.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/facebook.adoc
@@ -18,7 +18,15 @@ The email address returned by the Facebook Graph API will be used to create or l
 
 When the `picture` field is not requested FusionAuth will also call Facebook's `/me/picture` API to load the user's profile image and store it as the `imageUrl` in FusionAuth. When the `picture` field is requested, the user's profile image will be returned by the `/me` API and a second request to the `/me/picture` endpoint will not be required.
 
-Finally, FusionAuth will call Facebook's `/oauth/access_token` API to exchange the login token for a long-lived Facebook token. This token is stored in the `UserRegistration` object inside the `tokens` Map. This Map stores the tokens from the various identity providers so that you can use them in your application to call their APIs.
+:idp_display_name: Facebook
+:token_name: pass:normal[long-lived token]
+:return_text: pass:normal[`/oauth/access_token` (after presenting the login token)]
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
 
 Please note if an `idp_hint` is appended to the OAuth Authorize endpoint, then the interaction behavior will be defaulted to `redirect`, even if popup interaction is explicitly configured.
 

--- a/site/docs/v1/tech/apis/identity-providers/google.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/google.adoc
@@ -15,7 +15,15 @@ The Google identity provider type will use the Google OAuth v2.0 login API. It w
 
 This identity provider will call Google’s API to load the user's `email` and `preferred_username` and use those as `email` and `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider. Additional claims returned by Google can be used to reconcile the user to FusionAuth by using a Google Reconcile Lambda.
 
-FusionAuth will also store the Google `id_token` returned from the Google API in the link between the user and the identity provider. This token can be used by an application to make further requests to Google APIs on behalf of the user.
+:idp_display_name: Google
+:token_name: pass:normal[`id_token`]
+:return_text: pass:normal[Google API]
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
 
 Please note if an `idp_hint` is appended to the OAuth Authorize endpoint, then the login method interaction will be `redirect`, even if popup interaction is explicitly configured.
 

--- a/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
@@ -16,7 +16,15 @@ The LinkedIn identity provider type will use OAuth 2.0 to authenticate a user wi
 
 The email address returned by the LinkedIn `/v2/emailAddress` API will be used to create or look up the existing user. Additional claims returned by LinkedIn can be used to reconcile the User to FusionAuth by using a LinkedIn Reconcile lambda. Unless you assign a reconcile lambda to this provider, only the `email` address will be used from the available claims returned by LinkedIn.
 
-FusionAuth will also store the LinkedIn `access_token` returned from the login dialog in the `UserRegistration` object inside the `tokens` Map. This Map stores the tokens from the various identity providers so that you can use them in your application to call their APIs.
+:idp_display_name: LinkedIn
+:token_name: pass:normal[`access_token`]
+:return_text: pass:normal[login endpoint]
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
 
 === Operations
 

--- a/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
@@ -28,8 +28,6 @@ include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 :token_name!:
 :return_text!:
 
-If the external OpenID Connect identity provider returns a refresh token, it will be stored in the `UserRegistration` object inside the `tokens` Map. This Map stores the tokens from the various identity providers so that you can use them in your application to call their APIs.
-
 === Operations
 
 * <<Create an OpenID Connect Identity Provider>>

--- a/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
@@ -18,6 +18,16 @@ Optionally, this identity provider can define one or more domains it is associat
 
 FusionAuth will also leverage the `/userinfo` API that is part of the OpenID Connect specification. The email address returned from the Userinfo response will be used to create or lookup the existing user. Additional claims from the Userinfo response can be used to reconcile the User in FusionAuth by using an OpenID Connect Reconcile Lambda. Unless you assign a reconcile lambda to this provider, on the `email` address will be used from the available claims returned by the OpenID Connect identity provider.
 
+:idp_display_name: 
+:token_name: pass:normal[`refresh_token`]
+:return_text: pass:normal[external OpenID Connect provider, if such a token is provided,]
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
+
 If the external OpenID Connect identity provider returns a refresh token, it will be stored in the `UserRegistration` object inside the `tokens` Map. This Map stores the tokens from the various identity providers so that you can use them in your application to call their APIs.
 
 === Operations

--- a/site/docs/v1/tech/apis/identity-providers/sonypsn.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/sonypsn.adoc
@@ -17,7 +17,17 @@ The Sony PlayStation Network identity provider type will use the Sony OAuth v2.0
 
 This identity provider will call Sony’s API to load the user's `email` and `online_id` and use those as `email` and `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider. Additional claims returned by Sony PlayStation Network can be used to reconcile the user to FusionAuth by using a Sony PlayStation Network Reconcile Lambda.
 
-FusionAuth will also store the Sony PlayStation Network `access_token` returned from the Sony PlayStation Network API in the link between the user and the identity provider. This token can be used by an application to make further requests to Sony PlayStation Network APIs on behalf of the user.
+:idp_display_name: Sony PlayStation Network 
+:token_name: pass:normal[`access_token`]
+:return_text: pass:normal[Sony PlayStation Network API]
+:hide_token_map_deprecation: true
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
+:hide_token_map_deprecation!:
 
 :idp_display_name: Sony PlayStation Network
 :idp_id: 7764b5c7-165b-4e7e-94aa-02ebe2a0a5fb

--- a/site/docs/v1/tech/apis/identity-providers/steam.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/steam.adoc
@@ -17,7 +17,18 @@ The Steam identity provider type will use the Steam OAuth login API. It will als
 
 This identity provider will call Steam's API to load the Steam user's `personaname` and use that as `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider.  However, Steam does not allow access to user emails, so neither email linking strategy can be used and user’s will not be able to login or be created.
 
-FusionAuth will also store the Steam `token` that is returned from the Steam login in the link between the user and the identity provider. This token can be used by an application to make further requests to Steam APIs on behalf of the user.
+:idp_display_name: Steam
+:token_name: pass:normal[`token`]
+:return_text: pass:normal[Steam login]
+:hide_token_map_deprecation: true
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
+:hide_token_map_deprecation!:
+
 
 :idp_display_name: Steam
 :idp_id: e4f39345-7833-4b1d-b331-ca03bdc2c4be

--- a/site/docs/v1/tech/apis/identity-providers/twitch.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/twitch.adoc
@@ -20,6 +20,18 @@ This identity provider will call Twitch’s API to load the user's `email` and `
 FusionAuth will also store the Twitch `refresh_token` returned from the Twitch API in the link between the user and the identity provider. This token can be used by an application to make further requests to Twitch APIs on behalf of the user.
 
 :idp_display_name: Twitch
+:token_name: pass:normal[`refresh_token`]
+:return_text: pass:normal[Twitch API]
+:hide_token_map_deprecation: true
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
+:hide_token_map_deprecation!:
+
+:idp_display_name: Twitch
 :idp_id: bf4cf83f-e824-42d7-b4a3-5b10847a66b2
 :idp_linking_strategy: CreatePendingLink
 :idp_lowercase: twitch

--- a/site/docs/v1/tech/apis/identity-providers/twitter.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/twitter.adoc
@@ -18,7 +18,15 @@ The email address returned by Twitter will be used to create or lookup the exist
 
 Twitter does not require a user to have an email address. However, to prevent account hijacking and take-over, FusionAuth prevents users from logging in with Twitter unless they have setup an email address in their Twitter account. Keep this in mind as you enable this identity provider.
 
-Finally, FusionAuth stores the Twitter access token that is returned from the OAuth v1.0 login workflow in the `UserRegistration` object inside the `tokens` Map. This Map stores the tokens from the various identity providers so that you can use them in your application to call their APIs.
+:idp_display_name: Twitter
+:token_name: pass:normal[access token]
+:return_text: pass:normal[OAuth v1.0 login workflow]
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
 
 === Operations
 

--- a/site/docs/v1/tech/apis/identity-providers/xbox.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/xbox.adoc
@@ -17,7 +17,17 @@ The Xbox identity provider type will use the Xbox OAuth v2.0 login API. It will 
 
 This identity provider will call Xbox’s API to load the user's `email` and `gtg` (Gamer Tag) and use those as `email` and `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider. Additional claims returned by Xbox can be used to reconcile the user to FusionAuth by using an Xbox Reconcile Lambda.
 
-FusionAuth will also store the Xbox `refresh_token` returned from the Xbox API in the link between the user and the identity provider. This token can be used by an application to make further requests to Xbox APIs on behalf of the user.
+:idp_display_name: Xbox
+:token_name: pass:normal[`refresh_token`]
+:return_text: pass:normal[Xbox API]
+:hide_token_map_deprecation: true
+
+include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
+
+:idp_display_name!:
+:token_name!:
+:return_text!:
+:hide_token_map_deprecation!:
 
 :idp_display_name: Xbox
 :idp_id: af53ab21-34c3-468a-8ba2-ecb3905f67f2


### PR DESCRIPTION
Fix for https://github.com/FusionAuth/fusionauth-site/issues/1188