### PR TITLE
Add note on google refresh token params

### DIFF
--- a/site/docs/v1/tech/identity-providers/google.adoc
+++ b/site/docs/v1/tech/identity-providers/google.adoc
@@ -144,16 +144,14 @@ include::docs/v1/tech/identity-providers/_login-api-integration.adoc[]
 
 == Custom Parameters
 
-Google sometimes requires you to provide custom URL parameters to access functionality.
+Google sometimes requires custom URL parameters when starting a login to access certain functionality. Examples include: 
 
-Some examples include: 
-
-* `access_type=offline` if you want a refresh token.
+* `access_type=offline` if you want a refresh token from Google.
 * `prompt=select_account` if you want to force an account selection screen.
 
-There are more https://developers.google.com/identity/protocols/oauth2/openid-connect#advancedtopics[options discussed here].
+There are more https://developers.google.com/identity/protocols/oauth2/openid-connect#advancedtopics[options covered here].
 
-When you need these custom parameters, the Google Identity Provider won't work. Instead, do the following:
+When you need such custom parameters, the Google Identity Provider won't work. Instead, do the following:
 
 * Create an link:/docs/v1/tech/identity-providers/openid-connect/[OpenId Connect Identity Provider].
 * Set [field]#Discover endpoints# to be `false`.

--- a/site/docs/v1/tech/identity-providers/google.adoc
+++ b/site/docs/v1/tech/identity-providers/google.adoc
@@ -15,6 +15,7 @@ Adding a Login with Google button to FusionAuth is straightforward, and this gui
 * <<Create Google OAuth client credentials>>
 * <<Create a Google Identity Provider>>
 * <<Building Your Own Integration>>
+* <<Custom Parameters>>
 
 {empty} +
 
@@ -140,6 +141,24 @@ Enable debug to create an event log to assist you in debugging integration error
 include::docs/v1/tech/identity-providers/_login-api-integration.adoc[]
 :identity_provider_fragment!:
 :identity_provider_path!:
+
+== Custom Parameters
+
+Google sometimes requires you to provide custom URL parameters to access functionality.
+
+Some examples include: 
+
+* `access_type=offline` if you want a refresh token.
+* `prompt=select_account` if you want to force an account selection screen.
+
+There are more https://developers.google.com/identity/protocols/oauth2/openid-connect#advancedtopics[options discussed here].
+
+When you need these custom parameters, the Google Identity Provider won't work. Instead, do the following:
+
+* Create an link:/docs/v1/tech/identity-providers/openid-connect/[OpenId Connect Identity Provider].
+* Set [field]#Discover endpoints# to be `false`.
+* Enter the endpoints manually from the https://developers.google.com/identity/protocols/oauth2/openid-connect#discovery[Discovery document].
+* Append whatever additional parameters are needed to the [field]#Authorization endpoint# value. For example, you might end up with something like `\https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=select_account` .
 
 
 // leave blank line so we can unset the identity provider path variable


### PR DESCRIPTION
Sometimes google needs extra params. This documents how to do that in FusionAuth.