### PR TITLE
try some hooks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,7 +79,7 @@ algolia:
   index_name: 'website'
   search_only_api_key: 'e65ffc9f8bb352def753e7614de78416'
   files_to_exclude: []
-  nodes_to_index: 'a,blockquote,dd,dt,h1,h2,h3,h4,h5,p,span,code'
+  nodes_to_index: 'a,blockquote,code,dd,dt,h1,h2,h3,h4,h5,p,span'
   extensions_to_index:
     - md
     - adoc

--- a/site/_plugins/algolia_hooks.rb
+++ b/site/_plugins/algolia_hooks.rb
@@ -13,8 +13,8 @@ module Jekyll
           # Simplify h1, h2, h3, h4, h5 and h6 indexing in case of embedded elements.
           # - Specifically, the h1 in release notes includes an inner <a> that does not need to be indexed.
           if %w[h1 h2 h3 h4 h5 h6].include? _node.name
-            record[:html] = _node.text
-            record[:text] = _node.text.strip
+            record[:html] = _node.text.strip
+            record[:text] = _node.text
           end
 
           # Collapse JSON for better searching.

--- a/site/_plugins/algolia_hooks.rb
+++ b/site/_plugins/algolia_hooks.rb
@@ -8,12 +8,32 @@ module Jekyll
       end
 
       def self.before_indexing_each(record, _node, _context)
+        if _node != nil
+
+          # Simplify h1, h2, h3, h4, h5 and h6 indexing in case of embedded elements.
+          # - Specifically, the h1 in release notes includes an inner <a> that does not need to be indexed.
+          if %w[h1 h2 h3 h4 h5 h6].include? _node.name
+            record[:html] = _node.text
+            record[:text] = _node.text.strip
+          end
+
+          # Collapse JSON for better searching.
+          # - Sort of a variation of https://github.com/algolia/jekyll-algolia/issues/63#issuecomment-380863265
+          #   .content, .text, .to_str, and .inner_text are all aliases.
+          # - Do we have to also modify record[:html] ?
+          if _node.name == 'code' && _node.attr('data-lang') == 'json'
+            record[:html] = _node.text.strip
+            record[:text] = _node.text
+          end
+
+        end
+
         # skip really long records
         if record[:content] && record[:content].length > 9000
           puts "skipping some content on " + record[:url] + " as it has a length of " +record[:content].length.to_s
           return nil
         end
-        
+
         # from https://community.algolia.com/jekyll-algolia/hooks.html
         # don't send entire html
         # we don't need it, takes up more space


### PR DESCRIPTION
This sort of works I think? 

Goals:
For things like `code` elements, strip all inner tags such as `p`, `span` etc and just index the raw `innerText` This way we can properly search these elements without causing algolia to think we actually want each of these sub elements indexed. 

I think this is possible, I may not have it quite nailed down. I started with this example: https://github.com/algolia/jekyll-algolia/issues/63#issuecomment-380863265

Questions:
1. It passes a build (mostly) when running `bundle exec jekyll algolia --dry-run` is there any way to actually test the new index locally? 
4. With these changes I still get one doc to big - but it should be matching my `code` hook, so I may not completely understand what is happening yet. I must not be stripping things out as I want. Perhaps I need to traverse all children and concat the text or something? The too big doc is `/docs/v1/tech/apis/scim/SCIMServiceProvider.html`.

Any thoughts on how to test this and see what ends up in the index? 