### PR TITLE
Update events event info

### DIFF
--- a/site/docs/v1/tech/events-webhooks/events/_event-info.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/_event-info.adoc
@@ -1,19 +1,19 @@
-[field]#event.info.data# [type]#[]# [since]#Available since 1.30.0#::
+[field]#event.info.data# [type]#[]# {event_info_since_threat_detection}::
 An object that can hold any information about the event that should be persisted.
 
-[field]#event.info.deviceDescription# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.deviceDescription# [type]#[String]# {event_info_since_threat_detection}::
 The description of the device associated with the event.
 
-[field]#event.info.deviceName# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.deviceName# [type]#[String]# {event_info_since_threat_detection}::
 The device name associated with the event.
 
-[field]#event.info.deviceType# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.deviceType# [type]#[String]# {event_info_since_threat_detection}::
 The type of device associated with the event.
 
-[field]#event.info.ipAddress# [type]#[String]# [since]#Available since 1.27.0#::
+[field]#event.info.ipAddress# [type]#[String]# {event_info_since_ip_address}::
 The source IP address of the event.
 
-[field]#event.info.location.city# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.location.city# [type]#[String]# {event_info_since_threat_detection}::
 The city where the event originated.
 +
 :premium_feature: event info location
@@ -21,7 +21,7 @@ include::../../shared/_premium-edition-blurb-api.adoc[]
 +
 :premium_feature!:
 
-[field]#event.info.location.country# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.location.country# [type]#[String]# {event_info_since_threat_detection}::
 The country where the event originated.
 +
 :premium_feature: event info location
@@ -29,7 +29,7 @@ include::../../shared/_premium-edition-blurb-api.adoc[]
 +
 :premium_feature!:
 
-[field]#event.info.location.latitude# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.location.latitude# [type]#[String]# {event_info_since_threat_detection}::
 The latitude where the event originated.
 +
 :premium_feature: event info location
@@ -37,7 +37,7 @@ include::../../shared/_premium-edition-blurb-api.adoc[]
 +
 :premium_feature!:
 
-[field]#event.info.location.longitude# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.location.longitude# [type]#[String]# {event_info_since_threat_detection}::
 The longitude where the event originated.
 +
 :premium_feature: event info location
@@ -45,7 +45,7 @@ include::../../shared/_premium-edition-blurb-api.adoc[]
 +
 :premium_feature!:
 
-[field]#event.info.location.region# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.location.region# [type]#[String]# {event_info_since_threat_detection}::
 The geographic location where the event originated.
 +
 :premium_feature: event info location
@@ -53,7 +53,7 @@ include::../../shared/_premium-edition-blurb-api.adoc[]
 +
 :premium_feature!:
 
-[field]#event.info.location.zipcode# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.location.zipcode# [type]#[String]# {event_info_since_threat_detection}::
 The zip code where the event originated.
 +
 :premium_feature: event info location
@@ -61,8 +61,8 @@ include::../../shared/_premium-edition-blurb-api.adoc[]
 +
 :premium_feature!:
 
-[field]#event.info.os# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.os# [type]#[String]# {event_info_since_threat_detection}::
 The operating system associated with the event.
 
-[field]#event.info.userAgent# [type]#[String]# [since]#Available since 1.30.0#::
+[field]#event.info.userAgent# [type]#[String]# {event_info_since_threat_detection}::
 The user agent associated with the event.

--- a/site/docs/v1/tech/events-webhooks/events/_event-info.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/_event-info.adoc
@@ -1,4 +1,4 @@
-[field]#event.info.data# [type]#[]# {event_info_since_threat_detection}::
+[field]#event.info.data# [type]#[Object]# {event_info_since_threat_detection}::
 An object that can hold any information about the event that should be persisted.
 
 [field]#event.info.deviceDescription# [type]#[String]# {event_info_since_threat_detection}::

--- a/site/docs/v1/tech/events-webhooks/events/audit-log-create.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/audit-log-create.adoc
@@ -5,6 +5,9 @@ description: Audit Log Create event details
 ---
 
 :type: audit.log.create
+:event_info_since_threat_detection: 
+:event_info_since_ip_address: 
+
 == Audit Log Create
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/event-log-create.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/event-log-create.adoc
@@ -5,6 +5,9 @@ description: Event Log Create event details
 ---
 
 :type: event.log.create
+:event_info_since_threat_detection: 
+:event_info_since_ip_address: 
+
 == Event Log Create
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/index.adoc
@@ -25,6 +25,7 @@ These are the events that FusionAuth generates that can be optionally consumed b
 * link:/docs/v1/tech/events-webhooks/events/user-delete-complete[User Delete Complete] - when a user delete transaction has completed
 * link:/docs/v1/tech/events-webhooks/events/user-email-update[User Email Update] - when a user updates their email address
 * link:/docs/v1/tech/events-webhooks/events/user-email-verified[User Email Verified] - when a user verifies their email address
+* link:/docs/v1/tech/events-webhooks/events/user-identity-provider-link[User Identity Provider Link] - when a user completes a link with an Identity Provider
 * link:/docs/v1/tech/events-webhooks/events/user-login-failed[User Login Failed] - when a user fails to complete login
 * link:/docs/v1/tech/events-webhooks/events/user-login-success[User Login Success] - when a user successfully completes login
 * link:/docs/v1/tech/events-webhooks/events/user-reactivate[User Reactivate] - when a user is reactivated

--- a/site/docs/v1/tech/events-webhooks/events/jwt-public-key-update.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/jwt-public-key-update.adoc
@@ -5,6 +5,9 @@ description: JWT Public Key Update event details
 ---
 
 :type: jwt.public-key.update
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == JWT Public Key Update
 
 [source,shell]

--- a/site/docs/v1/tech/events-webhooks/events/jwt-refresh-token-revoke.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/jwt-refresh-token-revoke.adoc
@@ -5,6 +5,9 @@ description: JWT Refresh Token Revoke event details
 ---
 
 :type: jwt.refresh-token.revoke
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == JWT Refresh Token Revoke
 
 This event is generated when a refresh token is revoked. The JSON includes either the User Id and User or the Application Id depending on what was revoked. It will also include the time to live duration (in seconds) for each Application. This value is used to determine if JWTs are valid or not based on their expiration instants.

--- a/site/docs/v1/tech/events-webhooks/events/jwt-refresh.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/jwt-refresh.adoc
@@ -5,6 +5,9 @@ description: JWT Refresh event details
 ---
 
 :type: jwt.refresh
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == JWT Refresh
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/kickstart-success.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/kickstart-success.adoc
@@ -5,6 +5,9 @@ description: Kickstart Success event details
 ---
 
 :type: kickstart.success
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == Kickstart Success
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-actions.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-actions.adoc
@@ -5,6 +5,9 @@ description: User Action event details
 ---
 
 :type: user.action
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Action
 
 This event is generated when a User Action is taken on a user and when temporal actions transition between phases.

--- a/site/docs/v1/tech/events-webhooks/events/user-bulk-create.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-bulk-create.adoc
@@ -5,6 +5,9 @@ description: User Bulk Create event details
 ---
 
 :type: user.bulk.create
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Bulk Create
 
 This event is generated when multiple users are created. The JSON includes each of the Users that were created.

--- a/site/docs/v1/tech/events-webhooks/events/user-create-complete.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-create-complete.adoc
@@ -5,6 +5,11 @@ description: User Create Complete event details
 ---
 
 :type: user.create.complete
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Create Complete
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-create.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-create.adoc
@@ -5,6 +5,9 @@ description: User Create event details
 ---
 
 :type: user.create
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Create
 
 This event is generated when a single user is created. The JSON includes the User that was created.

--- a/site/docs/v1/tech/events-webhooks/events/user-deactivate.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-deactivate.adoc
@@ -5,6 +5,9 @@ description: User Deactivate event details
 ---
 
 :type: user.deactivate
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Deactivate
 
 This event is generated when a user is deactivated, also referred to as a soft delete.

--- a/site/docs/v1/tech/events-webhooks/events/user-delete-complete.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-delete-complete.adoc
@@ -6,6 +6,9 @@ description: User Delete Complete event details
 
 
 :type: user.delete.complete
+:event_info_since_threat_detection:
+:event_info_since_ip_address: 
+
 == User Delete Complete
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-delete.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-delete.adoc
@@ -5,6 +5,11 @@ description: User Delete event details
 ---
 
 :type: user.delete
+
+// these are passed in because there are new events after 1.30 and it doesn't make sense to say that this event has attributes from a version before it was created
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Delete
 
 This event is generated when a user is deleted.
@@ -42,7 +47,7 @@ The unique tenant identifier. This value may not be returned if not applicable.
 The event type, this value will always be `{type}`.
 
 [field]#event.user# [type]#[Object]#::
-The user that has been created. See the link:/docs/v1/tech/apis/users[Users API] for property definitions and example JSON.
+The user that has been deleted. See the link:/docs/v1/tech/apis/users[Users API] for property definitions and example JSON.
 
 [source,json]
 .Example Event JSON

--- a/site/docs/v1/tech/events-webhooks/events/user-email-update.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-email-update.adoc
@@ -5,6 +5,9 @@ description: User Email Update event details
 ---
 
 :type: user.email.update
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Email Update
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-email-verified.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-email-verified.adoc
@@ -5,6 +5,9 @@ description: User Email Verified event details
 ---
 
 :type: user.email.verified
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Email Verified
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-login-failed.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-login-failed.adoc
@@ -5,6 +5,9 @@ description: User Login Failed event details
 ---
 
 :type: user.login.failed
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Login Failed
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-login-id-duplicate-create.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-login-id-duplicate-create.adoc
@@ -5,6 +5,9 @@ description: User Login Id Duplicate Create event details
 ---
 
 :type: user.loginId.duplicate.create
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Login Id Duplicate Create
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-login-id-duplicate-update.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-login-id-duplicate-update.adoc
@@ -5,6 +5,9 @@ description: User Login Id Duplicate Update event details
 ---
 
 :type: user.loginId.duplicate.update
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Login Id Duplicate Update
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-login-new-device.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-login-new-device.adoc
@@ -5,6 +5,9 @@ description: User Login New Device event details
 ---
 
 :type: user.login.new-device
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Login New Device
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-login-success.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-login-success.adoc
@@ -5,6 +5,9 @@ description: User Login Success event details
 ---
 
 :type: user.login.success
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Login Success
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-login-suspicious.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-login-suspicious.adoc
@@ -5,6 +5,9 @@ description: User Login Suspicious event details
 ---
 
 :type: user.login.suspicious
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Login Suspicious
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-password-breach.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-password-breach.adoc
@@ -5,6 +5,9 @@ description: User Password Breach event details
 ---
 
 :type: user.password.breach
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Password Breach
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-password-reset-send.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-password-reset-send.adoc
@@ -5,6 +5,9 @@ description: User Password Reset Send event details
 ---
 
 :type: user.password.reset.send
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Password Reset Send
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-password-reset-start.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-password-reset-start.adoc
@@ -5,6 +5,9 @@ description: User Password Reset Start event details
 ---
 
 :type: user.password.reset.start
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Password Reset Start
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-password-reset-success.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-password-reset-success.adoc
@@ -5,6 +5,9 @@ description: User Password Reset Success event details
 ---
 
 :type: user.password.reset.success
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Password Reset Success
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-password-update.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-password-update.adoc
@@ -5,6 +5,9 @@ description: User Password Update event details
 ---
 
 :type: user.password.update
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Password Update
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-reactivate.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-reactivate.adoc
@@ -5,6 +5,9 @@ description: User Reactivate event details
 ---
 
 :type: user.reactivate
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Reactivate
 
 This event is generated when a user is re-activated. A re-activated user is one that had been soft deleted and has now been un-deleted.

--- a/site/docs/v1/tech/events-webhooks/events/user-registration-create-complete.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-registration-create-complete.adoc
@@ -5,6 +5,9 @@ description: User Registration Create Complete event details
 ---
 
 :type: user.registration.create.complete
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Registration Create Complete
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-registration-create.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-registration-create.adoc
@@ -5,6 +5,9 @@ description: User Registration Create event details
 ---
 
 :type: user.registration.create
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Registration Create
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-registration-delete-complete.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-registration-delete-complete.adoc
@@ -5,6 +5,9 @@ description: User Registration Delete Complete event details
 ---
 
 :type: user.registration.delete.complete
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Registration Delete Complete
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-registration-delete.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-registration-delete.adoc
@@ -5,6 +5,9 @@ description: User Registration Delete event details
 ---
 
 :type: user.registration.delete
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Registration Delete
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-registration-update-complete.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-registration-update-complete.adoc
@@ -5,6 +5,9 @@ description: User Registration Update Complete event details
 ---
 
 :type: user.registration.update.complete
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Registration Update Complete
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-registration-update.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-registration-update.adoc
@@ -5,6 +5,9 @@ description: User Registration Update event details
 ---
 
 :type: user.registration.update
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Registration Update
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-registration-verified.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-registration-verified.adoc
@@ -5,6 +5,9 @@ description: User Registration Verified event details
 ---
 
 :type: user.registration.verified
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Registration Verified
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-two-factor-method-add.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-two-factor-method-add.adoc
@@ -5,6 +5,9 @@ description: User Two-factor Method Add event details
 ---
 
 :type: user.two-factor.method.add
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Two-factor Method Add
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-two-factor-method-remove.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-two-factor-method-remove.adoc
@@ -5,6 +5,9 @@ description: User Two-factor Method Remove event details
 ---
 
 :type: user.two-factor.method.remove
+:event_info_since_threat_detection:
+:event_info_since_ip_address:
+
 == User Two-factor Method Remove
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-update-complete.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-update-complete.adoc
@@ -6,6 +6,9 @@ description: User Update Complete event details
 
 
 :type: user.update.complete
+:event_info_since_threat_detection: 
+:event_info_since_ip_address:
+
 == User Update Complete
 
 [NOTE.since]

--- a/site/docs/v1/tech/events-webhooks/events/user-update.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-update.adoc
@@ -5,6 +5,9 @@ description: User Update event details
 ---
 
 :type: user.update
+:event_info_since_threat_detection: pass:normal[[since]#Available since 1.30.0#]
+:event_info_since_ip_address: pass:normal[[since]#Available since 1.27.0#]
+
 == User Update
 
 [NOTE.since]


### PR DESCRIPTION
Some webhooks were added after eventinfo data was added, so it is weird to say a webhook was added in 1.30, but has a field since 1.27.