### PR TITLE
Add note about skip verification

### DIFF
--- a/site/docs/v1/tech/apis/_user-registration-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-registration-request-body.adoc
@@ -35,6 +35,8 @@ The username of the User for this Application. This username cannot be used to l
 ifeval::["{http_method}" == "POST"]
 [field]#skipRegistrationVerification# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 Indicates to FusionAuth that it should skip registration verification even if it is enabled for the Application.
++
+Setting this to `true` will set [field]#registration.verified# to `true` as well.
 endif::[]
 
 ifeval::["{http_method}" == "POST"]

--- a/site/docs/v1/tech/apis/_user-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-request-body.adoc
@@ -24,7 +24,7 @@ endif::[]
 [field]#skipVerification# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 Indicates to FusionAuth that it should skip email verification even if it is enabled. This is useful for creating admin or internal User accounts.
 +
-This will set the [field]#verified# field to true.
+Setting this to `true` will set the [field]#user.verified# field to true as well.
 
 [field]#user.birthDate# [type]#[String]# [optional]#Optional#::
 An `ISO-8601` formatted date of the User's birthdate such as `YYYY-MM-DD`.

--- a/site/docs/v1/tech/apis/_user-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-request-body.adoc
@@ -23,6 +23,8 @@ endif::[]
 
 [field]#skipVerification# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 Indicates to FusionAuth that it should skip email verification even if it is enabled. This is useful for creating admin or internal User accounts.
++
+This will set the [field]#verified# field to true.
 
 [field]#user.birthDate# [type]#[String]# [optional]#Optional#::
 An `ISO-8601` formatted date of the User's birthdate such as `YYYY-MM-DD`.

--- a/site/docs/v1/tech/apis/_user-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-request-body.adoc
@@ -24,7 +24,7 @@ endif::[]
 [field]#skipVerification# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 Indicates to FusionAuth that it should skip email verification even if it is enabled. This is useful for creating admin or internal User accounts.
 +
-Setting this to `true` will set the [field]#user.verified# field to true as well.
+Setting this to `true` will set the [field]#user.verified# field to `true` as well.
 
 [field]#user.birthDate# [type]#[String]# [optional]#Optional#::
 An `ISO-8601` formatted date of the User's birthdate such as `YYYY-MM-DD`.


### PR DESCRIPTION
As [outlined in this issue](https://github.com/FusionAuth/fusionauth-issues/issues/1732), skipVerification is a bit confusing to users, who seem to think it should leave the user in an unverified state.

But according to the code and https://github.com/FusionAuth/fusionauth-issues/issues/1732#issuecomment-1149934435, that is not so, it actually sets `verified` to `true`.

This doc updates our API docs to make that clear.