### PR TITLE
Review tenant API doc for edition feature limit correctness.

### DIFF
--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -637,178 +637,178 @@ When enabled the user's password will be validated during login. If the password
 [field]#tenant.rateLimitConfiguration.failedLogin.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
 Whether rate limiting is enabled for failed login.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.failedLogin.limit# [type]#[Integer]# [optional]#Optional# [default]#defaults to `5`# [since]#Available since 1.30.0#::
 The number of times a user can fail to login within the configured [field]#timePeriodInSeconds# duration. If a Failed authentication action has been configured then it will take precedence.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.failedLogin.timePeriodInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.30.0#::
 The duration for the number of times a user can fail login before being rate limited.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.forgotPassword.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
 Whether rate limiting is enabled for forgot password.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.forgotPassword.limit# [type]#[Integer]# [optional]#Optional# [default]#defaults to `5`# [since]#Available since 1.30.0#::
 The number of times a user can request a forgot password email within the configured [field]#timePeriodInSeconds# duration.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.forgotPassword.timePeriodInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.30.0#::
 The duration for the number of times a user can request a forgot password email before being rate limited.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendEmailVerification.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
 Whether rate limiting is enabled for send email verification.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendEmailVerification.limit# [type]#[Integer]# [optional]#Optional# [default]#defaults to `5`# [since]#Available since 1.30.0#::
 The number of times a user can request a verification email within the configured [field]#timePeriodInSeconds# duration.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendEmailVerification.timePeriodInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.30.0#::
 The duration for the number of times a user can request a verification email before being rate limited.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendPasswordless.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
 Whether rate limiting is enabled for send passwordless.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendPasswordless.limit# [type]#[Integer]# [optional]#Optional# [default]#defaults to `5`# [since]#Available since 1.30.0#::
 The number of times a user can request a passwordless login email within the configured [field]#timePeriodInSeconds# duration.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendPasswordless.timePeriodInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.30.0#::
 The duration for the number of times a user can request a passwordless login email before being rate limited.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendRegistrationVerification.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
 Whether rate limiting is enabled for send registration verification.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendRegistrationVerification.limit# [type]#[Integer]# [optional]#Optional# [default]#defaults to `5`# [since]#Available since 1.30.0#::
 The number of times a user can request a registration verification email within the configured [field]#timePeriodInSeconds# duration.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendRegistrationVerification.timePeriodInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.30.0#::
 The duration for the number of times a user can request a registration verification email before being rate limited.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendTwoFactor.enabled# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.30.0#::
 Whether rate limiting is enabled for send two factor.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendTwoFactor.limit# [type]#[Integer]# [optional]#Optional# [default]#defaults to `5`# [since]#Available since 1.30.0#::
 The number of times a user can request a two-factor code by email or SMS within the configured [field]#timePeriodInSeconds# duration.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.rateLimitConfiguration.sendTwoFactor.timePeriodInSeconds# [type]#[Integer]# [optional]#Optional# [default]#defaults to `60`# [since]#Available since 1.30.0#::
 The duration for the number of times a user can request a two-factor code by email or SMS before being rate limited.
 +
 Required when `enabled` is set to `true`.
 +
-:premium_feature: rate limiting
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: rate limiting
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.registrationConfiguration.blockedDomains# [type]#[Array<String>]# [optional]#Optional# [since]#Available since 1.30.0#::
 A list of unique domains that are not allowed to register when self service is enabled.
 +
-:premium_feature: blocked domains
-include::../shared/_premium-edition-blurb-api.adoc[]
+:enterprise_feature: blocked domains
+include::../shared/_enterprise-edition-blurb-api.adoc[]
 +
-:premium_feature!:
+:enterprise_feature!:
 
 [field]#tenant.scimServerConfiguration.clientEntityTypeId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.36.0#::
 The Entity Type that will be used to represent SCIM Clients for this tenant.


### PR DESCRIPTION
blocked domains and rate limiting are both enterprise features, not paid features.

This is a fix for https://github.com/FusionAuth/fusionauth-site/issues/1360