### PR TITLE
Revise idp complete login api doc

### DIFF
--- a/site/docs/src/json/identity-providers/login/xbox-request.json
+++ b/site/docs/src/json/identity-providers/login/xbox-request.json
@@ -1,7 +1,7 @@
 {
   "applicationId": "10000000-0000-0002-0000-000000000001",
   "data": {
-    "code": "twitch-request.json",
+    "code": "TLNnmUWqG0kh1vmduvxaAr9VXFMxUuv7waTwtOVR",
     "redirect_uri": "https://login.piedpiper.com/oauth2/callback"
   },
   "identityProviderId": "af53ab21-34c3-468a-8ba2-ecb3905f67f2",

--- a/site/docs/v1/tech/apis/identity-providers/README.md
+++ b/site/docs/v1/tech/apis/identity-providers/README.md
@@ -24,8 +24,6 @@ For the "others" group the basic structure of the `_oauth-idp-operations.adoc` i
   - _identity-provider-login-request-body.adoc
   - _identity-provider-login-response-body.adoc
     
-To remain backwards compatible the `_identity-provider-login-request-body.adoc` file looks at attributes coming from both groups.  The second group of "other" IdPs passes the IdP type in as {loginProvider} if this attribute is not defined then we assume it's included from one of the "oauth" IdPs and will pickup on the `idp_type` or other `ipd_` attributes to adjust the page for those IdPs.
-
 ### Available Since
 
 This is the only attribute `idp_since` that is set for every IdP.  Since it is used various places it is set before any includes and unset at the bottom of the `adoc` file.

--- a/site/docs/v1/tech/apis/identity-providers/README.md
+++ b/site/docs/v1/tech/apis/identity-providers/README.md
@@ -2,7 +2,7 @@
 
 ### Structure
 
-There are two groups of Identity Providers.  The first group are all very similiar, conform fairly well to a Oauth Redirect login flow and require a `client_id` and `client_secret` (except Steam the only one-off in this group).  The second group are all very different.
+There are two groups of Identity Providers.  The first group are all very similiar, conform fairly well to a Oauth Redirect login flow and require a `client_id` and `client_secret` (except Steam, the only one-off in this group).  The second group are all very different from the first group and each other.
 
 - Oauth IdPs: Epic, Google, Sony, Steam, Twitch, Xbox
 - Others: Apple, External JWT, Facebook, HYPR, LinkedIn, OpenId, Saml V2
@@ -17,12 +17,16 @@ For the Oauth group they each have an "Overview" and then include the following 
     
 Before including the `_oauth-idp-operations.adoc` all the needed `idp_` attributes are defined and they carry through into all the sub-includes.
 
-For the "others" group the basic structure of the `_oauth-idp-operations.adoc` is defined in the top level `adoc` (e.g. `apple.adoc`) and then IdP specific request and response `adoc` files are included.  For example:
+For the "others" group the basic structure of the `_oauth-idp-operations.adoc` is defined in the top level `adoc` (e.g. `apple.adoc`) and then IdP specific request and response `adoc` files are included.
+
+For example:
 - apple.adoc
   - _apple-request-body.adoc
   - _apple-response-body.adoc
   - _identity-provider-login-request-body.adoc
   - _identity-provider-login-response-body.adoc
+
+However, you must define `idp_display_name` for these providers.
     
 ### Available Since
 

--- a/site/docs/v1/tech/apis/identity-providers/_common-data-code-or-token.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_common-data-code-or-token.adoc
@@ -1,0 +1,14 @@
+
+[field]#data.code# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
+When using the authorization code grant, Facebook will have returned an authorization code. To complete the login request, provide the `code` and the `redirect_uri` parameters to allow FusionAuth to complete this grant by exchanging the authorization code for an `access_token`.
++
+When using `code` you must also supply `redirect_uri`. If `code` is not provided, then `token` will be required.
+
+[field]#data.redirect_uri# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
+The redirect URI that was provided to the Facebook Authorization endpoint. This value will be sent to the Token Info API as the `redirect_uri` parameter.
+
+[field]#data.token# [type]#[String]# [optional]#Optional#::
+When using a popup or other login mode where Facebook has already returned you an `accessToken` through a JavaScript callback or other mechanism, you will send this value in the `token` parameter. FusionAuth will use this value to request user details and then complete the login.
++
+When using `token` you do not have to supply `redirect_uri`. If `token` is not provided, then `code` will be required.
+

--- a/site/docs/v1/tech/apis/identity-providers/_common-data-code-or-token.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_common-data-code-or-token.adoc
@@ -1,14 +1,15 @@
-
-[field]#data.code# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
-When using the authorization code grant, Facebook will have returned an authorization code. To complete the login request, provide the `code` and the `redirect_uri` parameters to allow FusionAuth to complete this grant by exchanging the authorization code for an `access_token`.
+[field]#data.code# [type]#[String]# [optional]#Optional# {data_code_since}::
+When using the authorization code grant, {idp_display_name} will have returned an authorization code. To complete the login request, provide the `code` and the `redirect_uri` parameters to allow FusionAuth to complete this grant by exchanging the authorization code for an `access_token`.
 +
 When using `code` you must also supply `redirect_uri`. If `code` is not provided, then `token` will be required.
 
-[field]#data.redirect_uri# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
-The redirect URI that was provided to the Facebook Authorization endpoint. This value will be sent to the Token Info API as the `redirect_uri` parameter.
+[field]#data.redirect_uri# [type]#[String]# [optional]#Optional# {data_code_since}::
+The redirect URI that was provided to the {idp_display_name} authorization endpoint. This value will be sent to the Token Info API as the `redirect_uri` parameter.
++
+When using `code` this field is required.
 
 [field]#data.token# [type]#[String]# [optional]#Optional#::
-When using a popup or other login mode where Facebook has already returned you an `accessToken` through a JavaScript callback or other mechanism, you will send this value in the `token` parameter. FusionAuth will use this value to request user details and then complete the login.
+When using a popup or other login mode where {idp_display_name} has already returned you an `accessToken` through a JavaScript callback or other mechanism, you will send this value in the `token` parameter. FusionAuth will use this value to request user details and then complete the login.
 +
 When using `token` you do not have to supply `redirect_uri`. If `token` is not provided, then `code` will be required.
 

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
@@ -31,7 +31,7 @@ include::_common-data-code-or-token.adoc[]
 endif::[]
 ifeval::["{idp_token_or_code}" == "token"]
 [field]#data.oauth# [type]#[String]# [required]#Required#::
-The Steam oauth token returned from their login API. This token will be sent to the Steam Token Details API as the `access_token` parameter.
+The Steam `oauth` token returned from their login API. This token will be sent to the Steam Token Details API as the `access_token` parameter.
 endif::[]
 ifeval::["{idp_display_name}" == "Facebook"]
 include::_common-data-code-or-token.adoc[]

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
@@ -1,5 +1,14 @@
 ==== Request Body
 
+// default to empty string
+:data_code_since: 
+ifeval::["{idp_display_name}" == "Google"]
+:data_code_since: pass:normal[[since]#Available since 1.28.0#]
+endif::[]
+ifeval::["{idp_display_name}" == "Facebook"]
+:data_code_since: pass:normal[[since]#Available since 1.28.0#]
+endif::[]
+
 [.api]
 [field]#applicationId# [type]#[UUID]# [required]#Required#::
 The Id of the Application the user is to be logged into. This application must have {idp_display_name} login enabled for this request to succeed.
@@ -17,38 +26,15 @@ The Apple `id_token` returned during Sign in with Apple.
 [field]#data.redirect_uri# [type]#[String]# [required]#Required#::
 The authorized redirect URI from your Sign in with Apple configuration. This value will be the publicly available URL of FusionAuth with the `/oauth2/callback` suffix.
 endif::[]
-ifeval::["{idp_display_name}" == "Epic Games"]
-
+ifeval::["{idp_token_or_code}" == "token or code"]
+include::_common-data-code-or-token.adoc[]
+endif::[]
+ifeval::["{idp_token_or_code}" == "token"]
+[field]#data.oauth# [type]#[String]# [required]#Required#::
+The Steam oauth token returned from their login API. This token will be sent to the Steam Token Details API as the `access_token` parameter.
 endif::[]
 ifeval::["{idp_display_name}" == "Facebook"]
-
-[field]#data.code# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
-When using the authorization code grant, Facebook will have returned an authorization code. To complete the login request, provide the `code` and the `redirect_uri` parameters to allow FusionAuth to complete this grant by exchanging the authorization code for an `access_token`.
-+
-When using `code` you must also supply `redirect_uri`. If `code` is not provided, then `token` will be required.
-
-[field]#data.redirect_uri# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
-The redirect URI that was provided to the Facebook Authorization endpoint. This value will be sent to the Token Info API as the `redirect_uri` parameter.
-
-[field]#data.token# [type]#[String]# [optional]#Optional#::
-When using a popup or other login mode where Facebook has already returned you an `accessToken` through a JavaScript callback or other mechanism, you will send this value in the `token` parameter. FusionAuth will use this value to request user details and then complete the login.
-+
-When using `token` you do not have to supply `redirect_uri`. If `token` is not provided, then `code` will be required.
-
-endif::[]
-ifeval::["{idp_type}" == "Google"]
-[field]#data.code# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
-When using the authorization code grant, Google will have returned an authorization code. To complete the login request, provide the `code` and the `redirect_uri` parameters to allow FusionAuth to complete this grant by exchanging the authorization code for an `access_token`.
-+
-When using `code` you must also supply `redirect_uri`. If `code` is not provided, then `token` will be required.
-
-[field]#data.redirect_uri# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
-The redirect URI that was provided to the Google Authorization endpoint. This value will be sent to the Token Info API as the `redirect_uri` parameter.
-
-[field]#data.token# [type]#[String]# [optional]#Optional#::
-When using a popup or other login mode where Google has already returned you an `id_token` through a JavaScript callback or other mechanism, you will send this value in the `token` parameter. FusionAuth will use this value to request user details and then complete the login.
-+
-When using `token` you do not have to supply `redirect_uri`. If `token` is not provided, then `code` will be required.
+include::_common-data-code-or-token.adoc[]
 endif::[]
 ifeval::["{idp_display_name}" == "HYPR"]
 [field]#data.code# [type]#[String]# [required]#Required#::
@@ -94,17 +80,6 @@ The authorization code, this is the `code` parameter that was returned on the Au
 
 [field]#data.redirect_uri# [type]#[String]# [required]#Required#::
 The redirect URI that was provided to the OpenID Connect Authorization endpoint. This value will be sent to the Token endpoint as the `redirect_uri` parameter.
-endif::[]
-ifeval::["{idp_token_or_code}" == "code"]
-[field]#data.code# [type]#[String]# [required]#Required#::
-The authorization code, this is the `code` parameter that was returned on the Authorization redirect URI. This code will be sent to the Token endpoint as the `code` parameter. If `code` is not provided, then the `token` will be required.
-
-[field]#data.redirect_uri# [type]#[String]# [required]#Required#::
-The redirect URI that was provided to the {idp_display_name} Authorization endpoint. This value will be sent to the Token endpoint as the `redirect_uri` parameter.
-endif::[]
-ifeval::["{idp_token_or_code}" == "token"]
-[field]#data.oauth# [type]#[String]# [required]#Required#::
-The Steam oauth token returned from their login API. This token will be sent to the Steam Token Details API as the `access_token` parameter.
 endif::[]
 
 ifeval::["{idp_display_name}" == "External JWT"]
@@ -177,6 +152,7 @@ A refresh token from the identity provider.
 
 endif::[]
 
+// this handles setting up the JSON display
 ifeval::["{idp_display_name}" == "Apple"]
 :idp_request: apple
 endif::[]
@@ -215,3 +191,4 @@ endif::[]
 include::_identity-provider-login-request-example.adoc[]
 :show_code_and_token_examples!:
 :idp_request!:
+:data_code_since!:

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
@@ -4,39 +4,6 @@
 [field]#applicationId# [type]#[UUID]# [required]#Required#::
 The Id of the Application the user is to be logged into. This application must have {idp_display_name} login enabled for this request to succeed.
 
-ifeval::["{idp_display_name}" == "External JWT"]
-[field]#encodedJWT# [type]#[String]# [required]#Required#::
-The encoded JWT which contains the user's identity information.
-
-endif::[]
-
-[field]#identityProviderId# [type]#[UUID]# [required]#Required#::
-The unique Id of the identity provider to process this login request.
-+
-ifeval::["{idp_display_name}" == "Apple"]
-For the {idp_display_name} identity provider, this value will always be `13d2a5db-7ef9-4d62-b909-0df58612e775`.
-endif::[]
-ifeval::["{idp_display_name}" == "Facebook"]
-For the {idp_display_name} identity provider, this value will always be `56abdcc7-8bd9-4321-9621-4e9bbebae494`.
-endif::[]
-ifeval::["{idp_display_name}" == "HYPR"]
-For the {idp_display_name} identity provider, this value will always be `778985b7-6fd8-414d-acf2-94f18fb7c7e0`.
-endif::[]
-ifeval::["{idp_display_name}" == "LinkedIn"]
-For the {idp_display_name} identity provider, this value will always be `6177c09d-3f0e-4d53-9504-3600b1b23f46`.
-endif::[]
-ifeval::["{idp_display_name}" == "Twitter"]
-For the {idp_display_name} identity provider, this value will always be `45bb233c-0901-4236-b5ca-ac46e2e0a5a5`.
-endif::[]
-ifdef::idp_id[]
-For the {idp_display_name} identity provider, this value will always be `{idp_id}`.
-endif::[]
-
-[field]#ipAddress# [type]#[String]# [optional]#Optional#::
-The IP address of the end-user that is logging into FusionAuth. If this value is omitted FusionAuth will attempt to obtain the IP address of
-the client, the value will be that of the `X-Forwarded-For` header if provided or the last proxy that sent the request. The IP address will
-be stored in the User login history.
-
 ifeval::["{idp_display_name}" == "Apple"]
 [field]#data.appleUser# [type]#[String]# [optional]#Optional#::
 The Apple user object. The first time a user completes the Sign in with Apple flow a user object will be returned, when this occurs pass it in using this property. During subsequent authentication requests to Apple the user object will not be returned.
@@ -139,6 +106,39 @@ ifeval::["{idp_token_or_code}" == "token"]
 [field]#data.oauth# [type]#[String]# [required]#Required#::
 The Steam oauth token returned from their login API. This token will be sent to the Steam Token Details API as the `access_token` parameter.
 endif::[]
+
+ifeval::["{idp_display_name}" == "External JWT"]
+[field]#encodedJWT# [type]#[String]# [required]#Required#::
+The encoded JWT which contains the user's identity information.
+
+endif::[]
+
+[field]#identityProviderId# [type]#[UUID]# [required]#Required#::
+The unique Id of the identity provider to process this login request.
++
+ifeval::["{idp_display_name}" == "Apple"]
+For the {idp_display_name} identity provider, this value will always be `13d2a5db-7ef9-4d62-b909-0df58612e775`.
+endif::[]
+ifeval::["{idp_display_name}" == "Facebook"]
+For the {idp_display_name} identity provider, this value will always be `56abdcc7-8bd9-4321-9621-4e9bbebae494`.
+endif::[]
+ifeval::["{idp_display_name}" == "HYPR"]
+For the {idp_display_name} identity provider, this value will always be `778985b7-6fd8-414d-acf2-94f18fb7c7e0`.
+endif::[]
+ifeval::["{idp_display_name}" == "LinkedIn"]
+For the {idp_display_name} identity provider, this value will always be `6177c09d-3f0e-4d53-9504-3600b1b23f46`.
+endif::[]
+ifeval::["{idp_display_name}" == "Twitter"]
+For the {idp_display_name} identity provider, this value will always be `45bb233c-0901-4236-b5ca-ac46e2e0a5a5`.
+endif::[]
+ifdef::idp_id[]
+For the {idp_display_name} identity provider, this value will always be `{idp_id}`.
+endif::[]
+
+[field]#ipAddress# [type]#[String]# [optional]#Optional#::
+The IP address of the end-user that is logging into FusionAuth. If this value is omitted FusionAuth will attempt to obtain the IP address of
+the client, the value will be that of the `X-Forwarded-For` header if provided or the last proxy that sent the request. The IP address will
+be stored in the User login history.
 
 [field]#metaData.device.description# [type]#[String]# [optional]#Optional#::
 A human readable description of the device represented by the `device` parameter.

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
@@ -2,32 +2,31 @@
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [required]#Required#::
-The Id of the Application the user is to be logged into. This application must have {loginProvider} login enabled for this request to succeed.
+The Id of the Application the user is to be logged into. This application must have {idp_display_name} login enabled for this request to succeed.
 
-ifeval::["{loginProvider}" == "External JWT"]
+ifeval::["{idp_display_name}" == "External JWT"]
 [field]#encodedJWT# [type]#[String]# [required]#Required#::
 The encoded JWT which contains the user's identity information.
 
 endif::[]
 
-//TODO need to move this below the data stuff.
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::
 The unique Id of the identity provider to process this login request.
 +
-ifeval::["{loginProvider}" == "Apple"]
-For the {loginProvider} identity provider, this value will always be `13d2a5db-7ef9-4d62-b909-0df58612e775`.
+ifeval::["{idp_display_name}" == "Apple"]
+For the {idp_display_name} identity provider, this value will always be `13d2a5db-7ef9-4d62-b909-0df58612e775`.
 endif::[]
-ifeval::["{loginProvider}" == "Facebook"]
-For the {loginProvider} identity provider, this value will always be `56abdcc7-8bd9-4321-9621-4e9bbebae494`.
+ifeval::["{idp_display_name}" == "Facebook"]
+For the {idp_display_name} identity provider, this value will always be `56abdcc7-8bd9-4321-9621-4e9bbebae494`.
 endif::[]
-ifeval::["{loginProvider}" == "HYPR"]
-For the {loginProvider} identity provider, this value will always be `778985b7-6fd8-414d-acf2-94f18fb7c7e0`.
+ifeval::["{idp_display_name}" == "HYPR"]
+For the {idp_display_name} identity provider, this value will always be `778985b7-6fd8-414d-acf2-94f18fb7c7e0`.
 endif::[]
-ifeval::["{loginProvider}" == "LinkedIn"]
-For the {loginProvider} identity provider, this value will always be `6177c09d-3f0e-4d53-9504-3600b1b23f46`.
+ifeval::["{idp_display_name}" == "LinkedIn"]
+For the {idp_display_name} identity provider, this value will always be `6177c09d-3f0e-4d53-9504-3600b1b23f46`.
 endif::[]
-ifeval::["{loginProvider}" == "Twitter"]
-For the {loginProvider} identity provider, this value will always be `45bb233c-0901-4236-b5ca-ac46e2e0a5a5`.
+ifeval::["{idp_display_name}" == "Twitter"]
+For the {idp_display_name} identity provider, this value will always be `45bb233c-0901-4236-b5ca-ac46e2e0a5a5`.
 endif::[]
 ifdef::idp_id[]
 For the {idp_display_name} identity provider, this value will always be `{idp_id}`.
@@ -38,7 +37,7 @@ The IP address of the end-user that is logging into FusionAuth. If this value is
 the client, the value will be that of the `X-Forwarded-For` header if provided or the last proxy that sent the request. The IP address will
 be stored in the User login history.
 
-ifeval::["{loginProvider}" == "Apple"]
+ifeval::["{idp_display_name}" == "Apple"]
 [field]#data.appleUser# [type]#[String]# [optional]#Optional#::
 The Apple user object. The first time a user completes the Sign in with Apple flow a user object will be returned, when this occurs pass it in using this property. During subsequent authentication requests to Apple the user object will not be returned.
 
@@ -51,7 +50,10 @@ The Apple `id_token` returned during Sign in with Apple.
 [field]#data.redirect_uri# [type]#[String]# [required]#Required#::
 The authorized redirect URI from your Sign in with Apple configuration. This value will be the publicly available URL of FusionAuth with the `/oauth2/callback` suffix.
 endif::[]
-ifeval::["{loginProvider}" == "Facebook"]
+ifeval::["{idp_display_name}" == "Epic Games"]
+
+endif::[]
+ifeval::["{idp_display_name}" == "Facebook"]
 
 [field]#data.code# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.0#::
 When using the authorization code grant, Facebook will have returned an authorization code. To complete the login request, provide the `code` and the `redirect_uri` parameters to allow FusionAuth to complete this grant by exchanging the authorization code for an `access_token`.
@@ -81,26 +83,26 @@ When using a popup or other login mode where Google has already returned you an 
 +
 When using `token` you do not have to supply `redirect_uri`. If `token` is not provided, then `code` will be required.
 endif::[]
-ifeval::["{loginProvider}" == "HYPR"]
+ifeval::["{idp_display_name}" == "HYPR"]
 [field]#data.code# [type]#[String]# [required]#Required#::
 The `code` returned from the Start Login API.
 endif::[]
-ifeval::["{loginProvider}" == "LinkedIn"]
+ifeval::["{idp_display_name}" == "LinkedIn"]
 [field]#data.code# [type]#[String]# [required]#Required#::
 When using the authorization code grant, LinkedIn will have returned an authorization code. To complete the login request, provide the `code` and the `redirect_uri` parameters to allow FusionAuth to complete this grant by exchanging the authorization code for an `access_token`.
 
 [field]#data.redirect_uri# [type]#[String]# [required]#Required#::
 The redirect URI that was provided to the LinkedIn Authorization endpoint. This value will be sent to the Token Info API as the `redirect_uri` parameter.
 endif::[]
-ifeval::["{loginProvider}" == "SAML v2"]
+ifeval::["{idp_display_name}" == "SAML v2"]
 [field]#data.samlResponse# [type]#[String]# [required]#Required#::
 The `SAMLResponse` parameter from the form submit (via a `POST` request) from the SAML v2 identity provider.
 endif::[]
-ifeval::["{loginProvider}" == "SAML v2 IdP Initiated"]
+ifeval::["{idp_display_name}" == "SAML v2 IdP Initiated"]
 [field]#data.samlResponse# [type]#[String]# [required]#Required#::
 The `SAMLResponse` parameter from the form submit (via a `POST` request) from the SAML v2 IdP Initiated identity provider.
 endif::[]
-ifeval::["{loginProvider}" == "Twitter"]
+ifeval::["{idp_display_name}" == "Twitter"]
 [field]#data.oauth_token# [type]#[String]# [required]#Required#::
 The Twitter oauth token returned from their login API. This token will be sent to the Twitter OAuth Access Token API as the `oauth_token` parameter.
 +
@@ -119,7 +121,7 @@ The Twitter oauth verifier returned from their login API. This token will be sen
 [since]#Since 1.25.0#
 Beginning in version 1.25.0, you may optionally omit the [field]#oauth_verifier# field if the values for [field]#oauth_token# and [field]#oauth_token_secret# are an access token. This allows for a use case where you are not using the FusionAuth themed login pages and you have integrated the Twitter login using this API and prior to calling FusionAuth you have already exchanged these values for a Twitter access token. In this scenario, you may take these two parameters representing the access token and FusionAuth will still complete the login for you by skipping the request to exchange the request token for an access token.
 endif::[]
-ifeval::["{loginProvider}" == "OpenID Connect"]
+ifeval::["{idp_display_name}" == "OpenID Connect"]
 [field]#data.code# [type]#[String]# [required]#Required#::
 The authorization code, this is the `code` parameter that was returned on the Authorization redirect URI. This code will be sent to the Token endpoint as the `code` parameter.
 
@@ -169,41 +171,41 @@ This optional parameter may be helpful when performing high volume authenticatio
 When this value is set to `true`, if a link does not yet exist to a FusionAuth user, a `404` status code will be returned instead of using the requested linking strategy. This may be useful if you want to identify if a link exists before starting a full interactive workflow with the user to complete a link.
 
 
-ifeval::["{loginProvider}" == "External JWT"]
+ifeval::["{idp_display_name}" == "External JWT"]
 [field]#refresh_token# [type]#[String]# [optional]#Optional#::
 A refresh token from the identity provider.
 
 endif::[]
 
-ifeval::["{loginProvider}" == "Apple"]
+ifeval::["{idp_display_name}" == "Apple"]
 :idp_request: apple
 endif::[]
-ifeval::["{loginProvider}" == "External JWT"]
+ifeval::["{idp_display_name}" == "External JWT"]
 :idp_request: externaljwt
 endif::[]
-ifeval::["{loginProvider}" == "Facebook"]
+ifeval::["{idp_display_name}" == "Facebook"]
 :show_code_and_token_examples:
 :idp_request: facebook
 endif::[]
 ifeval::["{idp_type}" == "Google"]
 :show_code_and_token_examples:
 endif::[]
-ifeval::["{loginProvider}" == "HYPR"]
+ifeval::["{idp_display_name}" == "HYPR"]
 :idp_request: hypr
 endif::[]
-ifeval::["{loginProvider}" == "LinkedIn"]
+ifeval::["{idp_display_name}" == "LinkedIn"]
 :idp_request: linkedin
 endif::[]
-ifeval::["{loginProvider}" == "Twitter"]
+ifeval::["{idp_display_name}" == "Twitter"]
 :idp_request: twitter
 endif::[]
-ifeval::["{loginProvider}" == "OpenID Connect"]
+ifeval::["{idp_display_name}" == "OpenID Connect"]
 :idp_request: openid-connect
 endif::[]
-ifeval::["{loginProvider}" == "SAML v2"]
+ifeval::["{idp_display_name}" == "SAML v2"]
 :idp_request: samlv2
 endif::[]
-ifeval::["{loginProvider}" == "SAML v2 IdP Initiated"]
+ifeval::["{idp_display_name}" == "SAML v2 IdP Initiated"]
 :idp_request: samlv2
 endif::[]
 ifdef::idp_lowercase[]

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-start-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-start-request-body.adoc
@@ -2,9 +2,9 @@
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [required]#Required#::
-The Id of the Application the user is to be logged into. This application must have {loginProvider} login enabled for this request to succeed.
+The Id of the Application the user is to be logged into. This application must have {idp_display_name} login enabled for this request to succeed.
 
-ifeval::["{loginProvider}" == "SAML v2"]
+ifeval::["{idp_display_name}" == "SAML v2"]
 [field]#data.requestId# [type]#[String]# [optional]#Optional#::
 The optional SAML v2 request identifier to be used when making the SAML AuthN request to the SAML v2 IdP. If this parameter is omitted a value will be generated.
 endif::[]
@@ -12,11 +12,11 @@ endif::[]
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::
 The unique Id of the identity provider to process this login request.
 +
-ifeval::["{loginProvider}" == "HYPR"]
-For the {loginProvider} identity provider, this value will always be `778985b7-6fd8-414d-acf2-94f18fb7c7e0`.
+ifeval::["{idp_display_name}" == "HYPR"]
+For the {idp_display_name} identity provider, this value will always be `778985b7-6fd8-414d-acf2-94f18fb7c7e0`.
 endif::[]
 
-ifeval::["{loginProvider}" == "HYPR"]
+ifeval::["{idp_display_name}" == "HYPR"]
 [field]#loginId# [type]#[String]# [required]#Required#::
 The login identifier of the user. The login identifier can be either the [field]#email# or the [field]#username#.
 endif::[]
@@ -24,10 +24,10 @@ endif::[]
 [source,json]
 .Example Request JSON
 ----
-ifeval::["{loginProvider}" == "HYPR"]
+ifeval::["{idp_display_name}" == "HYPR"]
 include::../../../../src/json/identity-providers/start/hypr-request.json[]
 endif::[]
-ifeval::["{loginProvider}" == "SAML v2"]
+ifeval::["{idp_display_name}" == "SAML v2"]
 include::../../../../src/json/identity-providers/start/samlv2-request.json[]
 endif::[]
 ----

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-start-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-start-response-body.adoc
@@ -12,7 +12,7 @@
 |401
 |Unable to complete the login request. The response may contain a JSON body describing the reason for the status code in some cases.
 
-ifeval::["{loginProvider}" == "HYPR"]
+ifeval::["{idp_display_name}" == "HYPR"]
 |404
 |The user was not found or the password was incorrect. The response will be empty.
 endif::[]
@@ -30,10 +30,10 @@ The code used to complete login using the Complete HYPR Login API.
 [source,json]
 .Example Response JSON
 ----
-ifeval::["{loginProvider}" == "HYPR"]
+ifeval::["{idp_display_name}" == "HYPR"]
 include::../../../../src/json/identity-providers/start/hypr-response.json[]
 endif::[]
-ifeval::["{loginProvider}" == "SAML v2"]
+ifeval::["{idp_display_name}" == "SAML v2"]
 include::../../../../src/json/identity-providers/start/samlv2-response.json[]
 endif::[]
 ----

--- a/site/docs/v1/tech/apis/identity-providers/_oauth-idp-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_oauth-idp-request-body.adoc
@@ -36,7 +36,7 @@ The top-level button text to use on the FusionAuth login page for this Identity 
 [field]#identityProvider.client_id# [type]#[String]# [required]#Required#::
 The top-level {idp_display_name} client id for your Application. This value is retrieved from the {idp_display_name} developer website when you setup your {idp_display_name} developer account.
 
-ifeval::["{loginProvider}" != "Steam"]
+ifeval::["{idp_display_name}" != "Steam"]
 [field]#identityProvider.client_secret# [type]#[String]# [required]#Required#::
 The top-level client secret to use with the {idp_display_name} Identity Provider when retrieving the long-lived token. This value is retrieved from the {idp_display_name} developer website when you setup your {idp_display_name} developer account.
 endif::[]

--- a/site/docs/v1/tech/apis/identity-providers/apple.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/apple.adoc
@@ -191,15 +191,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: Apple
+:idp_display_name: Apple
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: Apple
+:idp_display_name: Apple
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/external-jwt.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/external-jwt.adoc
@@ -193,15 +193,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: External JWT
+:idp_display_name: External JWT
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: External JWT
+:idp_display_name: External JWT
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/facebook.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/facebook.adoc
@@ -189,15 +189,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: Facebook
+:idp_display_name: Facebook
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: Facebook
+:idp_display_name: Facebook
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/hypr.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/hypr.adoc
@@ -170,17 +170,17 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 [method]#POST# [uri]#/api/identity-provider/start#
 --
 
-:loginProvider: HYPR
+:idp_display_name: HYPR
 include::docs/v1/tech/apis/identity-providers/_identity-provider-start-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains a code that can be used to complete the login request.
 
-:loginProvider: HYPR
+:idp_display_name: HYPR
 include::docs/v1/tech/apis/identity-providers/_identity-provider-start-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 == Complete the HYPR Login
 
@@ -208,15 +208,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: HYPR
+:idp_display_name: HYPR
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: HYPR
+:idp_display_name: HYPR
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
@@ -195,15 +195,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: LinkedIn
+:idp_display_name: LinkedIn
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: LinkedIn
+:idp_display_name: LinkedIn
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
@@ -193,15 +193,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: OpenID Connect
+:idp_display_name: OpenID Connect
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: OpenID Connect
+:idp_display_name: OpenID Connect
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/samlv2-idp-initiated.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/samlv2-idp-initiated.adoc
@@ -195,15 +195,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: SAML v2 IdP Initiated
+:idp_display_name: SAML v2 IdP Initiated
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: SAML v2 IdP Initiated
+:idp_display_name: SAML v2 IdP Initiated
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/samlv2.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/samlv2.adoc
@@ -185,17 +185,17 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 [method]#POST# [uri]#/api/identity-provider/start#
 --
 
-:loginProvider: SAML v2
+:idp_display_name: SAML v2
 include::docs/v1/tech/apis/identity-providers/_identity-provider-start-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains a code that can be used to complete the login request.
 
-:loginProvider: SAML v2
+:idp_display_name: SAML v2
 include::docs/v1/tech/apis/identity-providers/_identity-provider-start-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 == Complete a SAML v2 Login
 
@@ -223,15 +223,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: SAML v2
+:idp_display_name: SAML v2
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: SAML v2
+:idp_display_name: SAML v2
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/twitter.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/twitter.adoc
@@ -193,15 +193,15 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:loginProvider: Twitter
+:idp_display_name: Twitter
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:loginProvider: Twitter
+:idp_display_name: Twitter
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
-:loginProvider!:
+:idp_display_name!:
 :idp_since!:


### PR DESCRIPTION
The 'complete login' parameters were incorrect in some of these, and missing for the new gaming idps. This updates them and rationalizes some of the content.

Reviewer note: just check out this branch and look at the 'complete login' section for all the IdPs. It should match the code (the `validate(Tenant tenant, IdentityProviderLoginRequest request)` method on the `XYZIdentityProviderAuthenticationService`.