### PR TITLE
increase record size

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -80,6 +80,7 @@ algolia:
   search_only_api_key: 'e65ffc9f8bb352def753e7614de78416'
   files_to_exclude: []
   nodes_to_index: 'a,blockquote,code,dd,div,dt,h1,h2,h3,h4,h5,p,span'
+  max_record_size: 20000
   extensions_to_index:
     - md
     - adoc


### PR DESCRIPTION
tenant data busted the 10k default: https://github.com/FusionAuth/fusionauth-site/runs/7075936745?check_suite_focus=true