### PR TITLE
Making sure users know the permission.name cannot be modified. I adde…

### DIFF
--- a/site/docs/src/json/entity-types/permission-update-request.json
+++ b/site/docs/src/json/entity-types/permission-update-request.json
@@ -1,0 +1,9 @@
+{
+  "permission": {
+    "data": {
+      "foo": "bar"
+    },
+    "description": "The permission description",
+    "isDefault": true
+  }
+}

--- a/site/docs/v1/tech/apis/_permission-response-body.adoc
+++ b/site/docs/v1/tech/apis/_permission-response-body.adoc
@@ -20,7 +20,7 @@ The link:/docs/v1/tech/reference/data-types#instants[instant] that the Permissio
 The link:/docs/v1/tech/reference/data-types#instants[instant] that the Permission was updated in the FusionAuth database.
 
 [field]#permission.name# [type]#[String]#::
-The name of the Permission.
+The name of the Permission. Once created, this field cannot be changed.
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/_permission-update-request-body.adoc
+++ b/site/docs/v1/tech/apis/_permission-update-request-body.adoc
@@ -8,12 +8,8 @@ The description of the Permission.
 [field]#permission.isDefault# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 Whether or not the Permission is a default permission. A default permission is automatically granted to an entity of this type if no permissions are provided in a grant request.
 
-[field]#permission.name# [type]#[String]# [required]#Required#::
-The name of the Permission. Once created, this field cannot be changed.
-
 [source,json]
 .Example Request JSON
 ----
-include::../../../src/json/entity-types/permission-request.json[]
+include::../../../src/json/entity-types/permission-update-request.json[]
 ----
-

--- a/site/docs/v1/tech/apis/entity-management/entity-types.adoc
+++ b/site/docs/v1/tech/apis/entity-management/entity-types.adoc
@@ -289,7 +289,7 @@ The Id of the permission that is being updated.
 
 ==== Request Body
 
-include::docs/v1/tech/apis/_permission-request-body.adoc[]
+include::docs/v1/tech/apis/_permission-update-request-body.adoc[]
 
 === Response
 


### PR DESCRIPTION
…d an adoc file because the Example Request to update the permission no longer requires a name so it needed a separate request.