### PR TITLE
Add theme doco

### DIFF
--- a/site/docs/v1/tech/themes/_messages-example.adoc
+++ b/site/docs/v1/tech/themes/_messages-example.adoc
@@ -1,0 +1,22 @@
+Consider the following message bundle and theme usage example with English and German messages defined.
+
+[source,properties]
+.English
+----
+greeting=Good day
+----
+
+[source,properties]
+.German
+----
+greeting=Guten Tag
+----
+
+[source,html]
+.Template
+----
+<p>${theme.message('greeting')}</p>
+----
+
+If I have selected German as my locale, I will be greeted with `Guten Tag` rendered on the page, if I have English selected I will instead find the greeting `Good day`.
+

--- a/site/docs/v1/tech/themes/_messages-example.adoc
+++ b/site/docs/v1/tech/themes/_messages-example.adoc
@@ -21,7 +21,7 @@ optional-greeting=Mitmensch
 
 If I have selected German as my locale, I will be greeted with `Guten Tag Mitmensch` rendered on the page. 
 
-If I have English selected I will instead find the greeting `Good day optional-gretting`.
+If I have English selected I will instead find the greeting `Good day optional-greeting`.
 
 The behavior differs between `theme.message` and `theme.optionalMessage` only when the key doesn't exist in any of the messages files, including the default one. 
 

--- a/site/docs/v1/tech/themes/_messages-example.adoc
+++ b/site/docs/v1/tech/themes/_messages-example.adoc
@@ -27,7 +27,7 @@ The behavior differs between `theme.message` and `theme.optionalMessage` only wh
 
 When there is no suitable key found and `theme.message` is used, an exception is thrown and the template fails to completely render. When there is no suitable key found and `theme.optionalMessage` is used, the key value is returned: `optional-message` in the example above.
 
-Here's an example of a template that will render for a user with a German locale but fail for a user with an English locale:
+Here's an example of a template that will render for a user with a German locale but fail for a user with an English locale, because `message` fails when there is no key found:
 
 [source,html]
 .Template Which Will Fail For Users With an English Locale
@@ -35,5 +35,25 @@ Here's an example of a template that will render for a user with a German locale
 <p>${theme.message('optional-greeting')}</p>
 ----
 
-There's an https://github.com/FusionAuth/fusionauth-issues/issues/1661[open issue about the behavior of `optionalMessage`].
+Here's a Freemarker function which returns an empty string when there is no value found for an optional message:
 
+[source,freemarker]
+.Freemarker Function to Return the Empty String When No Value is Found
+----
+[#function getOptionalMessage key=""]
+  [#if "${theme.optionalMessage(key)}" == "${key}"]
+    [#return "" /]
+  [/#if]
+  [#return theme.optionalMessage(key) /]
+[/#function]
+----
+
+If you add this to your `_helpers.ftl` file, you can call it like this:
+
+[source,freemarker]
+.Calling getOptionalMessage
+----
+[@helpers.getOptionalMessage key="optional-greeting" /]
+----
+
+There's an https://github.com/FusionAuth/fusionauth-issues/issues/1661[open issue on changing the behavior of `optionalMessage`].

--- a/site/docs/v1/tech/themes/_messages-example.adoc
+++ b/site/docs/v1/tech/themes/_messages-example.adoc
@@ -10,13 +10,30 @@ greeting=Good day
 .German
 ----
 greeting=Guten Tag
+optional-greeting=Mitmensch
 ----
 
 [source,html]
 .Template
 ----
-<p>${theme.message('greeting')}</p>
+<p>${theme.message('greeting')} ${theme.optionalMessage('optional-greeting')}</p>
 ----
 
-If I have selected German as my locale, I will be greeted with `Guten Tag` rendered on the page, if I have English selected I will instead find the greeting `Good day`.
+If I have selected German as my locale, I will be greeted with `Guten Tag Mitmensch` rendered on the page. 
+
+If I have English selected I will instead find the greeting `Good day optional-gretting`.
+
+The behavior differs between `theme.message` and `theme.optionalMessage` only when the key doesn't exist in any of the messages files, including the default one. 
+
+When there is no suitable key found and `theme.message` is used, an exception is thrown and the template fails to completely render. When there is no suitable key found and `theme.optionalMessage` is used, the key value is returned: `optional-message` in the example above.
+
+Here's an example of a template that will render for a user with a German locale but fail for a user with an English locale:
+
+[source,html]
+.Template Which Will Fail For Users With an English Locale
+----
+<p>${theme.message('optional-greeting')}</p>
+----
+
+There's an https://github.com/FusionAuth/fusionauth-issues/issues/1661[open issue about the behavior of `optionalMessage`].
 

--- a/site/docs/v1/tech/themes/index.adoc
+++ b/site/docs/v1/tech/themes/index.adoc
@@ -30,7 +30,8 @@ Continue reading below to see how to create a theme, how to preview a theme, exa
 * <<Preview a Theme>>
 * <<Apply a Theme>>
 * <<Example Code>>
-** <<Example of Customizing the Authorize Page>>
+** <<Displaying Messages>>
+** <<Customizing the Authorize Page>>
 * <<Troubleshooting>>
 * <<Upgrading>>
 
@@ -118,7 +119,14 @@ image::themes/apply-theme-application.png[Apply a theme to an application.,width
 
 == Example Code
 
-=== Example of Customizing the Authorize Page
+=== Displaying Messages
+
+You can customize messages by locale. You can also have optional keys.
+
+include::docs/v1/tech/themes/_messages-example.adoc[]
+
+
+=== Customizing the Authorize Page
 
 Now that you have a good overview of all the templates, macros and helpers, here is an example of customizing the Authorize page.
 

--- a/site/docs/v1/tech/themes/localization.adoc
+++ b/site/docs/v1/tech/themes/localization.adoc
@@ -20,27 +20,7 @@ You may also want to review our link:/docs/v1/tech/core-concepts/localization-an
 
 In the Messages tab of your theme editor you may specify one to many languages. Once you have specified a key and value the key may be used in any template to display a localized string.
 
-Consider the following message bundle and theme usage example with English and German messages defined.
-
-[source,properties]
-.English
-----
-greeting=Good day
-----
-
-[source,properties]
-.German
-----
-greeting=Guten Tag
-----
-
-[source,html]
-.Template
-----
-<p>${theme.message('greeting')}</p>
-----
-
-If I have selected German as my locale, I will be greeted with `Guten Tag` rendered on the page, if I have English selected I will instead find the greeting `Good day`.
+include::docs/v1/tech/themes/_messages-example.adoc[]
 
 == Locale
 

--- a/site/docs/v1/tech/themes/template-variables.adoc
+++ b/site/docs/v1/tech/themes/template-variables.adoc
@@ -59,7 +59,9 @@ The tenant that has been resolved for this template. This value has either been 
 See the link:/docs/v1/tech/apis/tenants[Tenant API] for details on this object.
 
 [field]#theme# [type]#[Theme]#::
-The theme object. 
+The theme that has been resolved for this template. This could be resolved based on the tenant or the application.
++
+See the link:/docs/v1/tech/apis/themes[Themes API] for details on this object.
 
 [field]#tenantId# [type]#[UUID]#::
 The unique Tenant identifier, this is equivalent to `tenant.id`.

--- a/site/docs/v1/tech/themes/template-variables.adoc
+++ b/site/docs/v1/tech/themes/template-variables.adoc
@@ -58,13 +58,16 @@ The tenant that has been resolved for this template. This value has either been 
 +
 See the link:/docs/v1/tech/apis/tenants[Tenant API] for details on this object.
 
+[field]#tenantId# [type]#[UUID]#::
+The unique Tenant identifier, this is equivalent to `tenant.id`.
+
 [field]#theme# [type]#[Theme]#::
 The theme that has been resolved for this template. This could be resolved based on the tenant or the application.
 +
 See the link:/docs/v1/tech/apis/themes[Themes API] for details on this object.
 
-[field]#tenantId# [type]#[UUID]#::
-The unique Tenant identifier, this is equivalent to `tenant.id`.
+[field]#themeId# [type]#[UUID]#::
+The unique Theme identifier, this is equivalent to `theme.id`.
 
 == Template Specific Variables
 

--- a/site/docs/v1/tech/themes/template-variables.adoc
+++ b/site/docs/v1/tech/themes/template-variables.adoc
@@ -58,6 +58,9 @@ The tenant that has been resolved for this template. This value has either been 
 +
 See the link:/docs/v1/tech/apis/tenants[Tenant API] for details on this object.
 
+[field]#theme# [type]#[Theme]#::
+The theme object. 
+
 [field]#tenantId# [type]#[UUID]#::
 The unique Tenant identifier, this is equivalent to `tenant.id`.
 


### PR DESCRIPTION
This adds some additional detail to the theme doco.

* document the `theme` variable present in all themes
* Add some more flavor to the `theme.message` and `theme.optionalMessage` documentation (the latter of which wasn't documented at all). This partially addresses https://github.com/FusionAuth/fusionauth-issues/issues/1661