### PR TITLE
More accurately reflect where we pull claims from.

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_openid-connect-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_openid-connect-request-body.adoc
@@ -71,18 +71,18 @@ The client authentication method to use with the OpenID Connect identity provide
 
 ifdef::update[]
 [field]#identityProvider.oauth2.emailClaim# [type]#[String]# [required]#Required# [since]#Available since 1.17.3#::
-An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address. The Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
+An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address. The UserInfo response found using the Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
 endif::[]
 ifndef::update[]
 [field]#identityProvider.oauth2.emailClaim# [type]#[String]# [optional]#Optional# [default]#defaults to `email`# [since]#Available since 1.17.3#::
-An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address. The Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
+An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address. The UserInfo response found using the Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
 endif::[]
 
 [field]#identityProvider.oauth2.uniqueIdClaim# [type]#[String]# [optional]#Optional# [default]#defaults to `id`#::
-An optional configuration to modify the expected name of the claim returned by the IdP that contains the user Id. The Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
+An optional configuration to modify the expected name of the claim returned by the IdP that contains the user Id. The UserInfo response found using the Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
 
 [field]#identityProvider.oauth2.usernameClaim# [type]#[String]# [optional]#Optional# [default]#defaults to `preferred_username`#::
-An optional configuration to modify the expected name of the claim returned by the IdP that contains the username. The Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
+An optional configuration to modify the expected name of the claim returned by the IdP that contains the username. The UserInfo response found using the Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
 
 [field]#identityProvider.oauth2.issuer# [type]#[String]# [optional]#Optional#::
 The top-level issuer URI for the OpenID Connect identity provider. If this is provided, the authorization endpoint, token endpoint and userinfo endpoint will all be resolved using the `issuer` URI plus `/.well-known/openid-configuration`.

--- a/site/docs/v1/tech/apis/identity-providers/_openid-connect-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_openid-connect-request-body.adoc
@@ -69,14 +69,8 @@ The client authentication method to use with the OpenID Connect identity provide
 * `client_secret_post`
 * `none`
 
-ifdef::update[]
-[field]#identityProvider.oauth2.emailClaim# [type]#[String]# [required]#Required# [since]#Available since 1.17.3#::
-An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address. The UserInfo response found using the Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
-endif::[]
-ifndef::update[]
 [field]#identityProvider.oauth2.emailClaim# [type]#[String]# [optional]#Optional# [default]#defaults to `email`# [since]#Available since 1.17.3#::
 An optional configuration to modify the expected name of the claim returned by the IdP that contains the email address. The UserInfo response found using the Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.
-endif::[]
 
 [field]#identityProvider.oauth2.uniqueIdClaim# [type]#[String]# [optional]#Optional# [default]#defaults to `id`#::
 An optional configuration to modify the expected name of the claim returned by the IdP that contains the user Id. The UserInfo response found using the Access Token is inspected for this claim first. If it is not present and an Id Token is available, the Id Token is examined as well.


### PR DESCRIPTION
Came up in this forum post: https://fusionauth.io/community/forum/topic/2183/oidc-identity-provider-claims

Our current doc is a bit off, since we look at the userinfo response found from the access token, not the access token itself.