### PR TITLE
Added in plugin to modify rendering of blog posts.

### DIFF
--- a/site/_plugins/jekyll-add-copy-to-blog-posts.rb
+++ b/site/_plugins/jekyll-add-copy-to-blog-posts.rb
@@ -1,0 +1,10 @@
+# this hook adds the copy/paste attributes to any highlighted blog post sections. 
+# they are then picked up by javascript in the browser, allowing the user to copy the contents easily.
+
+Jekyll::Hooks.register :posts, :post_render do |post|
+   # look for pre tags with highlight class, 
+   # add <i class="cursor-pointer fal fa-fw fa-copy" data-widget="copy-button" style="float:right"></i>
+   # as the first child
+   post.output.gsub!('<pre class="highlight">','<pre class="highlight"><i class="cursor-pointer fal fa-fw fa-copy" data-widget="copy-button" style="float:right"></i>')
+   
+end

--- a/site/_plugins/jekyll-add-copy-to-blog-posts.rb
+++ b/site/_plugins/jekyll-add-copy-to-blog-posts.rb
@@ -5,6 +5,6 @@ Jekyll::Hooks.register :posts, :post_render do |post|
    # look for pre tags with highlight class, 
    # add <i class="cursor-pointer fal fa-fw fa-copy" data-widget="copy-button" style="float:right"></i>
    # as the first child
-   post.output.gsub!('<pre class="highlight">','<pre class="highlight"><i class="cursor-pointer fal fa-fw fa-copy" data-widget="copy-button" style="float:right"></i>')
+   post.output.gsub!('<pre class="highlight">','<pre class="highlight"><i class="cursor-pointer fal fa-fw fa-copy" data-widget="copy-button" style="float:right"></i><div>   </div>')
    
 end


### PR DESCRIPTION
This plugin adds the copy-button widget to any pre section with the highlight class. 

https://www.mslinn.com/jekyll/10100-jekyll-plugin-background.html was useful.