### PR TITLE
Fixed typo on scope parameter in example password grant.

### DIFF
--- a/site/docs/v1/tech/oauth/index.adoc
+++ b/site/docs/v1/tech/oauth/index.adoc
@@ -343,7 +343,7 @@ client_id=3c219e58-ed0e-4b18-ad48-f4f92793ae32
     &grant_type=password
     &username=richard%40piedpiper.com
     &password=disrupt
-    &scopes=offline_access
+    &scope=offline_access
 ----
 
 [source,json]


### PR DESCRIPTION
Reported in https://github.com/FusionAuth/fusionauth-issues/issues/1826