### PR TITLE
fixed the reference to fusionauth-contrib.

### DIFF
--- a/site/docs/v1/tech/plugins/writing-a-plugin.adoc
+++ b/site/docs/v1/tech/plugins/writing-a-plugin.adoc
@@ -30,7 +30,7 @@ To begin, clone the following GitHub repository. This example code will assume y
 
 [source,shell]
 ----
-git clone git@github.com:FusionAuth/fusionauth-contrib.git
+git clone git@github.com:FusionAuth/fusionauth-example-password-encryptor.git
 cd fusionauth-example-password-encryptor
 mvn compile package
 ----
@@ -119,12 +119,7 @@ FusionAuth uses Guice for dependency injection and also to setup plugins. No mat
 In order for FusionAuth to locate your plugin, the package you put your plugin module into must include a parent package named either plugin or plugins. For example, a plugin class cannot be named `com.mycompany.fusionauth.MyExampleFusionAuthPluginModule`. Instead, it must be named `com.mycompany.fusionauth.plugins.MyExampleFusionAuthPluginModule`.
 ====
 
-Edit the example Guice module in the `src/main/java` directory.
-
-[source]
-----
-com/mycompany/fusionauth/plugins/guice/MyExampleFusionAuthPluginModule.java
-----
+Edit the example Guice module in the `src/main/java` directory: `com/mycompany/fusionauth/plugins/guice/MyExampleFusionAuthPluginModule.java`.
 
 Here is an example of what you will find in the example Guice module referenced above.
 


### PR DESCRIPTION
For the example project, we want to point to the example-password-encryptor repo, not the contrib repo.