### PR TITLE
setting correct default linking strategy

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/apple.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/apple.adoc
@@ -14,8 +14,8 @@ This API has been available since 1.17.0
 
 The Apple identity provider type will use the Sign in with Apple APIs and will provide a `Sign with Apple` button on FusionAuth's login page that will either redirect to an Apple sign in page or leverage native controls when using Safari on macOS or iOS. Additionally, this identity provider will call Apple's `/auth/token` API to load additional details about the user and store them in FusionAuth.
 
-
 :idp_display_name: Apple
+:idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[`refresh_token`]
 :return_text: pass:normal[`/auth/token` endpoint]
 

--- a/site/docs/v1/tech/apis/identity-providers/apple.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/apple.adoc
@@ -21,7 +21,6 @@ The Apple identity provider type will use the Sign in with Apple APIs and will p
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 
@@ -167,13 +166,11 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 
 == Complete the Apple Login
 
-:idp_display_name: Apple
 :token_text_with_article: an id token
 :token_text: id token
 include::docs/v1/tech/apis/identity-providers/_complete-login-text.adoc[]
 :token_text_with_article!:
 :token_text!:
-:idp_display_name!: 
 
 === Request
 
@@ -191,15 +188,13 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: Apple
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: Apple
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
+
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/epicgames.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/epicgames.adoc
@@ -24,12 +24,10 @@ This identity provider will call Epic Games' API to load the Epic Games user's `
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 :hide_token_map_deprecation!:
 
-:idp_display_name: Epic Games
 :idp_id: 1b932b19-61a8-47c7-9e81-27dbf9011dad
 :idp_linking_strategy: CreatePendingLink
 :idp_lowercase: epicgames

--- a/site/docs/v1/tech/apis/identity-providers/external-jwt.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/external-jwt.adoc
@@ -16,6 +16,7 @@ This is a special type of identity provider that is only used via the link:/docs
 
 In order for this identity provider to use the JWT, it also needs the public key or HMAC secret that the JWT was signed with. FusionAuth will verify that the JWT is valid and has not expired. Once the JWT has been validated, FusionAuth will reconcile it to ensure that the User exists and is up-to-date.
 
+// set this blank so it reads better
 :idp_display_name: 
 :idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[token provided in the `refresh_token` field]
@@ -23,10 +24,11 @@ In order for this identity provider to use the JWT, it also needs the public key
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 
+// set this here so it holds for everything after
+:idp_display_name: External JWT
 === Operations
 
 * <<Create an External JWT Identity Provider>>
@@ -194,15 +196,12 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: External JWT
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: External JWT
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/external-jwt.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/external-jwt.adoc
@@ -17,6 +17,7 @@ This is a special type of identity provider that is only used via the link:/docs
 In order for this identity provider to use the JWT, it also needs the public key or HMAC secret that the JWT was signed with. FusionAuth will verify that the JWT is valid and has not expired. Once the JWT has been validated, FusionAuth will reconcile it to ensure that the User exists and is up-to-date.
 
 :idp_display_name: 
+:idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[token provided in the `refresh_token` field]
 :return_text: request
 

--- a/site/docs/v1/tech/apis/identity-providers/facebook.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/facebook.adoc
@@ -25,7 +25,6 @@ When the `picture` field is not requested FusionAuth will also call Facebook's `
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 
@@ -166,13 +165,11 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 
 == Complete the Facebook Login
 
-:idp_display_name: Facebook
 :token_text_with_article: an access token
 :token_text: access token
 include::docs/v1/tech/apis/identity-providers/_complete-login-text.adoc[]
 :token_text_with_article!:
 :token_text!:
-:idp_display_name!: 
 
 === Request
 
@@ -190,15 +187,13 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: Facebook
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: Facebook
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
+
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/facebook.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/facebook.adoc
@@ -19,6 +19,7 @@ The email address returned by the Facebook Graph API will be used to create or l
 When the `picture` field is not requested FusionAuth will also call Facebook's `/me/picture` API to load the user's profile image and store it as the `imageUrl` in FusionAuth. When the `picture` field is requested, the user's profile image will be returned by the `/me` API and a second request to the `/me/picture` endpoint will not be required.
 
 :idp_display_name: Facebook
+:idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[long-lived token]
 :return_text: pass:normal[`/oauth/access_token` (after presenting the login token)]
 

--- a/site/docs/v1/tech/apis/identity-providers/google.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/google.adoc
@@ -16,6 +16,7 @@ The Google identity provider type will use the Google OAuth v2.0 login API. It w
 This identity provider will call Google’s API to load the user's `email` and `preferred_username` and use those as `email` and `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider. Additional claims returned by Google can be used to reconcile the user to FusionAuth by using a Google Reconcile Lambda.
 
 :idp_display_name: Google
+:idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[`id_token`]
 :return_text: pass:normal[Google API]
 

--- a/site/docs/v1/tech/apis/identity-providers/google.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/google.adoc
@@ -22,13 +22,11 @@ This identity provider will call Google’s API to load the user's `email` and `
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 
 Please note if an `idp_hint` is appended to the OAuth Authorize endpoint, then the login method interaction will be `redirect`, even if popup interaction is explicitly configured.
 
-:idp_display_name: Google
 :idp_id: 82339786-3dff-42a6-aac6-1f1ceecb6c46
 :idp_login_method:
 :idp_lowercase: google

--- a/site/docs/v1/tech/apis/identity-providers/hypr.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/hypr.adoc
@@ -6,6 +6,7 @@ description: APIs for creating, retrieving, updating and disabling the HYPR iden
 :idp_since: 11200
 :extra_start_text:
 :idp_linking_strategy: pass:normal[`Unsupported`]
+:idp_display_name: HYPR
 
 == Overview
 
@@ -172,27 +173,21 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 [method]#POST# [uri]#/api/identity-provider/start#
 --
 
-:idp_display_name: HYPR
 include::docs/v1/tech/apis/identity-providers/_identity-provider-start-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains a code that can be used to complete the login request.
 
-:idp_display_name: HYPR
 include::docs/v1/tech/apis/identity-providers/_identity-provider-start-response-body.adoc[]
-:idp_display_name!:
 
 == Complete the HYPR Login
 
-:idp_display_name: HYPR
 :token_text_with_article: a token
 :token_text: token
 include::docs/v1/tech/apis/identity-providers/_complete-login-text.adoc[]
 :token_text_with_article!:
 :token_text!:
-:idp_display_name!: 
 
 === Request
 
@@ -210,15 +205,12 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: HYPR
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: HYPR
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/hypr.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/hypr.adoc
@@ -5,6 +5,7 @@ description: APIs for creating, retrieving, updating and disabling the HYPR iden
 ---
 :idp_since: 11200
 :extra_start_text:
+:idp_linking_strategy: pass:normal[`Unsupported`]
 
 == Overview
 

--- a/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
@@ -23,7 +23,6 @@ The email address returned by the LinkedIn `/v2/emailAddress` API will be used t
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 
@@ -172,13 +171,11 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 
 == Complete the LinkedIn Login
 
-:idp_display_name: LinkedIn
 :token_text_with_article: an id token
 :token_text: id token
 include::docs/v1/tech/apis/identity-providers/_complete-login-text.adoc[]
 :token_text_with_article!:
 :token_text!:
-:idp_display_name!: 
 
 === Request
 
@@ -196,15 +193,12 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: LinkedIn
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: LinkedIn
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/linkedin.adoc
@@ -17,6 +17,7 @@ The LinkedIn identity provider type will use OAuth 2.0 to authenticate a user wi
 The email address returned by the LinkedIn `/v2/emailAddress` API will be used to create or look up the existing user. Additional claims returned by LinkedIn can be used to reconcile the User to FusionAuth by using a LinkedIn Reconcile lambda. Unless you assign a reconcile lambda to this provider, only the `email` address will be used from the available claims returned by LinkedIn.
 
 :idp_display_name: LinkedIn
+:idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[`access_token`]
 :return_text: pass:normal[login endpoint]
 

--- a/site/docs/v1/tech/apis/identity-providers/nintendo.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/nintendo.adoc
@@ -24,12 +24,10 @@ If the linking strategy depends on a username or email address, FusionAuth will 
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 :hide_token_map_deprecation!:
 
-:idp_display_name: Nintendo
 :idp_id: b0ac2e16-d4af-483e-98c8-7f6693610665
 :idp_linking_strategy: CreatePendingLink
 :idp_lowercase: nintendo

--- a/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
@@ -18,6 +18,7 @@ Optionally, this identity provider can define one or more domains it is associat
 
 FusionAuth will also leverage the `/userinfo` API that is part of the OpenID Connect specification. The email address returned from the Userinfo response will be used to create or lookup the existing user. Additional claims from the Userinfo response can be used to reconcile the User in FusionAuth by using an OpenID Connect Reconcile Lambda. Unless you assign a reconcile lambda to this provider, on the `email` address will be used from the available claims returned by the OpenID Connect identity provider.
 
+// leave empty so it looks better for the token storage note
 :idp_display_name: 
 :idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[`refresh_token`]
@@ -25,9 +26,11 @@ FusionAuth will also leverage the `/userinfo` API that is part of the OpenID Con
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
+
+// now set name for everything else that follows
+:idp_display_name: OpenID Connect
 
 === Operations
 
@@ -170,13 +173,11 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 
 == Complete an OpenID Connect Login
 
-:idp_display_name: OpenID Connect
 :token_text_with_article: an authorization code
 :token_text: authorization code
 include::docs/v1/tech/apis/identity-providers/_complete-login-text.adoc[]
 :token_text_with_article!:
 :token_text!:
-:idp_display_name!: 
 
 === Request
 
@@ -194,15 +195,13 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: OpenID Connect
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: OpenID Connect
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
+
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/openid-connect.adoc
@@ -19,6 +19,7 @@ Optionally, this identity provider can define one or more domains it is associat
 FusionAuth will also leverage the `/userinfo` API that is part of the OpenID Connect specification. The email address returned from the Userinfo response will be used to create or lookup the existing user. Additional claims from the Userinfo response can be used to reconcile the User in FusionAuth by using an OpenID Connect Reconcile Lambda. Unless you assign a reconcile lambda to this provider, on the `email` address will be used from the available claims returned by the OpenID Connect identity provider.
 
 :idp_display_name: 
+:idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[`refresh_token`]
 :return_text: pass:normal[external OpenID Connect provider, if such a token is provided,]
 

--- a/site/docs/v1/tech/apis/identity-providers/samlv2-idp-initiated.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/samlv2-idp-initiated.adoc
@@ -4,6 +4,7 @@ title: SAML v2 IdP Initiated Identity Provider APIs
 description: APIs for creating, retrieving, updating and deleting SAML v2 IdP Initiated identity providers
 ---
 :idp_since: 12600
+:idp_display_name: SAML v2 IdP Initiated
 
 include::docs/v1/tech/shared/_premium-edition-blurb.adoc[]
 
@@ -195,15 +196,12 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: SAML v2 IdP Initiated
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: SAML v2 IdP Initiated
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/samlv2.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/samlv2.adoc
@@ -5,6 +5,7 @@ description: APIs for creating, retrieving, updating and deleting SAML v2 identi
 ---
 :idp_since: 10600
 :extra_start_text: pass:normal[This parameter must be added as the `ID` attribute in the SAML request you are making. After you have retrieved the SAML response, this value will be in the `InResponseTo` attribute. When the Complete Login API is called this value will be verified by FusionAuth.]
+:idp_linking_strategy: pass:normal[`LinkByEmail`]
 
 == Overview
 

--- a/site/docs/v1/tech/apis/identity-providers/samlv2.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/samlv2.adoc
@@ -6,6 +6,7 @@ description: APIs for creating, retrieving, updating and deleting SAML v2 identi
 :idp_since: 10600
 :extra_start_text: pass:normal[This parameter must be added as the `ID` attribute in the SAML request you are making. After you have retrieved the SAML response, this value will be in the `InResponseTo` attribute. When the Complete Login API is called this value will be verified by FusionAuth.]
 :idp_linking_strategy: pass:normal[`LinkByEmail`]
+:idp_display_name: SAML v2
 
 == Overview
 
@@ -187,17 +188,13 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 [method]#POST# [uri]#/api/identity-provider/start#
 --
 
-:idp_display_name: SAML v2
 include::docs/v1/tech/apis/identity-providers/_identity-provider-start-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains a code that can be used to complete the login request.
 
-:idp_display_name: SAML v2
 include::docs/v1/tech/apis/identity-providers/_identity-provider-start-response-body.adoc[]
-:idp_display_name!:
 
 == Complete a SAML v2 Login
 
@@ -225,15 +222,12 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: SAML v2
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: SAML v2
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/sonypsn.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/sonypsn.adoc
@@ -24,12 +24,10 @@ This identity provider will call Sony’s API to load the user's `email` and `on
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 :hide_token_map_deprecation!:
 
-:idp_display_name: Sony PlayStation Network
 :idp_id: 7764b5c7-165b-4e7e-94aa-02ebe2a0a5fb
 :idp_linking_strategy: CreatePendingLink
 :idp_lowercase: sonypsn

--- a/site/docs/v1/tech/apis/identity-providers/steam.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/steam.adoc
@@ -24,13 +24,11 @@ This identity provider will call Steam's API to load the Steam user's `personana
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 :hide_token_map_deprecation!:
 
 
-:idp_display_name: Steam
 :idp_id: e4f39345-7833-4b1d-b331-ca03bdc2c4be
 :idp_linking_strategy: CreatePendingLink
 :idp_lowercase: steam

--- a/site/docs/v1/tech/apis/identity-providers/twitch.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/twitch.adoc
@@ -26,12 +26,10 @@ FusionAuth will also store the Twitch `refresh_token` returned from the Twitch A
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 :hide_token_map_deprecation!:
 
-:idp_display_name: Twitch
 :idp_id: bf4cf83f-e824-42d7-b4a3-5b10847a66b2
 :idp_linking_strategy: CreatePendingLink
 :idp_lowercase: twitch

--- a/site/docs/v1/tech/apis/identity-providers/twitter.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/twitter.adoc
@@ -25,7 +25,6 @@ Twitter does not require a user to have an email address. However, to prevent ac
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 
@@ -170,13 +169,11 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 
 == Complete the Twitter Login
 
-:idp_display_name: Twitter
 :token_text_with_article: tokens
 :token_text: set of tokens
 include::docs/v1/tech/apis/identity-providers/_complete-login-text.adoc[]
 :token_text!:
 :token_text_with_article!:
-:idp_display_name!: 
 
 === Request
 
@@ -194,15 +191,13 @@ link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[ty
 include::docs/v1/tech/apis/identity-providers/_x-forwarded-for-header.adoc[]
 include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation-row-only.adoc[]
 
-:idp_display_name: Twitter
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc[]
-:idp_display_name!:
 
 === Response
 
 The response for this API contains the User object.
 
-:idp_display_name: Twitter
 include::docs/v1/tech/apis/identity-providers/_identity-provider-login-response-body.adoc[]
+
 :idp_display_name!:
 :idp_since!:

--- a/site/docs/v1/tech/apis/identity-providers/twitter.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/twitter.adoc
@@ -19,6 +19,7 @@ The email address returned by Twitter will be used to create or lookup the exist
 Twitter does not require a user to have an email address. However, to prevent account hijacking and take-over, FusionAuth prevents users from logging in with Twitter unless they have setup an email address in their Twitter account. Keep this in mind as you enable this identity provider.
 
 :idp_display_name: Twitter
+:idp_linking_strategy: pass:normal[`LinkByEmail`]
 :token_name: pass:normal[access token]
 :return_text: pass:normal[OAuth v1.0 login workflow]
 

--- a/site/docs/v1/tech/apis/identity-providers/xbox.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/xbox.adoc
@@ -24,12 +24,10 @@ This identity provider will call Xbox’s API to load the user's `email` and `gt
 
 include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 
-:idp_display_name!:
 :token_name!:
 :return_text!:
 :hide_token_map_deprecation!:
 
-:idp_display_name: Xbox
 :idp_id: af53ab21-34c3-468a-8ba2-ecb3905f67f2
 :idp_linking_strategy: CreatePendingLink
 :idp_lowercase: xbox
@@ -37,6 +35,7 @@ include::docs/v1/tech/apis/identity-providers/_token-storage-note.adoc[]
 :idp_token_or_code: token or code
 :idp_type: Xbox
 include::docs/v1/tech/apis/identity-providers/_oauth-idp-operations.adoc[]
+
 :idp_display_name!:
 :idp_id!:
 :idp_linking_strategy!:


### PR DESCRIPTION
Fix for doc issues surfaced here: https://github.com/FusionAuth/fusionauth-issues/issues/1878

Also corrected `idp_display_name` and rationalized where it was set.