### PR TITLE
Fix link single sign on guide

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -26,6 +26,8 @@ jobs:
       # Spellcheck
       - uses: igsekor/pyspelling-any@v0.0.2
         name: Spellcheck
+      # invert the results of the find command. If we find anything, we want to fail. Otherwise succeed.
+      # more here: https://stackoverflow.com/questions/367069/how-can-i-negate-the-return-value-of-a-process
       - name: Check for broken asciidoctor links
         run: |
           ! find _site/docs -type f|xargs grep -l 'BROKEN LINK'

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -26,3 +26,7 @@ jobs:
       # Spellcheck
       - uses: igsekor/pyspelling-any@v0.0.2
         name: Spellcheck
+      - name: Check for broken asciidoctor links
+        run: |
+          ! find _site/docs -type f|xargs grep -l 'BROKEN LINK'
+        shell: bash

--- a/site/docs/v1/tech/guides/single-sign-on.adoc
+++ b/site/docs/v1/tech/guides/single-sign-on.adoc
@@ -33,7 +33,7 @@ If, instead, another datastore is your system of record, check out the link:/doc
 * <<Set Up The Code>>
 * <<Test The Results>>
 * <<Other Scenarios>>
-* <<Additional Configuration >>
+* <<Additional Configuration>>
 * <<Limitations>>
 * <<Additional Resources>>
 
@@ -681,7 +681,7 @@ video::QYuTOD8wjZU[youtube,width=560,height=315]
 
 Please see the link:/docs/v1/tech/samlv2/[SAML IdP] and link:/docs/v1/tech/oauth/[OIDC documentation] or the single sign-on documentation for the application you're looking to integrate with for more.
 
-== Additional Configuration 
+== Additional Configuration
 
 === Session Expiration
 


### PR DESCRIPTION
There is a 'broken link' in the TOC.

Also changed the spellcheck action to check and see if there are any borked links.