### PR TITLE
Fix event logs search

### DIFF
--- a/site/docs/src/json/event-logs/search-request.json
+++ b/site/docs/src/json/event-logs/search-request.json
@@ -3,6 +3,7 @@
     "end": "1655242262478",
     "message": "*",
     "numberOfResults": 50,
-    "start": "1655242262370"
+    "start": "1655242262370",
+    "type": "Information"
   }
 }

--- a/site/docs/v1/tech/apis/event-logs.adoc
+++ b/site/docs/v1/tech/apis/event-logs.adoc
@@ -101,11 +101,12 @@ The number of results to return from the search.
 [field]#orderBy# [type]#[String]# [optional]#Optional# [default]#defaults to `insertInstant DESC`#::
 The database column to order the search results on plus the order direction.
 +
-The columns you can use for this are:
+Valid values are:
 +
 * `insertInstant` - the link:/docs/v1/tech/reference/data-types#instants[instant] when the Event Log was created
 * `insertUser` - the user that create the Event Log
 * `message` - the message of the Event Log
+* `type` - the type of the Event Log
 +
 For example, to order the results by the insert instant in a descending order, the value would be provided as `insertInstant DESC`. The final string is optional can be set to `ASC` or `DESC`.
 
@@ -114,6 +115,15 @@ The start link:/docs/v1/tech/reference/data-types#instants[instant] of the date/
 
 [field]#startRow# [type]#[Integer]# [optional]#Optional# [default]#defaults to `0`#::
 The offset row to return results from. If the search has 200 records in it and this is 50, it starts with row 50.
+
+[field]#type# [type]#[String]# [optional]#Optional#::
+The type of Event Logs to return. Only one type may be provided. If omitted, all types will be returned.
++
+Valid values are:
++
+* `Information`
+* `Debug`
+* `Error`
 
 [.api-authentication]
 link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Searches the Event Logs using the given search criteria
@@ -153,6 +163,15 @@ The start link:/docs/v1/tech/reference/data-types#instants[instant] of the date/
 
 [field]#search.startRow# [type]#[Integer]# [optional]#Optional# [default]#defaults to `0`#::
 The offset row to return results from. If the search has 200 records in it and this is 50, it starts with row 50.
+
+[field]#search.type# [type]#[String]# [optional]#Optional#::
+The type of Event Logs to return. Only one type may be provided. If omitted, all types will be returned.
++
+Valid values are:
++
+* `Information`
+* `Debug`
+* `Error`
 
 [source,json]
 .Example JSON Request

--- a/site/docs/v1/tech/apis/event-logs.adoc
+++ b/site/docs/v1/tech/apis/event-logs.adoc
@@ -101,7 +101,7 @@ The number of results to return from the search.
 [field]#orderBy# [type]#[String]# [optional]#Optional# [default]#defaults to `insertInstant DESC`#::
 The database column to order the search results on plus the order direction.
 +
-Valid values are:
+The possible values are:
 +
 * `insertInstant` - the link:/docs/v1/tech/reference/data-types#instants[instant] when the Event Log was created
 * `insertUser` - the user that create the Event Log
@@ -119,7 +119,7 @@ The offset row to return results from. If the search has 200 records in it and t
 [field]#type# [type]#[String]# [optional]#Optional#::
 The type of Event Logs to return. Only one type may be provided. If omitted, all types will be returned.
 +
-Valid values are:
+The possible values are:
 +
 * `Information`
 * `Debug`
@@ -167,7 +167,7 @@ The offset row to return results from. If the search has 200 records in it and t
 [field]#search.type# [type]#[String]# [optional]#Optional#::
 The type of Event Logs to return. Only one type may be provided. If omitted, all types will be returned.
 +
-Valid values are:
+The possible values are:
 +
 * `Information`
 * `Debug`


### PR DESCRIPTION
It was missing the `type` parameter.