### PR TITLE
Typo 2022/09/06

### DIFF
--- a/site/docs/v1/tech/guides/single-sign-on.adoc
+++ b/site/docs/v1/tech/guides/single-sign-on.adoc
@@ -465,7 +465,7 @@ const logoutUrl = 'http://localhost:9011/oauth2/logout?client_id='+clientId;
 
 The top of the `index.js` file has configuration values and some needed constants. 
 
-Update `clientId` and `clientSecret` variables with the values noted in the administrative user interface when you created the application in FusionAuth. You'll also want to make sure that the second argument to the `client` constructor matches your FusionAuth installation, typically `\http://localhost:9011`. If FusionAuth lives at a place other than that, change the `loginUrl` and `loginUrl` values as well.
+Update `clientId` and `clientSecret` variables with the values noted in the administrative user interface when you created the application in FusionAuth. You'll also want to make sure that the second argument to the `client` constructor matches your FusionAuth installation, typically `\http://localhost:9011`. If FusionAuth lives at a place other than that, change the `loginUrl` and `logoutUrl` values as well.
 
 The first argument is `noapikeyneeded` because the client interactions this application performs do not require an API key. If you extend these applications to update user data or make other privileged API calls, you'll need to change that value to a link:/docs/v1/tech/apis/authentication#managing-api-keys[real API key].
 


### PR DESCRIPTION
Fixed a typo where `loginUrl` was repeated rather than showing `logoutUrl` for the second instance.