### PR TITLE
Start Forgot Password without Email Template

### DIFF
--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -1100,7 +1100,7 @@ The login identifier of the user. The login identifier can be either the `email`
 
 [field]#sendForgotPasswordEmail# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `true`#::
 Whether or not calling this API should attempt to send the user an email using the Forgot Password Email Template. Setting this to
-false will skip the email attempt and only set the `changePasswordId` for the user.
+false will skip the email attempt and only set the `changePasswordId` for the user. This also allows you to start the forgot password flow without a Forgot Password Email Template.
 
 [field]#state# [type]#[Object]# [optional]#Optional#::
 An optional object that will be returned un-modified when you complete the forgot password request. This may be useful to return the user to particular state once they complete the password change.

--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -1100,7 +1100,7 @@ The login identifier of the user. The login identifier can be either the `email`
 
 [field]#sendForgotPasswordEmail# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `true`#::
 Whether or not calling this API should attempt to send the user an email using the Forgot Password Email Template. Setting this to
-false will skip the email attempt and only set the `changePasswordId` for the user. This also allows you to start the forgot password flow without a Forgot Password Email Template.
+false will skip the email attempt and only set the `changePasswordId` for the user and allow you to start the forgot password flow without a Forgot Password Email Template.
 
 [field]#state# [type]#[Object]# [optional]#Optional#::
 An optional object that will be returned un-modified when you complete the forgot password request. This may be useful to return the user to particular state once they complete the password change.


### PR DESCRIPTION
Add a note to User API doc about starting the forgot password workflow without a configured email template if not requesting FusionAuth to send the email.

Related:
- https://github.com/FusionAuth/fusionauth-issues/issues/1735

Requires internal:
- https://github.com/FusionAuth/fusionauth-app/pull/160