### PR TITLE
Per the java client libs, it looks like the userId is provided

### DIFF
--- a/site/docs/v1/tech/events-webhooks/events/jwt-refresh.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/jwt-refresh.adoc
@@ -56,6 +56,9 @@ The unique tenant identifier.
 [field]#event.type# [type]#[String]#::
 The event type, this value will always be `{type}`.
 
+[field]#event.userId# [type]#[UUID]#::
+The unique Id of the User for which a refresh token has been revoked.
+
 [source,json]
 .Example Event JSON
 ----

--- a/site/docs/v1/tech/events-webhooks/events/jwt-refresh.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/jwt-refresh.adoc
@@ -57,7 +57,7 @@ The unique tenant identifier.
 The event type, this value will always be `{type}`.
 
 [field]#event.userId# [type]#[UUID]#::
-The unique Id of the User for which a refresh token has been revoked.
+The unique Id of the User for which the access token was granted.
 
 [source,json]
 .Example Event JSON


### PR DESCRIPTION
https://github.com/FusionAuth/fusionauth-java-client/blob/master/src/main/java/io/fusionauth/domain/event/JWTRefreshEvent.java

Looks like we just forgot to put it in the event docs. It is in the sample code.