### PR TITLE
Update Start/Stop Documentation

### DIFF
--- a/site/docs/v1/tech/5-minute-setup-guide.adoc
+++ b/site/docs/v1/tech/5-minute-setup-guide.adoc
@@ -90,7 +90,7 @@ fusionauth/bin/startup.sh
 
 This will start both the `fusionauth-app` component as well as the `fusionauth-search` component if you downloaded the Elasticsearch option. (Here's link:/docs/v1/tech/core-concepts/users#user-search[a document on how to choose whether to do so].) 
 
-If you are on Windows, you'll need to use the `startup.bat` file instead.
+If you are on Windows, you'll need to use the `startup.bat` (prior to version 1.37.0) or `startup.ps1` (version 1.40.0 and later) file instead. Versions 1.37.0 through 1.39.0 do not support native Windows installation.
 
 == 3. Complete Maintenance Mode 
 

--- a/site/docs/v1/tech/admin-guide/upgrade.adoc
+++ b/site/docs/v1/tech/admin-guide/upgrade.adoc
@@ -119,7 +119,7 @@ net stop FusionAuthApp
 net stop FusionAuthSearch
 
 # Uninstall Services
-cd \fusionauth\fusionauth-app\apache-tomcat\bin
+cd \fusionauth\fusionauth-app\bin
 FusionAuthApp.exe /uninstall
 cd \fusionauth\fusionauth-search\elasticsearch\bin
 FusionAuthSearch.exe /uninstall
@@ -129,6 +129,15 @@ cd \fusionauth
 move fusionauth-app fusionauth-app-old
 move fusionauth-search fusionauth-search-old
 ----
+
+[NOTE]
+====
+Prior to version 1.37.0 you can find `FusionAuthApp.exe` at
+
+`\fusionauth\fusionauth-app\apache-tomcat\bin\FusionAuthApp.exe`
+
+Versions 1.37.0 through 1.39.0 do not support native Windows installation.
+====
 
 During an upgrade, most everything is saved in the database, so it is safe to delete these directories. To preserve your configuration and Elasticsearch index you want to be sure to preserve the following directories:
 
@@ -147,7 +156,7 @@ After you have extracted the new packages, re-install the Windows services and s
 [source,title=Install and Start FusionAuth]
 ----
 # Install Windows Services
-cd \fusionauth\fusionauth-app\apache-tomcat\bin
+cd \fusionauth\fusionauth-app\bin
 FusionAuthApp.exe /install
 cd \fusionauth\fusionauth-search\elasticsearch\bin
 FusionAuthSearch.exe /install
@@ -156,6 +165,15 @@ FusionAuthSearch.exe /install
 net start FusionAuthSearch
 net start FusionAuthApp
 ----
+
+[NOTE]
+====
+Prior to version 1.37.0 you can find `FusionAuthApp.exe` at
+
+`\fusionauth\fusionauth-app\apache-tomcat\bin\FusionAuthApp.exe`
+
+Versions 1.37.0 through 1.39.0 do not support native Windows installation.
+====
 
 That is it, you're done!
 
@@ -279,6 +297,7 @@ fusionauth-database-schema/
       |-- 1.33.0.sql
       |-- 1.35.0.sql
       |-- 1.36.0.sql
+      |-- 1.37.0.sql
 ----
 
 == Themes

--- a/site/docs/v1/tech/installation-guide/_fast-path-install.adoc
+++ b/site/docs/v1/tech/installation-guide/_fast-path-install.adoc
@@ -50,6 +50,11 @@ sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-instal
 
 === Windows
 
+[NOTE]
+====
+Windows installation is not supported in FusionAuth versions 1.37.0 through 1.39.0.
+====
+
 Please feel free to read these install scripts before running them. Always a good idea.
 
 :code_id: guide-windows-1

--- a/site/docs/v1/tech/installation-guide/fast-path.adoc
+++ b/site/docs/v1/tech/installation-guide/fast-path.adoc
@@ -47,13 +47,29 @@ In this example, we'll assume you have previously installed FusionAuth in `\fusi
 
 First, terminate the running FusionAuth and Elasticsearch processes.
 
+[source,title=Shutdown FusionAuth]
+----
+# Stop Services
+<FUSIONAUTH_HOME>\bin\shutdown.ps1
+----
+
+[NOTE]
+====
+If you are running a pre-1.37.0 version of FusionAuth, you can terminate the processes by closing the command line windows for FusionAuth and Elasticsearch. Versions 1.37.0 through 1.39.0 do not support native Windows installation.
+====
+
 Then, run the appropriate FastPath install/upgrade command from the parent directory of `FUSIONAUTH_HOME` (if `FUSIONAUTH_HOME` is `\fusionauth`, run this command from `\`).  Reference the commands defined in the install steps above to determine which install/upgrade command is appropriate for your environment.
 
 [source,title=Start FusionAuth]
 ----
 # Startup Services
-<FUSIONAUTH_HOME>\bin\startup.bat
+<FUSIONAUTH_HOME>\bin\startup.ps1
 ----
+
+[NOTE]
+====
+Prior to version 1.37.0 use `startup.bat` to start Elasticsearch and FusionAuth App services. Versions 1.37.0 through 1.39.0 do not support native Windows installation.
+====
 
 === Linux
 

--- a/site/docs/v1/tech/installation-guide/fusionauth-app.adoc
+++ b/site/docs/v1/tech/installation-guide/fusionauth-app.adoc
@@ -82,9 +82,15 @@ Next, install the Windows service by changing to the directory designated as `FU
 
 [source]
 ----
-cd \fusionauth\fusionauth-app\apache-tomcat\bin
+cd \fusionauth\fusionauth-app\bin
 FusionAuthApp.exe /install
 ----
+
+[NOTE]
+====
+* Prior to version 1.37.0 `FusionAuthApp.exe` is located at `\fusionauth\fusionauth-app\apache-tomcat\bin`
+* Versions 1.37.0 through 1.39.0 do not support native Windows installation.
+====
 
 == Start FusionAuth App
 
@@ -112,13 +118,13 @@ sudo systemctl start fusionauth-app
 [source,shell]
 .macOS (ZIP package)
 ----
-<FUSIONAUTH_HOME>/fusionauth-app/apache-tomcat/bin/startup.sh
+<FUSIONAUTH_HOME>/bin/startup.sh
 ----
 
 [source]
 .Windows (ZIP package)
 ----
-\fusionauth\fusionauth-app\apache-tomcat\bin\startup.bat
+\fusionauth\bin\startup.ps1
 ----
 
 [source]

--- a/site/docs/v1/tech/tutorials/start-and-stop.adoc
+++ b/site/docs/v1/tech/tutorials/start-and-stop.adoc
@@ -7,19 +7,18 @@ navcategory: getting-started
 
 == Start and Stop FusionAuth
 
-If you are using the FusionAuth server version, may need to manually start or stop FusionAuth periodically. If you find yourself in this situation
-you'll be glad you know how.
+If you are self-hosting FusionAuth, you may need to manually start or stop FusionAuth periodically. If you find yourself in this situation you'll be glad you know how.
 
 [NOTE]
 ====
-Unless you are hosting and managing FusionAuth these instructions do not apply to you. FusionAuth manages and monitors instances hosted in our private
+Unless you are self-hosting FusionAuth these instructions do not apply to you. FusionAuth manages and monitors instances hosted in our private
 cloud and will restart FusionAuth if necessary.
 ====
 
 
 [NOTE]
 ====
-*Note* that you *MUST* start the FusionAuth Search before starting the FusionAuth App service. You should also shutdown the Search Engine last. FusionAuth
+*Note* that it is recommended you start the FusionAuth Search service before starting the FusionAuth App service. You should also shutdown the Search Engine last. FusionAuth
 utilizes the Search Engine and database for persisting and retrieving users.
 ====
 
@@ -56,43 +55,65 @@ If you'd prefer to use the native Elastic and Tomcat scripts you may follow the 
 
 === macOS
 
-*Start and Stop services using the native Elastic and Tomcat scripts*
+*Start and Stop services using the native Elastic and FusionAuth scripts*
 
 [source,shell]
 .Start FusionAuth
 ----
 /usr/local/fusionauth/fusionauth-search/elasticsearch/bin/elasticsearch
-/usr/local/fusionauth/fusionauth-app/apache-tomcat/bin/catalina.sh start
+/usr/local/fusionauth/fusionauth-app/bin/start.sh
 ----
 
 [source,shell]
 .Stop FusionAuth
 ----
-/usr/local/fusionauth/fusionauth-app/apache-tomcat/bin/catalina.sh stop
+/usr/local/fusionauth/fusionauth-app/bin/stop.sh
 ----
 
 Elasticsearch should be stopped last. If you started Elasticsearch using the `elasticsearch` script then you may simply kill the terminal where
 the service is running to initiate shutdown.
 
+[NOTE]
+====
+Prior to version 1.37.0 you can start and stop FusionAuth using the Tomcat `catalina.sh` script.
+====
+[source,shell]
+.Start/Stop FusionAuth (pre-1.37.0)
+----
+/usr/local/fusionauth/fusionauth-app/apache-tomcat/bin/catalina.sh start
+/usr/local/fusionauth/fusionauth-app/apache-tomcat/bin/catalina.sh stop
+----
+
 === Windows
 
-*Start and Stop services using the native Elastic and Tomcat scripts*
+*Start and Stop services using the native PowerShell scripts*
 
 [source]
-.Start CleanSpeak
+.Start FusionAuth
 ----
 \fusionauth\fusionauth-search\elasticsearch\bin\elasticsearch.bat
-\fusionauth\fusionauth-app\apache-tomcat\bin\catalina.bat start
+\fusionauth\fusionauth-app\bin\start.ps1
 ----
 
 [source]
 .Stop FusionAuth
 ----
-\fusionauth\fusionauth-app\apache-tomcat\bin\catalina.bat stop
+\fusionauth\fusionauth-app\bin\stop.ps1
 ----
 
 Elasticsearch should be stopped last. If you started Elasticsearch using the `elasticsearch.bat` script then you may simply close the command
 window where the service is running to initiate shutdown.
+
+[NOTE]
+====
+Prior to version 1.37.0 you can start and stop FusionAuth using the Tomcat `catalina.bat` script. Versions 1.37.0 through 1.39.0 do not support native Windows installation.
+====
+[source,shell]
+.Start/Stop FusionAuth (pre-1.37.0)
+----
+\fusionauth\fusionauth-app\apache-tomcat\bin\catalina.bat start
+\fusionauth\fusionauth-app\apache-tomcat\bin\catalina.bat stop
+----
 
 *Start and Stop services using Windows Services*
 
@@ -102,15 +123,24 @@ We also provide support for running FusionAuth as a Windows service.
 .Register Windows Services
 ----
 \fusionauth\fusionauth-search\elasticsearch\bin\FusionAuthSearch.exe /install
-\fusionauth\fusionauth-app\apache-tomcat\bin\FusionAuthApp.exe /install
+\fusionauth\fusionauth-app\bin\FusionAuthApp.exe /install
 ----
 
 [source]
 .Unregister Windows Services
 ----
-\fusionauth\fusionauth-app\apache-tomcat\bin\FusionAuthApp.exe /uninstall
+\fusionauth\fusionauth-app\bin\FusionAuthApp.exe /uninstall
 \fusionauth\fusionauth-search\elasticsearch\bin\FusionAuthSearch.exe /uninstall
 ----
+
+[NOTE]
+====
+Prior to version 1.37.0 you can find `FusionAuthApp.exe` at
+
+`\fusionauth\fusionauth-app\apache-tomcat\bin\FusionAuthApp.exe`
+
+Versions 1.37.0 through 1.39.0 do not support native Windows installation.
+====
 
 [source]
 .Start Services


### PR DESCRIPTION
FusionAuth removed Tomcat in version 1.37.0. This change updates instructions for starting and stopping FusionAuth and Elasticsearch while maintaining the instructions for earlier versions.

- https://github.com/FusionAuth/fusionauth-issues/issues/1848

**Linked PR**:
- https://github.com/inversoft/inversoft-scripts/pull/2
- https://github.com/FusionAuth/fusionauth-install/pull/12
- https://github.com/FusionAuth/fusionauth-app/pull/143
- https://github.com/FusionAuth/fusionauth-search/pull/5