### PR TITLE
Correct WebAuthn API Page formatting

### DIFF
--- a/site/docs/v1/tech/admin-guide/securing.adoc
+++ b/site/docs/v1/tech/admin-guide/securing.adoc
@@ -78,7 +78,7 @@ Create a keystore and truststore as documented by the https://docs.oracle.com/ja
 
 [source,properties]
 ----
-fusionauth-app.additional-java-args="-Djavax.net.ssl.keyStore=/usr/local/fusionauth/config/my-keystore -Djavax.net.ssl.keyStorePassword=changeit -Djavax.net.ssl.trustStore=/usr/local/fusionauth/config/my-truststore -Djavax.net.ssl.trustStorePassword=changeit"
+fusionauth-app.additional-java-args=-Djavax.net.ssl.keyStore=/usr/local/fusionauth/config/my-keystore -Djavax.net.ssl.keyStorePassword=changeit -Djavax.net.ssl.trustStore=/usr/local/fusionauth/config/my-truststore -Djavax.net.ssl.trustStorePassword=changeit
 ----
 
 Learn more about link:/docs/v1/tech/reference/configuration[configuration options].

--- a/site/docs/v1/tech/apis/_import-webauthn-request-body.adoc
+++ b/site/docs/v1/tech/apis/_import-webauthn-request-body.adoc
@@ -46,6 +46,8 @@ The link:/docs/v1/tech/reference/data-types#instants[instant] when the passkey w
 
 [field]#credentials``[x]``.name# [type]#[String]# [required]#Required#::
 A unique name meant to disambiguate passkeys with the same [field]#credential.displayName#.
++
+Prior to version `1.42.0` this field was optional.
 
 [field]#credentials``[x]``.publicKey# [type]#[String]# [required]#Required#::
 The passkey's public key, encoded in PEM format.

--- a/site/docs/v1/tech/apis/_webauthn-register-start-request-body.adoc
+++ b/site/docs/v1/tech/apis/_webauthn-register-start-request-body.adoc
@@ -8,7 +8,7 @@ The primary display name for the new passkey.
 The optional name for the passkey. This is meant to disambiguate passkeys with the same [field]#displayName#. When this parameter is omitted, it will be defaulted to the user's email address. If the user does not have an email address, this parameter will be defaulted to their username instead.
 +
 Prior to version `1.42.0` [field]#name# was defaulted to a random four character alphanumeric string.
-
++
 [NOTE.note]
 ====
 The passkey [field]#name# is set at the time the passkey is registered. There is currently no way to change the name of the passkey. Prompts displayed by the WebAuthn JavaScript API will continue to display the original value at the time the passkey was registered even if the user updates their email address or username. In order to display the updated email or username the user must register a new passkey.

--- a/site/docs/v1/tech/apis/webauthn.adoc
+++ b/site/docs/v1/tech/apis/webauthn.adoc
@@ -128,7 +128,7 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 == Import Passkeys
 
 This API is used to bulk import multiple passkeys into FusionAuth. Reasonable defaults are provided for optional fields. This request is useful for migrating data from an existing database into FusionAuth.
-
+ 
 === Request
 
 [.api-authentication]

--- a/site/docs/v1/tech/apis/webauthn.adoc
+++ b/site/docs/v1/tech/apis/webauthn.adoc
@@ -128,7 +128,7 @@ include::docs/v1/tech/apis/_standard-delete-response-codes.adoc[]
 == Import Passkeys
 
 This API is used to bulk import multiple passkeys into FusionAuth. Reasonable defaults are provided for optional fields. This request is useful for migrating data from an existing database into FusionAuth.
- 
+
 === Request
 
 [.api-authentication]


### PR DESCRIPTION
* Correct the formatting for note on passkey `name` default.
* Add a note about passkey `name` being optional on import prior to version 1.42.0
* Remove quotes from sample config for custom keystore

- https://github.com/FusionAuth/fusionauth-site/issues/1766