### PR TITLE
Add magic link passwordless guide

### DIFF
--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -17,6 +17,7 @@ Here's a video showing the default passwordless process in FusionAuth:
 
 video::hMqxo68ZJlw[youtube,width=560,height=315]
 
+* <<Magic Links>>
 * <<When Does It Make Sense>>
 * <<Setting Up For Passwordless>>
 * <<Using the FusionAuth OAuth Interface>>
@@ -25,6 +26,16 @@ video::hMqxo68ZJlw[youtube,width=560,height=315]
 * <<Customizing Passwordless>>
 * <<Security>>
 * <<Troubleshooting>>
+
+== Magic Links
+
+This feature in FusionAuth sends a secure, one time, timebound encoded code. By default, this is sent via email. When a user visits the link, they are logged in, as if by magic. They don't need to provide any other credentials; ownership and access to the code is considered proof of who they are.
+
+This is also known as "magic link" login. It does not require a password, hence the general term "passwordless".
+
+You are not required to use email as a transport mechanism, though it is quite common. If you use the API directly, you can use text messages/SMS, push notifications, or send it via carrier pigeon. As long as the user can provide the value to FusionAuth, it will be validated and the user will be logged in.
+
+In the rest of this document, the terms "passwordless" and "magic link" will be used synonymously.
 
 == When Does It Make Sense
 

--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -85,11 +85,11 @@ image::guides/passwordless/passwordless-email-request-form.png[The passwordless 
 . Go to the user's inbox
 . Click on the link
 
-As soon as the link is clicked, the user has begun an Authorization Code grant. You can link:/docs/v1/tech/oauth/#example-authorization-code-grant[consume the authorization code] using a library or your own code. Whatever you would normally do if someone signed in with a password, you can now do here. This means that you'll be provided with the same refresh tokens, user data, or JWTs that would be delivered if the user had signed in with a password.
+As soon as the magic link is clicked, the user has begun an Authorization Code grant. You can link:/docs/v1/tech/oauth/#example-authorization-code-grant[consume the authorization code] using a library or your own code. Whatever you would normally do if someone signed in with a password, you can now do here. This means that you'll be provided with the same refresh tokens, user data, or JWTs that would be delivered if the user had signed in with a password.
 
 To customize the look of the login pages, use link:/docs/v1/tech/themes/[themes]. While editing the theme, you could remove the username/password form. This would force everyone to use passwordless authentication.
 
-Since changing a theme modifies it across all applications in a tenant, this might also affect the FusionAuth admin application (if the new application is in the default tenant) and other applications in the same tenant. If you want to hide the username/password form on an application by application basis, you can use separate tenants or add logic to your theme to hide parts of the HTML based on the `client_id`.
+Since changing a theme modifies it across all applications in a tenant, this might also affect the FusionAuth admin application (if the new application is in the default tenant) and other applications in the same tenant. If you want to hide the username/password form on an application by application basis, you can use separate tenants or add logic to your theme to hide parts of the HTML based on the `client_id`, or you can use application specific themes. The latter are a feature requiring a paid license.
 
 === Limitations
 

--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -320,5 +320,5 @@ One option is to consult with your email client adminstrator. It may be possible
 
 In version 1.27, FusionAuth changed the link processing behavior to remedy this for some situations. Given the wide variety of email client behavior, it may still be present in other scenarios.
 
-If your users' passwordless codes are being expired by an email client, please add details to https://github.com/FusionAuth/fusionauth-issues/issues/629[this GitHub issue].
+If your users' passwordless codes are being expired by an email client, please https://github.com/FusionAuth/fusionauth-issues/issues[file a GitHub issue].
 

--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -33,7 +33,7 @@ This feature in FusionAuth sends a secure, one time, timebound encoded code. By 
 
 This is also known as "magic link" login. It does not require a password, hence the general term "passwordless".
 
-You are not required to use email as a transport mechanism, though it is quite common. If you use the <<Using the API Directly,using the API>>, you can use text messages/SMS, push notifications, or send it via carrier pigeon. As long as the user can provide the value to FusionAuth, it will be validated and the user will be logged in.
+You are not required to use email as a transport mechanism, though it is quite common. If you are <<Using the API Directly,using the API>>, you can use text messages/SMS, push notifications, or send it via carrier pigeon. As long as the user can provide the value to FusionAuth, it will be validated and the user will be logged in.
 
 In the rest of this document, the terms "passwordless" and "magic link" will be used synonymously.
 
@@ -177,7 +177,7 @@ When the user provides the code to you, call the link:/docs/v1/tech/apis/passwor
 include::docs/src/json/passwordless/start-response.json[]
 ----
 
-If the code is valid, your application will receive user data, a JWT, and other data based on the application configuration. If you sent a `state` property in the JSON when starting the authentication process, it will also be included in the response, under the `state` key.
+If the code is valid, your application will receive user data, a JWT, and other data based on the application configuration. If you send a `state` property in the JSON when starting the authentication process, it will also be included in the response, under the `state` key.
 
 [source,json]
 .Complete Passwordless Response JSON
@@ -316,7 +316,7 @@ If you are experiencing troubles with email deliverability, review link:/docs/v1
 
 In some cases, email clients will visit links in an email before the user does. In particular, this is known to happen with Outlook "safe links". If the client does this when the email contains a passwordless one time code, that code may be invalid when the user clicks on it, as it has already been "used" by the client.
 
-One option is to consult with your email client adminstrator. It may be possible to add the application's URL to an allow list.
+One option is to consult with your email client administrator. It may be possible to add the application's URL to an allow list.
 
 In version 1.27, FusionAuth changed the link processing behavior to remedy this for some situations. Given the wide variety of email client behavior, it may still be present in other scenarios.
 

--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -18,10 +18,10 @@ Here's a video showing the default passwordless process in FusionAuth:
 video::hMqxo68ZJlw[youtube,width=560,height=315]
 
 * <<Magic Links>>
-* <<When Does It Make Sense>>
+* <<When Does Passwordless Make Sense>>
 * <<Setting Up For Passwordless>>
 * <<Using the FusionAuth OAuth Interface>>
-* <<Using the API directly>>
+* <<Using the API Directly>>
 * <<Two Factor Authentication>>
 * <<Customizing Passwordless>>
 * <<Security>>
@@ -33,11 +33,11 @@ This feature in FusionAuth sends a secure, one time, timebound encoded code. By 
 
 This is also known as "magic link" login. It does not require a password, hence the general term "passwordless".
 
-You are not required to use email as a transport mechanism, though it is quite common. If you use the API directly, you can use text messages/SMS, push notifications, or send it via carrier pigeon. As long as the user can provide the value to FusionAuth, it will be validated and the user will be logged in.
+You are not required to use email as a transport mechanism, though it is quite common. If you use the <<Using the API Directly,using the API>>, you can use text messages/SMS, push notifications, or send it via carrier pigeon. As long as the user can provide the value to FusionAuth, it will be validated and the user will be logged in.
 
 In the rest of this document, the terms "passwordless" and "magic link" will be used synonymously.
 
-== When Does It Make Sense
+== When Does Passwordless Make Sense
 
 Passwordless authentication eases a user's sign-in experience. Rather than having to remember which password they used, a user gives their email address and is sent a link. When they click through, they are authenticated.
 
@@ -98,7 +98,7 @@ There are a few limitations when using the FusionAuth OAuth interface:
 * This approach will only send the passwordless code via email
 * This approach also requires you to use the Authorization Code or Implicit grant
 
-== Using the API directly
+== Using the API Directly
 
 While using the FusionAuth OAuth interface works for many, you may need more control. You can use the passwordless API to authenticate a user with a one-time code. The link:/docs/v1/tech/apis/passwordless[passwordless API reference docs] cover each of the API calls, but this guide will walk you through an implementation.
 
@@ -209,7 +209,7 @@ Learn more about setting up link:/docs/v1/tech/guides/multi-factor-authenticatio
 
 === Two Factor Authentication With the API
 
-Two factor authentication also works when <<Using the API directly,using the api>>. In that case, when you complete the passwordless authentication, instead of getting the user data, you'll get a `twoFactorId`:
+Two factor authentication also works when <<Using the API Directly,using the API>>. In that case, when you complete the passwordless authentication, instead of getting the user data, you'll get a `twoFactorId`:
 
 [source,json]
 ----

--- a/site/docs/v1/tech/guides/passwordless.adoc
+++ b/site/docs/v1/tech/guides/passwordless.adoc
@@ -5,7 +5,7 @@ description: Learn how to create a passwordless experience for your end users.
 navcategory: developer
 ---
 
-== What Is Passwordless
+== Overview
 
 Passwordless authentication allows a user to prove their identity without a password.
 
@@ -17,7 +17,6 @@ Here's a video showing the default passwordless process in FusionAuth:
 
 video::hMqxo68ZJlw[youtube,width=560,height=315]
 
-* <<What Is Passwordless>>
 * <<When Does It Make Sense>>
 * <<Setting Up For Passwordless>>
 * <<Using the FusionAuth OAuth Interface>>


### PR DESCRIPTION
Adds a magic link section to the passwordless guide, explaining that the guide is applicable to both and treats them as equivalent.