### PR TITLE
Fix busted premium features link

### DIFF
--- a/site/_layouts/doc.liquid
+++ b/site/_layouts/doc.liquid
@@ -393,6 +393,7 @@
                 <li {% if page.navcategory == "premium" %} class="open"{% endif %}>
                  <a href="#" class="sub-menu"><i class="fal fa-fw fa-dollar-sign"></i> Premium Features <i class="fal fa-chevron-{% if page.navcategory == "premium" %}up{% else %}down{% endif %} fa-fw"></i></a>
                   <ul>
+                    <li {% if page.url == "/docs/v1/tech/premium-features/" %}class="active"{% endif %}><a href="/docs/v1/tech/premium-features/">Overview</a></li>
                     <li {% if page.url == "/docs/v1/tech/advanced-threat-detection/" %}class="active"{% endif %}><a href="/docs/v1/tech/advanced-threat-detection/">Advanced Threat Detection</a></li>
                     <li {% if page.url contains "/connectors/" %} class="open"{% endif %}>
                       <a href="#" class="sub-menu">Connectors <i class="fal fa-chevron-{% if page.url contains "/connectors/" %}up{% else %}down{% endif %} fa-fw"></i></a>

--- a/site/docs/v1/tech/core-concepts/index.adoc
+++ b/site/docs/v1/tech/core-concepts/index.adoc
@@ -31,5 +31,4 @@ Finally, FusionAuth is under active development and the roadmap guidance is help
 * link:/docs/v1/tech/core-concepts/authentication-authorization[Authentication and Authorization]
 * link:/docs/v1/tech/core-concepts/integration-points[Integration Points]
 * link:/docs/v1/tech/core-concepts/localization-and-internationalization[Localization and Internationalization]
-* link:/docs/v1/tech/premium-features[Premium Features]
 * link:/docs/v1/tech/core-concepts/roadmap[Roadmap Guidance]

--- a/site/docs/v1/tech/core-concepts/index.adoc
+++ b/site/docs/v1/tech/core-concepts/index.adoc
@@ -31,5 +31,5 @@ Finally, FusionAuth is under active development and the roadmap guidance is help
 * link:/docs/v1/tech/core-concepts/authentication-authorization[Authentication and Authorization]
 * link:/docs/v1/tech/core-concepts/integration-points[Integration Points]
 * link:/docs/v1/tech/core-concepts/localization-and-internationalization[Localization and Internationalization]
-* link:/docs/v1/tech/core-concepts/premium-features[Premium Features]
+* link:/docs/v1/tech/premium-features[Premium Features]
 * link:/docs/v1/tech/core-concepts/roadmap[Roadmap Guidance]

--- a/site/docs/v1/tech/premium-features/index.adoc
+++ b/site/docs/v1/tech/premium-features/index.adoc
@@ -1,0 +1,19 @@
+---
+layout: doc
+title: FusionAuth Premium Features
+description: FusionAuth Premium Features
+navcategory: premium
+---
+
+:sectnumlevels: 0
+
+== Overview
+
+FusionAuth has a full featured community edition, but some features are reserved for customer with a license key. This section outlines the features and how to use them.
+
+* link:/docs/v1/tech/advanced-threat-detection[Advanced Threat Detection] - IP ACLS, security related events, CAPTCHA and more
+* link:/docs/v1/tech/connectors[Connectors] - authenticate and migrate users from external data sources
+* link:/docs/v1/tech/core-concepts/entity-management[Entity Management] - model permissions for things other than users such as companies or IoT devices
+* link:/docs/v1/tech/core-concepts/scim[SCIM] - Provision users with the SCIM standard
+* link:/docs/v1/tech/account-management[Self Service Account Management] - Allow users to modify their profile and enable MFA
+

--- a/src/cloudfront/fusionauth-website-request-handler.js
+++ b/src/cloudfront/fusionauth-website-request-handler.js
@@ -34,6 +34,7 @@ var indexPages = {
   '/docs/v1/tech/migration-guide/': true,
   '/docs/v1/tech/oauth/': true,
   '/docs/v1/tech/plugins/': true,
+  '/docs/v1/tech/premium-features/': true,
   '/docs/v1/tech/reference/': true,
   '/docs/v1/tech/samlv2/': true,
   '/docs/v1/tech/themes/': true,


### PR DESCRIPTION
This adds an overview page to the premium features section.

It also removes the link from core concepts.