### PR TITLE
Update the version to be a placeholder.

### DIFF
--- a/site/docs/v1/tech/client-libraries/java.adoc
+++ b/site/docs/v1/tech/client-libraries/java.adoc
@@ -22,7 +22,7 @@ Maven Dependency
 <dependency>
   <groupId>io.fusionauth</groupId>
   <artifactId>fusionauth-java-client</artifactId>
-  <version>1.7.0</version>
+  <version>${fusionauth.version}</version>
 </dependency>
 ----
 When building your application, utilize the version that corresponds to the version of FusionAuth your running. View all available versions on https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.fusionauth%22%20AND%20a%3A%22fusionauth-java-client%22[https://search.maven.org]


### PR DESCRIPTION
For the java maven example, don't hardcode a version, otherwise folks won't grab the latest version.