### PR TITLE
Update Link API Doc (audit)

### DIFF
--- a/site/docs/src/json/identity-providers/links/create-link-request.json
+++ b/site/docs/src/json/identity-providers/links/create-link-request.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "jared@someLinkedIdp.com",
+  "displayName": "richard@piedpiper.com",
   "identityProviderId" : "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
   "identityProviderUserId" : "42",
   "userId" : "fbf0e652-b2b5-45eb-b9c9-d4640889740b"

--- a/site/docs/src/json/identity-providers/links/create-link-request.json
+++ b/site/docs/src/json/identity-providers/links/create-link-request.json
@@ -1,4 +1,5 @@
 {
+  "displayName": "jared@someLinkedIdp.com",
   "identityProviderId" : "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
   "identityProviderUserId" : "42",
   "userId" : "fbf0e652-b2b5-45eb-b9c9-d4640889740b"

--- a/site/docs/src/json/identity-providers/links/create-response.json
+++ b/site/docs/src/json/identity-providers/links/create-response.json
@@ -3,6 +3,9 @@
     "displayName": "richard@piedpiper.com",
     "identityProviderId" : "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
     "identityProviderUserId" : "42",
+    "insertInstant" :1623183147998,
+    "lastLoginInstant" : 1623183152224,
+    "tenantId" : "30663132-6464-6665-3032-326466613934",
     "userId" : "fbf0e652-b2b5-45eb-b9c9-d4640889740b"
   }
 }

--- a/site/docs/src/json/identity-providers/links/create-response.json
+++ b/site/docs/src/json/identity-providers/links/create-response.json
@@ -1,6 +1,6 @@
 {
   "identityProviderLink" : {
-    "displayName": "jared@someLinkedIdp.com",
+    "displayName": "richard@piedpiper.com",
     "identityProviderId" : "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
     "identityProviderUserId" : "42",
     "userId" : "fbf0e652-b2b5-45eb-b9c9-d4640889740b"

--- a/site/docs/src/json/identity-providers/links/create-response.json
+++ b/site/docs/src/json/identity-providers/links/create-response.json
@@ -1,5 +1,6 @@
 {
   "identityProviderLink" : {
+    "displayName": "jared@someLinkedIdp.com",
     "identityProviderId" : "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
     "identityProviderUserId" : "42",
     "userId" : "fbf0e652-b2b5-45eb-b9c9-d4640889740b"

--- a/site/docs/src/json/identity-providers/links/response.json
+++ b/site/docs/src/json/identity-providers/links/response.json
@@ -1,6 +1,6 @@
 {
   "identityProviderLink" : {
-    "displayName" : "erlich@piedpiper.com",
+    "displayName" : "richard@piedpiper.com",
     "identityProviderId" : "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
     "identityProviderUserId" : "42",
     "insertInstant" :1623183147998,

--- a/site/docs/src/json/identity-providers/links/responses.json
+++ b/site/docs/src/json/identity-providers/links/responses.json
@@ -1,23 +1,23 @@
 {
   "identityProviderLinks" : [
     {
-      "displayName" : "erlich@piedpiper.com",
+      "displayName" : "richard@piedpiper.com",
       "identityProviderId" : "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
       "identityProviderUserId" : "42",
       "insertInstant" :1623183147998,
       "lastLoginInstant" : 1623183152224,
       "tenantId" : "30663132-6464-6665-3032-326466613934",
-      "token" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+      "token" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0MiIsIm5hbWUiOiJSaWNoYXJkIiwiaWF0IjoxNTE2MjM5MDIyfQ.hFtOTx0nZ58YNJlYLI9kV2Tt0Jg1yxdW7Gy-43V4clc",
       "userId" : "fbf0e652-b2b5-45eb-b9c9-d4640889740b"
     },
     {
-      "displayName" : "erlich@piedpiper.com",
+      "displayName" : "richard@hooli.com",
       "identityProviderId" : "363ae8d9-dd4d-4473-bdc6-3694f1d0329e",
       "identityProviderUserId" : "9821123",
       "insertInstant" :1623183147998,
-      "lastLoginInstant" : 1623183152224,
+      "lastLoginInstant" : 1623183152225,
       "tenantId" : "30663132-6464-6665-3032-326466613934",
-      "token" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+      "token" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5ODIxMTIzIiwibmFtZSI6IlJpY2hhcmQiLCJpYXQiOjE1MTYyMzkwMjJ9.bGRRUQBhdg6kS4sjiWrR-7xrOa6A2MzI9QhWlDcNf-Y",
       "userId" : "fbf0e652-b2b5-45eb-b9c9-d4640889740b"
     }
   ]

--- a/site/docs/v1/tech/apis/identity-providers/_link-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_link-response-body-base.adoc
@@ -5,7 +5,7 @@ The list of Link objects.
 endif::[]
 
 [field]#{base_field_name}.displayName# [type]#[String]#::
-A human readable name for this link for identification and convenience. This value will generally be an email address, or username. This value can be set by the API caller. So for instance, this value could be `Initial piedpiper link from user migration`. This value will be updated during the next login for the linked user based on the identify provider (`richard@piedpiper.com`, for instance). This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
+A human readable name for this link. In most cases this value will be the username or email address of the user in the remote identity provider.
 
 [field]#{base_field_name}.identityProviderId# [type]#[UUID]#::
 The unique Id of the identity provider.

--- a/site/docs/v1/tech/apis/identity-providers/_link-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_link-response-body-base.adoc
@@ -5,7 +5,7 @@ The list of Link objects.
 endif::[]
 
 [field]#{base_field_name}.displayName# [type]#[String]#::
-A human readable name for this link to help you identify this link. This value will generally be an email address, or username. This value is recorded when the link is made, and updated during the next login for this identity provider. This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
+A human readable name for this link for identification and convenience. This value will generally be an email address, or username. This value can be set by the API caller. So for instance, this value could be `Initial piedpiper link from user migration`. This value will be updated during the next login for the linked user based on the identify provider (`richard@piedpiper.com`, for instance). This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
 
 [field]#{base_field_name}.identityProviderId# [type]#[UUID]#::
 The unique Id of the identity provider.

--- a/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
@@ -2,7 +2,7 @@
 
 [.api]
 [field]#displayName# [type]#[String]# [optional]#Optional#::
-The display name of the linked user from the IdP.
+A human readable name for this link to help you identify this link. This value will generally be an email address, or username. This value is recorded when the link is made, and updated during the next login for this identity provider. This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider
 
 [field]#identityProviderLink.identityProviderId# [type]#[UUID]#::
 The unique Id of the identity provider.

--- a/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
@@ -1,6 +1,9 @@
 ==== Response Body
 
 [.api]
+[field]#displayName# [type]#[String]# [optional]#Optional#::
+The display name of the linked user from the IdP.
+
 [field]#identityProviderLink.identityProviderId# [type]#[UUID]#::
 The unique Id of the identity provider.
 

--- a/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
@@ -1,7 +1,7 @@
 ==== Response Body
 
 [.api]
-[field]#displayName# [type]#[String]#::
+[field]#identityProviderLink.displayName# [type]#[String]#::
 A human readable name for this link for identification and convenience. This value will generally be an email address, or username. This value can be set by the API caller. So for instance, this value could be `Initial piedpiper link from user migration`. This value will be updated during the next login for the linked user based on the identify provider (`richard@piedpiper.com`, for instance). This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
 
 [field]#identityProviderLink.identityProviderId# [type]#[UUID]#::

--- a/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
@@ -1,8 +1,8 @@
 ==== Response Body
 
 [.api]
-[field]#displayName# [type]#[String]# [optional]#Optional#::
-A human readable name for this link to help you identify this link. This value will generally be an email address, or username. This value is recorded when the link is made, and updated during the next login for this identity provider. This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider
+[field]#displayName# [type]#[String]#::
+A human readable name for this link for identification and convenience. This value will generally be an email address, or username. This value can be set by the API caller. So for instance, this value could be `Initial piedpiper link from user migration`. This value will be updated during the next login for the linked user based on the identify provider (`richard@piedpiper.com`, for instance). This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
 
 [field]#identityProviderLink.identityProviderId# [type]#[UUID]#::
 The unique Id of the identity provider.

--- a/site/docs/v1/tech/apis/identity-providers/index.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/index.adoc
@@ -35,7 +35,7 @@ The way a link is established between an identity provider and FusionAuth is det
 
 === Login
 
-The Login endpoint is used to allow credentials from a corresponding IdP to be used to log a user in. The endpoint remains the same, but details will vary with each IdP. Please reference the `complete the login` section of each IdP you are integrating with for more information.
+This endpoint is shared across all IdP's. Please reference the `complete the login` section of each IdP you are integrating with for more information regarding.
 
 
 link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Complete the login with any Identity Provider

--- a/site/docs/v1/tech/apis/identity-providers/index.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/index.adoc
@@ -33,6 +33,18 @@ To learn how to configure these Identity Providers using the FusionAuth UI, go h
 
 The way a link is established between an identity provider and FusionAuth is determined by the `linkingStrategy` for each identity provider. An API is provided to manually link and unlink a user to a 3rd party identity provider. To learn more about managing links between FusionAuth and a 3rd party identity provider, see the link:/docs/v1/tech/apis/identity-providers/links[Link APIs].
 
+=== Login
+
+The Login endpoint is used to allow credentials from a corresponding IdP to be used to log a user in. The endpoint remains the same, but details will vary with each IdP. Please reference the `complete the login` section of each IdP you are integrating with for more information.
+
+
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Complete the login with any Identity Provider
+[.endpoint]
+.URI
+--
+[method]#GET# [uri]#/api/identity-provider/login#
+--
+
 === Global Operations
 
 * <<Retrieve all Identity Providers>>

--- a/site/docs/v1/tech/apis/identity-providers/index.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/index.adoc
@@ -37,7 +37,6 @@ The way a link is established between an identity provider and FusionAuth is det
 
 This endpoint is shared across all IdP's. Please reference the `complete the login` section of each IdP you are integrating with for more information regarding.
 
-
 link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Complete the login with any Identity Provider
 [.endpoint]
 .URI

--- a/site/docs/v1/tech/apis/identity-providers/index.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/index.adoc
@@ -35,7 +35,7 @@ The way a link is established between an identity provider and FusionAuth is det
 
 === Login
 
-This endpoint is shared across all IdP's. Please reference the `complete the login` section of each IdP you are integrating with for more information regarding.
+This endpoint is accessible across all IdP's. Please reference the `complete the login` section of each IdP you are integrating with for more information regarding the request and response object required.
 
 link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Complete the login with any Identity Provider
 [.endpoint]

--- a/site/docs/v1/tech/apis/identity-providers/index.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/index.adoc
@@ -33,17 +33,6 @@ To learn how to configure these Identity Providers using the FusionAuth UI, go h
 
 The way a link is established between an identity provider and FusionAuth is determined by the `linkingStrategy` for each identity provider. An API is provided to manually link and unlink a user to a 3rd party identity provider. To learn more about managing links between FusionAuth and a 3rd party identity provider, see the link:/docs/v1/tech/apis/identity-providers/links[Link APIs].
 
-=== Login
-
-This endpoint is accessible across all IdP's. Please reference the `complete the login` section of each IdP you are integrating with for more information regarding the request and response object required.
-
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Complete the login with any Identity Provider
-[.endpoint]
-.URI
---
-[method]#GET# [uri]#/api/identity-provider/login#
---
-
 === Global Operations
 
 * <<Retrieve all Identity Providers>>

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -35,7 +35,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 ==== Request Body
 
 [.api]
-[field]#displayName# [type]#[String]# [optional]#Optional#::
+[field]#displayName# [type]#[String]# [optional]#Optional# [since]#Available since 1.36.5#::
 A human readable name for this link for identification and convenience. This value will generally be an email address, or username. This value can be set by the API caller. So for instance, this value could be `Initial piedpiper link from user migration`. This value will be updated during the next login for the linked user based on the identify provider (`richard@piedpiper.com`, for instance). This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
 
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -63,7 +63,7 @@ include::docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc[]
 
 == Complete a pending Link
 
-This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a pending link Id will be returned from the Login API that can be used here.
+This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a pending link Id will be returned from the Login API for the particular IdP (`POST /api/identity-provider/login`) can be used here.
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -56,14 +56,16 @@ include::docs/src/json/identity-providers/links/create-link-request.json[]
 === Response
 
 :never_search_error:
+:webhook_event:
 include::docs/v1/tech/apis/_standard-post-response-codes.adoc[]
+:webhook_event!:
 :never_search_error!:
 
 include::docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc[]
 
 == Complete a pending Link
 
-This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned from the Login API (`POST /api/identity-provider/login`).  This value should be used here.
+This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned from the link:/docs/v1/tech/apis/identity-providers/#complete-the-login[Login API]).  This value should be used here.
 
 === Request
 
@@ -93,7 +95,9 @@ include::docs/src/json/identity-providers/links/pending-link-request.json[]
 === Response
 
 :never_search_error:
+:webhook_event:
 include::docs/v1/tech/apis/_standard-post-response-codes.adoc[]
+:webhook_event!:
 :never_search_error!:
 
 include::docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc[]
@@ -196,5 +200,7 @@ The FusionAuth User Id that is linked to the identity provider.
 This API does not return a JSON response body.
 
 :never_search_error:
+:webhook_event:
 include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 :never_search_error!:
+:webhook_event!:

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -35,6 +35,9 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 ==== Request Body
 
 [.api]
+[field]#displayName# [type]#[String]# [optional]#Optional#::
+The display name of the linked user.
+
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::
 The Id of the identity provider. This identity provider must exist.
 

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -35,7 +35,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 ==== Request Body
 
 [.api]
-[field]#displayName# [type]#[String]# [optional]#Optional# [since]#Available since 1.36.5#::
+[field]#displayName# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.1#::
 A human readable name for this link for identification and convenience. This value will generally be an email address, or username. This value can be set by the API caller. So for instance, this value could be `Initial piedpiper link from user migration`. This value will be updated during the next login for the linked user based on the identify provider (`richard@piedpiper.com`, for instance). This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
 
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::
@@ -63,7 +63,7 @@ include::docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc[]
 
 == Complete a pending Link
 
-This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned from the Login API (`/api/identity-provider/login`).  This value should be used here.
+This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned from the Login API (`POST /api/identity-provider/login`).  This value should be used here.
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -36,7 +36,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 
 [.api]
 [field]#displayName# [type]#[String]# [optional]#Optional#::
-A human readable name for this link to help you identify this link. This value will generally be an email address, or username. This value is recorded when the link is made, and updated during the next login for this identity provider. This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider
+A human readable name for this link for identification and convenience. This value will generally be an email address, or username. This value can be set by the API caller. So for instance, this value could be `Initial piedpiper link from user migration`. This value will be updated during the next login for the linked user based on the identify provider (`richard@piedpiper.com`, for instance). This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
 
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::
 The Id of the identity provider. This identity provider must exist.
@@ -63,7 +63,7 @@ include::docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc[]
 
 == Complete a pending Link
 
-This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a pending link Id will be returned from the Login API for the particular IdP (`POST /api/identity-provider/login`) can be used here.
+This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned from the Login API (`/api/identity-provider/login`).  This value should be used here.
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -36,7 +36,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 
 [.api]
 [field]#displayName# [type]#[String]# [optional]#Optional#::
-The display name of the linked user.
+A human readable name for this link to help you identify this link. This value will generally be an email address, or username. This value is recorded when the link is made, and updated during the next login for this identity provider. This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider
 
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::
 The Id of the identity provider. This identity provider must exist.

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -36,7 +36,10 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 
 [.api]
 [field]#displayName# [type]#[String]# [optional]#Optional# [since]#Available since 1.28.1#::
-A human readable name for this link for identification and convenience. This value will generally be an email address, or username. This value can be set by the API caller. So for instance, this value could be `Initial piedpiper link from user migration`. This value will be updated during the next login for the linked user based on the identify provider (`richard@piedpiper.com`, for instance). This value may not necessarily reflect the username or email you used to authenticate with the 3rd party identity provider.
+A human readable name for this link. This value should be used to make it easier to identify the user this link represents in the remote identity provider.
++
+This value is optional and it will always be set by FusionAuth the next time this link is used to resolve the FusionAuth user during a login event for this IdP.
+
 
 [field]#identityProviderId# [type]#[UUID]# [required]#Required#::
 The Id of the identity provider. This identity provider must exist.

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -68,7 +68,7 @@ include::docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc[]
 
 == Complete a pending Link
 
-This API is used complete a pending link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned from the link:/docs/v1/tech/apis/identity-providers/#complete-the-login[Login API].  This value can be used in the below request.
+This API is used complete a pending link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned by the Identity Provider API (see the `Complete the Login` section for each respective IdP). This value can be used in the request below.
 
 === Request
 

--- a/site/docs/v1/tech/apis/identity-providers/links.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/links.adoc
@@ -65,7 +65,7 @@ include::docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc[]
 
 == Complete a pending Link
 
-This API is used complete a pending Link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned from the link:/docs/v1/tech/apis/identity-providers/#complete-the-login[Login API]).  This value should be used here.
+This API is used complete a pending link. If an identity provider is configured with a linking strategy of `Create a pending link`, a `pendingLinkId` will be returned from the link:/docs/v1/tech/apis/identity-providers/#complete-the-login[Login API].  This value can be used in the below request.
 
 === Request
 


### PR DESCRIPTION
- Add display name to link API.
- Minor adjustments after completing link flow.
- Closes:  https://github.com/FusionAuth/fusionauth-site/issues/1404

confirmed the response for 

- [x]  `POST /api/identity-provider/link` when using `userId`, `displayName`, `identityProviderId`, and `identityProviderUserId` as request params
- [x]  `POST /api/identity-provider/link` when using `pendingIdpLinkId`, `userId` as request params
- [x] `GET all/idp/user links` responses.  the only change would be to maybe list another example token when more than one link is returned. 

added issue -> https://github.com/FusionAuth/fusionauth-issues/issues/1746 -> related