### PR TITLE
Update lambda exception behavior doc

### DIFF
--- a/site/docs/v1/tech/lambdas/index.adoc
+++ b/site/docs/v1/tech/lambdas/index.adoc
@@ -210,21 +210,16 @@ function populate(jwt, user, registration) {
 
 === Exceptions
 
-When an exception is thrown, further processing ceases.
-Whatever operation the lambda was part of (login, Identity Provider user reconciliation, etc) will not complete.
+Any exception thrown in a lambda does two things:
 
-[source,javascript]
-----
-function populate(jwt, user, registration) {
-  if (user.data.isNoLongerWelcome == true) {
-    throw "Stop!";
-  }
-}
-----
+* write an event log entry
+* exit the lambda code path
 
-If using the hosted login pages, FusionAuth will display a customizable error message.
+What that means for the overall user experience depends on the type of lambda. For example, for a JWT populate lambda, the JWT will not be modified. For a reconcile lambda, the user will not be created or linked.
 
-To learn about an exception, enable debugging on the lambda via the [field]#Debug enabled# toggle in the administrative user interface or the API.
+In general, exceptions should not be used for flow control and should instead be used for exceptional situations.
+
+To view exception details, enable debugging on the lambda via the [field]#Debug enabled# toggle in the administrative user interface or the API.
 
 == Limitations
 


### PR DESCRIPTION
Per https://github.com/FusionAuth/fusionauth-issues/issues/1933 and https://github.com/FusionAuth/fusionauth-issues/issues/1707 , we are not correctly documenting the JWT populate lambda behavior.

Per https://github.com/FusionAuth/fusionauth-issues/issues/1707#issuecomment-1113654537 exceptions in lambdas are really a dev time concern, so extensively documenting how each type fails will probably lock us into an implementation choice that we don't want to take at this time.

This PR makes it clear that using a lambda exception for flow control is not recommended, and removes an erroneous example.