### PR TITLE
clarified registration behavior.

### DIFF
--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -240,7 +240,7 @@ Determines if self service registration is enabled for this application. When th
 +
 Self service registration cannot be enabled on the FusionAuth application.
 +
-If `true`, any user logging in to this application will automatically have a registration created, if they are not already registered.
+If `true`, any user logging in to this application using hosted login pages will automatically have a registration created, if they are not already registered.
 
 [field]#application.registrationConfiguration.firstName.enabled# [type]#[Boolean]# [optional]#Optional# [default]#Defaults to `false`# [since]#Available since 1.4.0#::
 Determines if the `firstName` field will be included on the registration form.


### PR DESCRIPTION
https://github.com/FusionAuth/fusionauth-site/pull/1470 was slightly incomplete. The login has to be via the hosted login pages. The login API doesn't have this behavior.