### PR TITLE
Fix busted link to the API docs

### DIFF
--- a/site/docs/v1/tech/client-libraries/_how-to-use-client-libraries.adoc
+++ b/site/docs/v1/tech/client-libraries/_how-to-use-client-libraries.adoc
@@ -2,7 +2,7 @@
 FusionAuth client libraries are a bit different than full featured SDKs that you might have encountered before.
 They are a thin wrapper around the REST API. Client libraries are typically used in two different ways.
 
-First, they can be used to access the FusionAuth link:/docs/v1/tech/apis[APIs] in a familiar format, leveraging language features like auto-completion.
+First, they can be used to access the FusionAuth link:/docs/v1/tech/apis/[APIs] in a familiar format, leveraging language features like auto-completion.
 When used for this, they can be helpful to script FusionAuth configuration, automate common tasks, and create copies of existing applications, groups and more.
 
 To use the client libraries effectively in this way, it is helpful to review the source code of the client library and the API documentation, which contains the JSON structure.

--- a/site/docs/v1/tech/reference/cookies.adoc
+++ b/site/docs/v1/tech/reference/cookies.adoc
@@ -9,7 +9,7 @@ navcategory: admin
 
 Cookies are a critical part of web applications.
 
-When you call certain APIs, such as the Login API, cookies may be set. Such cookies are specified in the link:/docs/v1/tech/apis[API documentation].
+When you call certain APIs, such as the Login API, cookies may be set. Such cookies are specified in the link:/docs/v1/tech/apis/[API documentation].
 
 When you use the link:/docs/v1/tech/core-concepts/integration-points#hosted-login-pages[hosted login pages], FusionAuth uses cookies to enable functionality.
 


### PR DESCRIPTION
Needs the extra slash.