### PR TITLE
Fix json web tokens tutorial

### DIFF
--- a/site/docs/v1/tech/core-concepts/_application-json-web-token-settings.adoc
+++ b/site/docs/v1/tech/core-concepts/_application-json-web-token-settings.adoc
@@ -1,0 +1,13 @@
+[.api]
+[field]#Issuer# [read-only]#Read-only#::
+The issuer used in the `iss` claim when building the Access Token and Id Token. This is a read-only value in this configuration. It can be modified in the Tenant configuration.
+
+[field]#JWT duration# [required]#Required#::
+The duration in seconds for which a JWT will be valid after creation. After this time has passed the JWT will expire and can no longer be used.
+
+[field]#Access token signing key# [optional]#Optional#::
+The signing key used to sign the Access Token (which is a JWT) when a user authenticates against this Application. When this value is not selected, FusionAuth will generate a new key pair and assign it to this configuration.
+
+[field]#Id token signing key# [optional]#Optional#::
+The signing key used to sign the Id Token (which is a JWT) when a user authenticates against this Application. When this value is not selected, FusionAuth will generate a new key pair and assign it to this configuration.
+

--- a/site/docs/v1/tech/core-concepts/_application-lambda-settings.adoc
+++ b/site/docs/v1/tech/core-concepts/_application-lambda-settings.adoc
@@ -1,0 +1,9 @@
+The application specific lambda settings are available even if you choose not to enable additional application specific JWT configuration by leaving the [field]#Enable# field off.
+
+[.api]
+[field]#Access token populate lambda# [optional]#Optional#::
+The lambda to be invoked during the generation of an Access Token (JWT) when a user authenticates against this Application.
+
+[field]#Id token populate lambda# [optional]#Optional#::
+The lambda to be invoked during the generation of an Id Token (JWT) when a user authenticates against this Application.
+

--- a/site/docs/v1/tech/core-concepts/_tenant-json-web-token-settings.adoc
+++ b/site/docs/v1/tech/core-concepts/_tenant-json-web-token-settings.adoc
@@ -1,0 +1,9 @@
+[.api]
+[field]#JWT duration# [required]#Required#::
+The length of time the issued token (access token and Id token) is valid.  JWT tokens are typically short lived.
+
+[field]#Access token signing key# [optional]#Optional#::
+The key used to sign the access token JWT.
+
+[field]#Id token signing key# [optional]#Optional#::
+The key used to sign the Id token JWT.

--- a/site/docs/v1/tech/core-concepts/applications.adoc
+++ b/site/docs/v1/tech/core-concepts/applications.adoc
@@ -205,14 +205,7 @@ When enabled you may configure Application specific JWT configuration including 
 
 ==== Lambda Settings
 
-The application specific lambda settings are available even if you choose not to enable additional application specific JWT configuration by leaving the [field]#Enable# field off.
-
-[.api]
-[field]#Access token populate lambda# [optional]#Optional#::
-The lambda to be invoked during the generation of an Access Token (JWT) when a user authenticates against this Application.
-
-[field]#Id token populate lambda# [optional]#Optional#::
-The lambda to be invoked during the generation of an Id Token (JWT) when a user authenticates against this Application.
+include::docs/v1/tech/core-concepts/_application-lambda-settings.adoc[]
 
 Once you have enabled JWT configuration for this Application you will be provided with additional configuration options.
 
@@ -220,18 +213,7 @@ image::core-concepts/application-jwt-enabled-configuration.png[Application JWT e
 
 ==== JWT Settings
 
-[.api]
-[field]#Issuer# [read-only]#Read-only#::
-The issuer used in the `iss` claim when building the Access Token and Id Token. This is a read-only value in this configuration. It can be modified in the Tenant configuration.
-
-[field]#JWT duration# [required]#Required#::
-The duration in seconds for which a JWT will be valid after creation. After this time has passed the JWT will expire and can no longer be used.
-
-[field]#Access token signing key# [optional]#Optional#::
-The signing key used to sign the Access Token (which is a JWT) when a user authenticates against this Application. When this value is not selected, FusionAuth will generate a new key pair and assign it to this configuration.
-
-[field]#Id token signing key# [optional]#Optional#::
-The signing key used to sign the Id Token (which is a JWT) when a user authenticates against this Application. When this value is not selected, FusionAuth will generate a new key pair and assign it to this configuration.
+include::docs/v1/tech/core-concepts/_application-json-web-token-settings.adoc[]
 
 image::core-concepts/application-jwt-enabled-refresh-token.png[Application Refresh Token configuration,width=1200,role=shadowed top-cropped]
 

--- a/site/docs/v1/tech/core-concepts/tenants.adoc
+++ b/site/docs/v1/tech/core-concepts/tenants.adoc
@@ -324,19 +324,11 @@ The lambda that will be called to populate the JWT during a client credentials g
 
 
 ==== JWT
-image::core-concepts/tenant-configuration-jwt.png[Tenant Configuration - JWT,width=1200,role=shadowed top-cropped]
+image::core-concepts/tenant-configuration-jwt.png[Tenant Configuration - JWT,width=1200,role=top-cropped]
 
 ===== JSON Web Token settings
 
-[.api]
-[field]#JWT duration# [required]#Required#::
-The length of time the issued token (access token and Id token) is valid.  JWT tokens are typically short lived.
-
-[field]#Access token signing key# [optional]#Optional#::
-The key used to sign the access token JWT.
-
-[field]#Id token signing key# [optional]#Optional#::
-The key used to sign the Id token JWT.
+include::docs/v1/tech/core-concepts/_tenant-json-web-token-settings.adoc[]
 
 ===== Refresh Token settings
 

--- a/site/docs/v1/tech/oauth/_access-token-claims.adoc
+++ b/site/docs/v1/tech/oauth/_access-token-claims.adoc
@@ -17,7 +17,7 @@ The method used to authenticate the User which resulted in this JWT being genera
 include::_authentication_type_claim_values.adoc[]
 
 [field]#auth_time# [type]#[Long]# [since]#Available since 1.36.0#::
-The time of the initial authentication request expressed as UNIX time which is the number of seconds since Epoch. This claim will remain the same even when the token has been re-issued through the use of a Refresh Token.
+The time of the initial authentication request, expressed as UNIX time which is the number of seconds since Epoch. This claim will remain the same even when the token has been re-issued through the use of a Refresh Token.
 
 [field]#email# [type]#[String]#::
 The email address of the User whose claims are represented by this JWT.

--- a/site/docs/v1/tech/oauth/_access-token-claims.adoc
+++ b/site/docs/v1/tech/oauth/_access-token-claims.adoc
@@ -1,0 +1,57 @@
+[.api]
+[field]#applicationId# [type]#[UUID]#::
+The unique Id of the Application for which the User has been authenticated. A JWT can only represent authorization to a single Application.
++
+This claim is only present if the User has a registration to the Application.
++
+To obtain a JWT for another Application you must either authenticate again with a different `applicationId` using the link:/docs/v1/tech/apis/login#authenticate-a-user[Authentication] API or utilize the link:/docs/v1/tech/apis/jwt#issue-a-jwt[Issue a JWT] API to exchange a valid JWT for another.
+
+[field]#aud# [type]#[String]#::
+The audience the JWT is intended for. This registered claim is defined by https://tools.ietf.org/html/rfc7519#section-4.1.3[RFC 7519 Section 4.1.3].
++
+This claim will be equal to the `client_id`.
+
+[field]#authenticationType# [type]#[String]#::
+The method used to authenticate the User which resulted in this JWT being generated. The possible values are:
++
+include::_authentication_type_claim_values.adoc[]
+
+[field]#auth_time# [type]#[Long]# [since]#Available since 1.36.0#::
+The time of the initial authentication request expressed as UNIX time which is the number of seconds since Epoch. This claim will remain the same even when the token has been re-issued through the use of a Refresh Token.
+
+[field]#email# [type]#[String]#::
+The email address of the User whose claims are represented by this JWT.
+
+[field]#email_verified# [type]#[Boolean]#::
+The OpenId Connect claim indicating if the User's email has been verified.
+
+[field]#exp# [type]#[Long]#::
+The expiration instant of the JWT, expressed as UNIX time which is the number of seconds since Epoch. This registered claim is defined by
+https://tools.ietf.org/html/rfc7519#section-4.1.4[RFC 7519 Section 4.1.4].
+
+[field]#iat# [type]#[Long]#::
+The instant that the JWT was issued, expressed as UNIX time which is the number of seconds since Epoch. This registered claim is defined by
+https://tools.ietf.org/html/rfc7519#section-4.1.6[RFC 7519 Section 4.1.6].
+
+[field]#jti# [type]#[String]# [since]#Available since 1.18.0#::
+The unique identifier for this JWT. This registered claim is defined by
+https://tools.ietf.org/html/rfc7519#section-4.1.7[RFC 7519 Section 4.1.7].
+
+[field]#iss# [type]#[String]#::
+The issuer of the JWT. For FusionAuth, this is always the value defined in the tenant JWT configuration. This registered claim is defined by
+https://tools.ietf.org/html/rfc7519#section-4.1.1[RFC 7519 Section 4.1.1].
+
+[field]#preferred_username# [type]#[String]# [since]#Available since 1.5.0#::
+The username of the User whose claims are represented by this JWT.
+
+[field]#roles# [type]#[Array<String>]#::
+The roles assigned to the User in the authenticated Application. This claim is only present if the User has a registration to the Application.
+
+[field]#sid# [type]#[String]# [since]#Available since 1.37.0#::
+The unique Id of the refresh token returned along with this access token when the `offline_access` scope was requested. This unique Id is the persistent identifier for this refresh token, and will not change even when using one-time use refresh tokens. This value may optionally be used to revoke the token using the link:/docs/v1/tech/apis/jwt#revoke-refresh-tokens[Refresh Token API].
+
+[field]#sub# [type]#[UUID]#::
+The subject of the access token. This value is equal to the User's unique Id in FusionAuth. This registered claim is defined by https://tools.ietf.org/html/rfc7519#section-4.1.2[RFC 7519 Section 4.1.2].
+
+[field]#tid# [type]#[UUID]# [since]#Available since 1.36.0#::
+The FusionAuth Tenant unique Id.

--- a/site/docs/v1/tech/oauth/tokens.adoc
+++ b/site/docs/v1/tech/oauth/tokens.adoc
@@ -45,63 +45,7 @@ The access token is an opaque token per the OAuth2 specification. In the FusionA
 
 === Access Token Claims
 
-[.api]
-[field]#applicationId# [type]#[UUID]#::
-The unique Id of the Application for which the User has been authenticated. A JWT can only represent authorization to a single Application.
-+
-This claim is only present if the User has a registration to the Application.
-+
-To obtain a JWT for another Application you must either authenticate again with a different `applicationId` using the link:/docs/v1/tech/apis/login#authenticate-a-user[Authentication] API or utilize the link:/docs/v1/tech/apis/jwt#issue-a-jwt[Issue a JWT] API to exchange a valid JWT for another.
-
-[field]#aud# [type]#[String]#::
-The audience the JWT is intended for. This registered claim is defined by https://tools.ietf.org/html/rfc7519#section-4.1.3[RFC 7519 Section 4.1.3].
-+
-This claim will be equal to the `client_id`.
-
-[field]#authenticationType# [type]#[String]#::
-The method used to authenticate the User which resulted in this JWT being generated. The possible values are:
-+
-include::docs/v1/tech/oauth/_authentication_type_claim_values.adoc[]
-
-[field]#auth_time# [type]#[Long]# [since]#Available since 1.36.0#::
-The time of the initial authentication request expressed as UNIX time which is the number of seconds since Epoch. This claim will remain the same even when the token has been re-issued through the use of a Refresh Token.
-
-[field]#email# [type]#[String]#::
-The email address of the User whose claims are represented by this JWT.
-
-[field]#email_verified# [type]#[Boolean]#::
-The OpenId Connect claim indicating if the User's email has been verified.
-
-[field]#exp# [type]#[Long]#::
-The expiration instant of the JWT, expressed as UNIX time which is the number of seconds since Epoch. This registered claim is defined by
-https://tools.ietf.org/html/rfc7519#section-4.1.4[RFC 7519 Section 4.1.4].
-
-[field]#iat# [type]#[Long]#::
-The instant that the JWT was issued, expressed as UNIX time which is the number of seconds since Epoch. This registered claim is defined by
-https://tools.ietf.org/html/rfc7519#section-4.1.6[RFC 7519 Section 4.1.6].
-
-[field]#jti# [type]#[String]# [since]#Available since 1.18.0#::
-The unique identifier for this JWT. This registered claim is defined by
-https://tools.ietf.org/html/rfc7519#section-4.1.7[RFC 7519 Section 4.1.7].
-
-[field]#iss# [type]#[String]#::
-The issuer of the JWT. For FusionAuth, this is always the value defined in the tenant JWT configuration. This registered claim is defined by
-https://tools.ietf.org/html/rfc7519#section-4.1.1[RFC 7519 Section 4.1.1].
-
-[field]#preferred_username# [type]#[String]# [since]#Available since 1.5.0#::
-The username of the User whose claims are represented by this JWT.
-
-[field]#roles# [type]#[Array<String>]#::
-The roles assigned to the User in the authenticated Application. This claim is only present if the User has a registration to the Application.
-
-[field]#sid# [type]#[String]# [since]#Available since 1.37.0#::
-The unique Id of the refresh token returned along with this access token when the `offline_access` scope was requested. This unique Id is the persistent identifier for this refresh token, and will not change even when using one-time use refresh tokens. This value may optionally be used to revoke the token using the link:/docs/v1/tech/apis/jwt#revoke-refresh-tokens[Refresh Token API].
-
-[field]#sub# [type]#[UUID]#::
-The subject of the access token. This value is equal to the User's unique Id in FusionAuth. This registered claim is defined by https://tools.ietf.org/html/rfc7519#section-4.1.2[RFC 7519 Section 4.1.2].
-
-[field]#tid# [type]#[UUID]# [since]#Available since 1.36.0#::
-The FusionAuth Tenant unique Id.
+include::docs/v1/tech/oauth/_access-token-claims.adoc[]
 
 == Client Credentials Access Token
 

--- a/site/docs/v1/tech/tutorials/json-web-tokens.adoc
+++ b/site/docs/v1/tech/tutorials/json-web-tokens.adoc
@@ -88,21 +88,25 @@ FusionAuth provides three configuration locations for JWT signing:
 * an Application level setting
 * with link:/docs/v1/tech/core-concepts/entity-management[Entity Management], each entity type can have a unique key
 
-FusionAuth supports configurations for HMAC, ECDSA or RSA based signing algorithms.
+FusionAuth supports configurations for HMAC, ECDSA (Elliptic Curve) or RSA based signing algorithms.
 
 Keys are managed in link:/docs/v1/tech/core-concepts/key-master[Key Master] and can be generated or imported there.
 
 === ECDSA & RSA Signing
 
-If you are using FusionAuth in a hybrid environment where applications may be untrusted, asymetric ECDSA or RSA signing is preferred. Using this approach allows you to provide applications with a public key to verify the JWT signature while securing the private key in FusionAuth.
+If you are using FusionAuth in a hybrid environment where applications may be untrusted, asymetric ECDSA or RSA signing is preferred.
 
-This means that only one party holds the private key can is able to produce JWTs. It is easier to know for certain who issued and signed the JWT: FusionAuth.
+Using this approach allows you to provide applications with a public key to verify the JWT signature while securing the private key in FusionAuth.
 
-TODO image
+This means that only one party holds the private key can is able to produce JWTs. It is easier to know for certain who issued and signed the JWT. It will be FusionAuth.
 
 === HMAC Signing
 
-If you are in a secure environment and you require better performance, symmetric HMAC signing is best. The downside of using HMAC signing is that each application requires access to the HMAC secret. Anyone with the secret can both produce a JWT with a valid signature and verify the signature which makes it difficult to know for certain who issued and signed the JWT.
+If you are in a secure environment and you require better performance, symmetric HMAC signing is best.
+
+The downside of using HMAC signing is that each application requires access to the HMAC secret and you'll need to ensure it is distributed safely.
+
+Anyone with the secret can both produce a JWT with a valid signature and verify the signature which makes it difficult to know for certain who issued and signed the JWT.
 
 == Login and JWTs
 

--- a/site/docs/v1/tech/tutorials/json-web-tokens.adoc
+++ b/site/docs/v1/tech/tutorials/json-web-tokens.adoc
@@ -16,7 +16,7 @@ If you are using OAuth grants for authentication, only the JWT signing configura
 
 Much of this tutorial is aimed at those using the Login API, not the hosted login pages.
 
-Visit the link:/docs/v1/tech/oauth/[OAuth documentation for more on OAuth].
+For more on the OAuth grants and the tokens returned when using them, visit link:/docs/v1/tech/oauth/[the OAuth documentation].
 ====
 
 After a User is authenticated via the link:/docs/v1/tech/apis/login[Login API] or link:/docs/v1/tech/oauth/[OAuth], FusionAuth creates a JWT and returns

--- a/site/docs/v1/tech/tutorials/json-web-tokens.adoc
+++ b/site/docs/v1/tech/tutorials/json-web-tokens.adoc
@@ -10,13 +10,34 @@ navcategory: developer
 JSON Web Tokens (or JWT for short - pronounced "jot") is a standard defined as link:https://tools.ietf.org/html/rfc7519[RFC 7519] that
 provides a portable unit of identity. FusionAuth implements the JWT specification and can provide JWTs as part of the authentication workflows.
 
+[NOTE.note]
+====
+If you are using OAuth grants for authentication, only the JWT signing configuration documentation applies.
+
+Much of this tutorial is aimed at those using the Login API, not the hosted login pages.
+
+Visit the link:/docs/v1/tech/oauth/[OAuth documentation for more on OAuth].
+====
+
 After a User is authenticated via the link:/docs/v1/tech/apis/login[Login API] or link:/docs/v1/tech/oauth/[OAuth], FusionAuth creates a JWT and returns
 it to the caller. This JWT will be cryptographically signed to allow other applications to verify that it was created by FusionAuth.
 
-[NOTE.note]
-====
-If you are using OAuth grants for authentication, only the JWT signing configuration will be useful. Most of this tutorial is aimed at those using the Login API directly. Visit the link:/docs/v1/tech/oauth/[OAuth documentation for more].
-====
+* <<Configuring JWTs in FusionAuth>>
+** <<JSON Web Token Settings>>
+** <<Refresh Token Settings>>
+* <<Application Specific Configuration>>
+** <<JSON Web Token Settings>>
+** <<Refresh Token Settings>>
+** <<Lambda Settings>>
+* <<Configuring JWT Signing>>
+** <<ECDSA & RSA Signing>>
+** <<HMAC Signing>>
+* <<Login and JWTs>>
+** <<Skipping JWT Creation>>
+* <<JWT Payload>>
+** <<Claims>>
+** <<Example JWT>>
+* <<Refresh Tokens>>
 
 == Configuring JWTs in FusionAuth
 
@@ -26,11 +47,11 @@ The following is an example screenshot of the tenant JWT configuration.
 
 image::core-concepts/tenant-configuration-jwt.png[Tenant Configuration - JWT,width=1200,role=top-cropped]
 
-=== JSON Web Token settings
+=== JSON Web Token Settings
 
 include::docs/v1/tech/core-concepts/_tenant-json-web-token-settings.adoc[]
 
-=== Refresh Token settings
+=== Refresh Token Settings
 
 :page: tenant
 include::docs/v1/tech/core-concepts/_refresh-token-settings.adoc[]

--- a/site/docs/v1/tech/tutorials/json-web-tokens.adoc
+++ b/site/docs/v1/tech/tutorials/json-web-tokens.adoc
@@ -94,11 +94,11 @@ Keys are managed in link:/docs/v1/tech/core-concepts/key-master[Key Master] and 
 
 === ECDSA & RSA Signing
 
-If you are using FusionAuth in a hybrid environment where applications may be untrusted, asymetric ECDSA or RSA signing is preferred.
+If you are using FusionAuth in a hybrid environment where applications may be untrusted, asymmetric ECDSA or RSA signing is preferred.
 
 Using this approach allows you to provide applications with a public key to verify the JWT signature while securing the private key in FusionAuth.
 
-This means that only one party holds the private key can is able to produce JWTs. It is easier to know for certain who issued and signed the JWT. It will be FusionAuth.
+Only the party that holds the private key can produce JWTs. It is easier to know for certain who issued and signed the JWT. It will be FusionAuth.
 
 === HMAC Signing
 
@@ -157,7 +157,7 @@ include::docs/src/json/login/jwt.json[]
 
 Refresh tokens are a method of allowing a User to stay logged into an Application for a long period of time without requiring them to type in their password. This method is often used by Applications that don't store sensitive data such as games and social networks.
 
-To receive a refresh token from the Login API, enable Refresh Tokens for the application. Using the FusionAuth UI, navigate to [breadcrumb]#Settings -> Applications -> Security Tab#. Here you will find the Login API settings. Esnure that both [field]#Generate Refresh Tokens# and [field]#Enable JWT refresh# fields are enabled.
+To receive a refresh token from the Login API, enable Refresh Tokens for the application. Using the FusionAuth UI, navigate to [breadcrumb]#Settings -> Applications -> Security Tab#. Here you will find the Login API settings. Ensure that both [field]#Generate Refresh Tokens# and [field]#Enable JWT refresh# fields are enabled.
 
 FusionAuth provides refresh tokens in the response from the link:/docs/v1/tech/apis/login[Login API] provided that you supply these elements:
 

--- a/site/docs/v1/tech/tutorials/json-web-tokens.adoc
+++ b/site/docs/v1/tech/tutorials/json-web-tokens.adoc
@@ -13,7 +13,10 @@ provides a portable unit of identity. FusionAuth implements the JWT specificatio
 After a User is authenticated via the link:/docs/v1/tech/apis/login[Login API] or link:/docs/v1/tech/oauth/[OAuth], FusionAuth creates a JWT and returns
 it to the caller. This JWT will be cryptographically signed to allow other applications to verify that it was created by FusionAuth.
 
-If you are using OAuth grants for authentication, with the exception of the JWT signing configuration, most of this tutorial is aimed at those using the Login API directly.
+[NOTE.note]
+====
+If you are using OAuth grants for authentication, only the JWT signing configuration will be useful. Most of this tutorial is aimed at those using the Login API directly. Visit the link:/docs/v1/tech/oauth/[OAuth documentation for more].
+====
 
 == Configuring JWTs in FusionAuth
 
@@ -54,6 +57,7 @@ include::docs/v1/tech/core-concepts/_refresh-token-settings.adoc[]
 
 include::docs/v1/tech/core-concepts/_application-lambda-settings.adoc[]
 
+Learn more about the link:/docs/v1/tech/lambdas/jwt-populate[JWT Populate Lambda].
 
 == Configuring JWT Signing
 
@@ -73,15 +77,15 @@ If you are using FusionAuth in a hybrid environment where applications may be un
 
 This means that only one party holds the private key can is able to produce JWTs. It is easier to know for certain who issued and signed the JWT: FusionAuth.
 
+TODO image
+
 === HMAC Signing
 
 If you are in a secure environment and you require better performance, symmetric HMAC signing is best. The downside of using HMAC signing is that each application requires access to the HMAC secret. Anyone with the secret can both produce a JWT with a valid signature and verify the signature which makes it difficult to know for certain who issued and signed the JWT.
 
 == Login and JWTs
 
-When you complete a request to the link:/docs/v1/tech/apis/login[Login API], FusionAuth will return a JWT in the JSON response body as well as in an HTTP
-Only session cookie. The cookie has the benefit of allowing web applications to authenticate directly against FusionAuth and managing JWT
-identities through the browser. The cookie name that the JWT is returned in is called `access_token`.
+When you complete a request to the link:/docs/v1/tech/apis/login[Login API], FusionAuth will return a JWT in the JSON response body as well as in an HTTP Only session cookie. The cookie has the benefit of allowing web applications to authenticate directly against FusionAuth and managing JWT identities through the browser. The cookie name that the JWT is returned in is called `access_token`.
 
 Here is an example of this `Set-Cookie` response header that includes a JWT with line breaks and spaces for readability.
 
@@ -104,82 +108,15 @@ include::docs/src/json/login/login-response-short.json[]
 
 === Skipping JWT Creation
 
-There are some circumstances where you don't need a JWT returned as part of the link:/docs/v1/tech/apis/login[Login API] response and therefore you can
-instruct FusionAuth to omit the JWT from the response. This will reduce the latency of calling the link:/docs/v1/tech/apis/login[Login API] because FusionAuth can
-skip the creation and signing of the JWT. To disable JWTs during authentication, supply the `noJWT` parameter in the JSON request body on the link:/docs/v1/tech/apis/login#authenticate-a-user[Login API].
+There are some circumstances where you don't need a JWT returned as part of the link:/docs/v1/tech/apis/login[Login API] response and therefore you can instruct FusionAuth to omit the JWT from the response. This will reduce the latency of calling the link:/docs/v1/tech/apis/login[Login API] because FusionAuth can skip the creation and signing of the JWT. To disable JWTs during authentication, supply the `noJWT` parameter in the JSON request body on the link:/docs/v1/tech/apis/login#authenticate-a-user[Login API].
 
 == JWT Payload
 
-FusionAuth provides a few custom claims in addition to some registered claims as defined by https://tools.ietf.org/html/rfc7519#section-4.1[RFC 7519 Section 4.1].
-The following claims will be found in a JWT issued by FusionAuth.
+FusionAuth provides a few custom claims in addition to some registered claims as defined by https://tools.ietf.org/html/rfc7519#section-4.1[RFC 7519 Section 4.1]. The following claims will be found in a JWT issued by FusionAuth.
 
 === Claims
 
-[.api]
-[field]#applicationId# [type]#[UUID]#::
-The unique Id of the Application for which the User has been authenticated. A JWT can only represent authorization to a single Application.
-+
-This claim is only present if the User has a registration to the Application.
-+
-To obtain a JWT for another Application you must either authenticate again with a different `applicationId` using the link:/docs/v1/tech/apis/login#authenticate-a-user[Authentication] API or utilize the link:/docs/v1/tech/apis/jwt#issue-a-jwt[Issue a JWT] API to exchange a valid JWT for another.
-
-[field]#aud# [type]#[String]#::
-The audience the JWT is intended for. This registered claim is defined by https://tools.ietf.org/html/rfc7519#section-4.1.3[RFC 7519 Section 4.1.3]
-+
-This claim will be equal to the `client_id`.
-
-[field]#authenticationType# [type]#[String]#::
-The method used to authenticate the User which resulted in this JWT being generated. The possible values are:
-+
-    * `APPLE` - The User was authenticated using Apple. [since]#Available since 1.17.0#
-    * `APPLICATION_TOKEN` - The User was authenticated using an link:/docs/v1/tech/tutorials/application-authentication-tokens[Application Authentication Token].
-    * `FACEBOOK` - The User was authenticated using Facebook. &nbsp; [since]#Available since 1.1.0#
-    * `FEDERATED_JWT` - The User was authenticated using a JWT from an external Identity Provider.
-    * `GENERIC_CONNECTOR` - The user was authenticated using a generic connector.  &nbsp; [since]#Available since 1.18.0#
-    * `GOOGLE` - The User was authenticated using Google. [since]#Available since 1.1.0#
-    * `HYPR` - The User was authenticated using HYPR provider. [since]#Available since 1.12.0#
-    * `JWT_SSO` - A valid JWT authorized to one Application was exchanged for another JWT authorized to a different Application.
-    * `LDAP_CONNECTOR` -  The user was authenticated using an LDAP connector.  &nbsp; [since]#Available since 1.18.0#
-    * `LINKEDIN` -  The user was authenticated using LinkedIn.  &nbsp; [since]#Available since 1.23.0#
-    * `ONE_TIME_PASSWORD` The User was authenticated using a one time password. &nbsp; [since]#Available since 1.5.0#
-    * `OPENID_CONNECT` - The User was authenticated using an external OpenID Connect provider. [since]#Available since 1.1.0#
-    * `PASSWORD` - The User was authenticated using a loginId and password combination.
-    * `PASSWORDLESS` - The user was authenticated using a passwordless login link. &nbsp; [since]#Available since 1.5.0#
-    * `PING` - The user was authenticated using the PING API w/ a valid JWT.
-    * `REGISTRATION` - The user was created using the Registration API.  &nbsp; [since]#Available since 1.16.0#
-    * `REFRESH_TOKEN` - The User requested a new JWT using a Refresh Token.
-    * `SAMLv2` - The User was authenticated using an external SAMLv2 provider. [since]#Available since 1.6.0#
-    * `TWITTER` - The User was authenticated using Twitter. [since]#Available since 1.1.0#
-    * `USER_CREATE` - The user was created using the User API. &nbsp; [since]#Available since 1.16.0#
-
-
-[field]#email# [type]#[String]#::
-The email address of the User whose claims are represented by this JWT.
-
-[field]#email_verified# [type]#[Boolean]#::
-The OpenId Connect claim indicating if the User's email has been verified.
-
-[field]#exp# [type]#[Long]#::
-The expiration instant of the JWT expressed as UNIX time which is the number of seconds since Epoch. This registered claim is defined by
-https://tools.ietf.org/html/rfc7519#section-4.1.4[RFC 7519 Section 4.1.4]
-
-[field]#iat# [type]#[Long]#::
-The instant that the JWT was issued expressed as UNIX time which is the number of seconds since Epoch. This registered claim is defined by
-https://tools.ietf.org/html/rfc7519#section-4.1.6[RFC 7519 Section 4.1.6]
-
-[field]#iss# [type]#[String]#::
-The issuer of the JWT. For FusionAuth, this is always the value defined in the global JWT configuration. This registered claim is defined by
-https://tools.ietf.org/html/rfc7519#section-4.1.1[RFC 7519 Section 4.1.1]
-
-[field]#preferred_username# [type]#[String]# [since]#Available since 1.5.0#::
-The username of the User who claims are represented by this JWT.
-
-[field]#roles# [type]#[Array<String>]#::
-The roles assigned to the User in the authenticated Application. This claim is only present if the User has a registration to the Application.
-
-[field]#sub# [type]#[UUID]#::
-The subject of the access token. This value is equal to the User's unique Id in FusionAuth. This registered claim is defined by https://tools.ietf.org/html/rfc7519#section-4.1.2[RFC 7519 Section 4.1.2]
-
+include::docs/v1/tech/oauth/_access-token-claims.adoc[]
 
 === Example JWT
 
@@ -193,18 +130,24 @@ include::docs/src/json/login/jwt.json[]
 
 == Refresh Tokens
 
-Refresh tokens are a method of allowing a User to stay logged into an Application for a long period of time without requiring them to type in
-their password. This method is often used by Applications that don't store sensitive data such as games and social networks. FusionAuth provides refresh tokens in the response from the link:/docs/v1/tech/apis/login[Login API] provided that you supply these elements:
+Refresh tokens are a method of allowing a User to stay logged into an Application for a long period of time without requiring them to type in their password. This method is often used by Applications that don't store sensitive data such as games and social networks.
+
+To receive a refresh token from the Login API, enable Refresh Tokens for the application. Using the FusionAuth UI, navigate to [breadcrumb]#Settings -> Applications -> Security Tab#. Here you will find the Login API settings. Esnure that both [field]#Generate Refresh Tokens# and [field]#Enable JWT refresh# fields are enabled.
+
+FusionAuth provides refresh tokens in the response from the link:/docs/v1/tech/apis/login[Login API] provided that you supply these elements:
 
 * `loginId` - the User's login Id
 * `password` - the User's password or Authentication Token
 * `applicationId` - the identifier for the Application the user is logging into
 
-If all of these attributes are supplied to the link:/docs/v1/tech/apis/login[Login API] then FusionAuth will produce a refresh token. The refresh token
-will be returned in the JSON in the response body as well as in a  in a cookie header. The refresh token will be in a parameter called `refreshToken`
-in the JSON response and the HTTP Only persistent cookie will be named `refresh_token`.
+If all of these attributes are supplied to the link:/docs/v1/tech/apis/login[Login API] then FusionAuth will produce a refresh token.
 
-You will also need to verify that you have enabled Refresh Tokens for the application. Using the FusionAuth UI, navigate to [breadcrumb]#Settings -> Applications -> Security Tab#. Here you will find the Login API settings. Verify this application is configured to generate and use refresh tokens.
+[WARNING.warning]
+====
+If any of the required elements are missing, no refresh token will be generated.
+====
+
+The refresh token will be returned in the JSON in the response body as well as in a cookie header. The refresh token will be in a parameter called `refreshToken` in the JSON response and the HTTP Only persistent cookie will be named `refresh_token`.
 
 Here is an example of this `Set-Cookie` response header for a refresh token.
 
@@ -222,12 +165,12 @@ Here is an example of the JSON response body that contains the refresh token:
 include::docs/src/json/login/login-response-short-refresh-token.json[]
 ----
 
-[quote]
-[role=warn]
-____
-*Note*: Refresh Tokens are considered sensitive information. The token must be secured on the User's device. If a Refresh Token is compromised,
+[WARNING.warning]
+====
+Refresh Tokens are considered sensitive information. The token must be secured on the User's device. If a Refresh Token is compromised,
 the token bearer may perform authenticated requests on behalf of the User.
-____
+====
 
 Once you have a refresh token on the device, you can call the link:/docs/v1/tech/apis/jwt#refresh-a-jwt[Refresh a JWT] API to get a new JWT from FusionAuth using the refresh token.
 Using this pattern allows you to perform authenticated actions using the JWT without prompting the User to authenticate as long as the refresh token is active.
+

--- a/site/docs/v1/tech/tutorials/json-web-tokens.adoc
+++ b/site/docs/v1/tech/tutorials/json-web-tokens.adoc
@@ -7,11 +7,6 @@ navcategory: developer
 
 == Overview
 
-[WARNING.warning]
-====
-As of June 2021, this document is slightly out of date. Please see https://github.com/FusionAuth/fusionauth-site/issues/723[this issue] for more details.
-====
-
 JSON Web Tokens (or JWT for short - pronounced "jot") is a standard defined as link:https://tools.ietf.org/html/rfc7519[RFC 7519] that
 provides a portable unit of identity. FusionAuth implements the JWT specification and can provide JWTs as part of the authentication workflows.
 
@@ -26,71 +21,61 @@ FusionAuth provides the ability to configure a couple of aspects of its JWT hand
 
 The following is an example screenshot of the tenant JWT configuration.
 
-image::global-jwt-configuration.png[Global JWT Configuration,width=1200,role=shadowed]
+image::core-concepts/tenant-configuration-jwt.png[Tenant Configuration - JWT,width=1200,role=top-cropped]
 
-=== Form Fields
+=== JSON Web Token settings
 
-[.api]
-[field]#Refresh token duration# [required]#Required# [default]#defaults to `43200` or 30 days#::
-The length of time in minutes a Refresh Toke is considered valid. See <<Refresh Tokens>> below for additional information.
+include::docs/v1/tech/core-concepts/_tenant-json-web-token-settings.adoc[]
 
-[field]#JWT duration# [required]#Required# [default]#defaults to `60` or 1 minute#::
-The length of time in seconds before a JWT expires.
+=== Refresh Token settings
 
-[field]#Access token signing key# [default]#defaults to `HMAC using SHA-256`#::
-The selected key will be used to sign the access token JWT, see Key Master settings to add or manage keys.
-+
-    * ECDSA using SHA-256 [since]#Available since 1.4.0#
-    * ECDSA using SHA-384 [since]#Available since 1.4.0#
-    * ECDSA using SHA-512 [since]#Available since 1.4.0#
-    * HMAC using SHA-256
-    * HMAC using SHA-384
-    * HMAC using SHA-512
-    * RSA using SHA-256
-    * RSA using SHA-384
-    * RSA using SHA-512
-
-[field]#Id token signing key# [default]#defaults to `HMAC using SHA-256`#::
-The selected key will be used to sign the Id token JWT, see Key Master settings to add or manage keys.
-+
-    * ECDSA using SHA-256 [since]#Available since 1.4.0#
-    * ECDSA using SHA-384 [since]#Available since 1.4.0#
-    * ECDSA using SHA-512 [since]#Available since 1.4.0#
-    * HMAC using SHA-256
-    * HMAC using SHA-384
-    * HMAC using SHA-512
-    * RSA using SHA-256
-    * RSA using SHA-384
-    * RSA using SHA-512
-
-=== Configuring JWT Signing
-
-FusionAuth provides two levels of configuration for JWT signing, the global default values shown above, and then each Application has the option to
-override these default values and define their own.
-
-From the global JWT configuration page, you can configure the global JWT signing algorithm and keys. FusionAuth supports configurations for HMAC, ECDSA or RSA based signing algorithms.
-
-==== ECDSA & RSA Signing
-
-If you are using FusionAuth in a hybrid environment where some applications are trusted while others are not, ECDSA or RSA signing is preferred. This allows
-you to provide those applications with the public key to verify the JWT signature while securing the private key inside FusionAuth.
-
-This means that only one party holds the private key can is able to produce a JWTs, and it is easier to know for certain who issued and signed the JWT.
-
-==== HMAC Signing
-
-On the other hand, if you are in a secure environment and you require better performance, HMAC is a better solution. The downside of using HMAC
-signing is that each application that has access to the HMAC secret. Anyone with the secret can both produce a JWT with a valid signature
-and verify the signature which makes it difficult to know for certain who issued and signed the JWT.
+:page: tenant
+include::docs/v1/tech/core-concepts/_refresh-token-settings.adoc[]
 
 == Application Specific Configuration
 
-If you navigate to [breadcrumb]#Applications# from the main menu, you can also configure the JWT parameters,
-including the signing algorithm, on a per application basis. If you don't select to enable Application specific JWT configuration, the global algorithm configuration will be used.
+If you navigate to [breadcrumb]#Applications# from the main menu, you can also configure the JWT parameters, including the signing algorithm, on a per application basis. If you don't select to enable Application specific JWT configuration, the tenant configuration will be used.
 
 The following is an example screenshot of an Application specific JWT configuration.
 
-image::application-jwt-configuration.png[Application JWT Configuration,width=1200,role=shadowed]
+image::core-concepts/application-jwt-enabled-configuration.png[Application Configuration - JWT,width=1200,role=bottom-cropped top-cropped]
+
+=== JSON Web Token Settings
+
+include::docs/v1/tech/core-concepts/_application-json-web-token-settings.adoc[]
+
+image::core-concepts/application-jwt-enabled-refresh-token.png[Application Configuration - Refresh Tokens,width=1200,role=bottom-cropped top-cropped]
+
+=== Refresh Token Settings
+
+include::docs/v1/tech/core-concepts/_refresh-token-settings.adoc[]
+
+=== Lambda Settings
+
+include::docs/v1/tech/core-concepts/_application-lambda-settings.adoc[]
+
+
+== Configuring JWT Signing
+
+FusionAuth provides three configuration locations for JWT signing: 
+
+* the tenant default values shown above
+* an Application level setting
+* with link:/docs/v1/tech/core-concepts/entity-management[Entity Management], each entity type can have a unique key
+
+FusionAuth supports configurations for HMAC, ECDSA or RSA based signing algorithms.
+
+Keys are managed in link:/docs/v1/tech/core-concepts/key-master[Key Master] and can be generated or imported there.
+
+=== ECDSA & RSA Signing
+
+If you are using FusionAuth in a hybrid environment where applications may be untrusted, asymetric ECDSA or RSA signing is preferred. Using this approach allows you to provide applications with a public key to verify the JWT signature while securing the private key in FusionAuth.
+
+This means that only one party holds the private key can is able to produce JWTs. It is easier to know for certain who issued and signed the JWT: FusionAuth.
+
+=== HMAC Signing
+
+If you are in a secure environment and you require better performance, symmetric HMAC signing is best. The downside of using HMAC signing is that each application requires access to the HMAC secret. Anyone with the secret can both produce a JWT with a valid signature and verify the signature which makes it difficult to know for certain who issued and signed the JWT.
 
 == Login and JWTs
 


### PR DESCRIPTION
This is a fix for issue https://github.com/FusionAuth/fusionauth-site/issues/723

I updated the JSON Web Tokens tutorial, as this has an 84% bounce rate and gets the most tutorial traffic of anything in the docs section (some stuff under /blog gets more).