### PR TITLE
Add release rss feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ out/
 assets/img/diagrams
 site/assets/img/diagrams
 
+# Generated releases.xml file
+site/docs/v1/tech/releases.xml
+
 .shelf
 
 # these are used by the github action but we want to ignore when checking to see if we have anything not checked in

--- a/site/_plugins/jekyll-releases-rss.rb
+++ b/site/_plugins/jekyll-releases-rss.rb
@@ -1,0 +1,67 @@
+require 'net/http'
+require 'uri'
+require 'json'
+require 'rss'
+require 'nokogiri'
+
+module Jekyll
+  class ReleasesFeedGenerator < Generator
+
+    def generate(site)
+      url = 'https://account.fusionauth.io/api/version'
+      content = Net::HTTP.get(URI.parse(url))
+
+      rn_url = 'https://fusionauth.io/docs/v1/tech/release-notes'
+      rn_content = Net::HTTP.get(URI.parse(rn_url))
+      rn_doc = Nokogiri::HTML::DocumentFragment.parse(rn_content)
+
+      rn_archive_url = 'https://fusionauth.io/docs/v1/tech/archive/release-notes'
+      rn_archive_content = Net::HTTP.get(URI.parse(rn_archive_url))
+      rn_archive_doc = Nokogiri::HTML::DocumentFragment.parse(rn_archive_content)
+
+
+      releases = JSON.parse(content)
+      releaseslist = releases['versions'].reverse()
+      rss = RSS::Maker.make("atom") do |maker|
+        maker.channel.author = "FusionAuth"
+        maker.channel.about = "https://fusionauth.io"
+        maker.channel.title = "FusionAuth Releases Feed"
+
+        maker.channel.updated = nil
+        
+        releaseslist.each do |r|
+          if /RC/.match(r)
+            next
+          end
+          anchor_text = r.to_s.gsub("\.","-")
+          
+          fragment = rn_doc.css('#version-'+anchor_text +' + p')
+          date = fragment.css('p > em').inner_text
+          unless date && date.length > 2
+            # look in archive
+            fragment = rn_archive_doc.css('#version-'+anchor_text +' + p')
+            date = fragment.css('p > em').inner_text
+          end
+
+          maker.items.new_item do |item|
+            item.link = "https://fusionauth.io/docs/v1/tech/release-notes#version-"+anchor_text
+            item.title = "Release "+r.to_s
+            if date && date.length > 2
+              item.updated = date.to_s
+            end
+          end
+
+          if maker.channel.updated.nil?
+            # first time, we want to grab the latest release timestamp
+            maker.channel.updated =  date.to_s
+          end
+        end
+      end
+
+      file_name = "releases.xml"
+      output_dir = "#{site.source}/docs/v1/tech/"
+      File.open(output_dir+file_name, "w") { |f| f.write rss}
+      site.static_files << Jekyll::StaticFile.new(site, '', output_dir, file_name)
+    end
+  end
+end

--- a/site/_plugins/jekyll-releases-rss.rb
+++ b/site/_plugins/jekyll-releases-rss.rb
@@ -48,6 +48,9 @@ module Jekyll
             item.title = "Release "+r.to_s
             if date && date.length > 2
               item.updated = date.to_s
+            else
+              # too new to have release notes, let's mark it as today.
+              item.updated = Time.now.to_s
             end
           end
 

--- a/site/docs/v1/tech/release-notes.adoc
+++ b/site/docs/v1/tech/release-notes.adoc
@@ -54,7 +54,9 @@ Release notes should have sections such as the following, omit ones that do not 
 
 Looking for release notes older than 1.23.0? Look in the link:/docs/v1/tech/archive/release-notes[release notes archive].
 
-Looking for link:/docs/v1/tech/releases.xml[a RSS feed of releases?]
+++++
+<a href='/docs/v1/tech/releases.xml'>RSS feed of releases: <i class="fas fa-rss"></i></a>
+++++
 
 [role=release-note]
 

--- a/site/docs/v1/tech/release-notes.adoc
+++ b/site/docs/v1/tech/release-notes.adoc
@@ -54,6 +54,8 @@ Release notes should have sections such as the following, omit ones that do not 
 
 Looking for release notes older than 1.23.0? Look in the link:/docs/v1/tech/archive/release-notes[release notes archive].
 
+Looking for link:/docs/v1/tech/releases.xml[a RSS feed of releases?]
+
 [role=release-note]
 
 == Version 1.36.4


### PR DESCRIPTION
This addresses: https://github.com/FusionAuth/fusionauth-issues/issues/1184 by providing a public RSS feed for anyone who wants to be notified of new FusionAuth releases automatically.