### PR TITLE
Fixed incorrect event type on the unlinking event page

### DIFF
--- a/site/docs/v1/tech/events-webhooks/events/user-identity-provider-unlink.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/user-identity-provider-unlink.adoc
@@ -22,7 +22,7 @@ This event is generated when a link to an Identity Provider is removed.
 .Event type
 [subs="attributes"]
 ----
-user.delete
+{type}
 ----
 
 === Event Scope


### PR DESCRIPTION
Filed here: https://github.com/FusionAuth/fusionauth-site/issues/1533