### PR TITLE
Corrected complete 'code' description.

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-start-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-start-response-body.adoc
@@ -1,3 +1,4 @@
+----
 [cols="1,9a"]
 .Response Codes
 |===
@@ -25,7 +26,7 @@ endif::[]
 
 [.api]
 [field]#code# [type]#[String]#::
-The code used to complete login using the Complete HYPR Login API.
+The code used to complete login using the Complete {idp_display_name} Login API.
 
 [source,json]
 .Example Response JSON


### PR DESCRIPTION
It was hardcoded to say HYPR but now says samlv2 when appropriate