### PR TITLE
don't show the token on the user update response.

### DIFF
--- a/site/docs/v1/tech/apis/_user-response-body.adoc
+++ b/site/docs/v1/tech/apis/_user-response-body.adoc
@@ -41,11 +41,13 @@ The Two Factor Trust identifier. This value is returned when `trustComputer` was
 subsequent login requests to bypass the Two Factor challenge.
 endif::[]
 
+ifdef::create_user[]
 [field]#token# [type]#[String]# [since]#Available since 1.16.0#::
 The access token, this string is an encoded JSON Web Token (JWT).
 
 [field]#tokenExpirationInstant# [type]#[Long]# [since]#Available since 1.33.0#::
 The link:/docs/v1/tech/reference/data-types#instants[instant] the [field]#token# will expire. If the response does not contain a [field]#token#, this field will also be omitted from the response.
+endif::[]
 
 [field]#user.active# [type]#[Boolean]#::
 True if the User is active. False if the User has been deactivated. Deactivated Users will not be able to login.


### PR DESCRIPTION
Fix for https://github.com/FusionAuth/fusionauth-site/issues/1329