### PR TITLE
Explain what the http read timeout actually does.

### DIFF
--- a/site/docs/v1/tech/reference/configuration.adoc
+++ b/site/docs/v1/tech/reference/configuration.adoc
@@ -238,7 +238,7 @@ Deprecated names:
 * `fusionauth-app.https-port`
 
 [field]#fusionauth-app.http.read-timeout# [type]#[Integer]# [default]#defaults to `20,000`# [since]#Available since 1.37.0#::
-The HTTP read timeout in milliseconds that the server will wait to read data from
+The HTTP read timeout in milliseconds that the server will wait to read data from an incoming request.
 
 [field]#fusionauth-app.kickstart.file# [type]#[String]#::
 The path to the FusionAuth Kickstart JSON file.


### PR DESCRIPTION
Noticed that this is cut off in the current configuration reference.

However, it appears to say milliseconds, but the read timeout handler so configured seems to use seconds as the unit. So maybe there's a deeper issue?

Relevant links:

* https://github.com/prime-framework/prime-mvc/blob/master/src/main/java/org/primeframework/mvc/netty/PrimeHTTPServerInitializer.java#L59 
* https://netty.io/4.0/api/io/netty/handler/timeout/ReadTimeoutHandler.html

Also I couldn't find where it was defaulted to 20,000.