### PR TITLE
Fix Link to In-Depth Guides

### DIFF
--- a/site/docs/v1/tech/developer-guide/index.adoc
+++ b/site/docs/v1/tech/developer-guide/index.adoc
@@ -14,7 +14,7 @@ Here is documentation about developing and integrating with a FusionAuth instanc
 * link:/docs/v1/tech/client-libraries[Client Libraries/SDKs] - Manipulate FusionAuth using your favorite language
 * link:/docs/v1/tech/events-webhooks[Events and Webhooks] - Configure FusionAuth to send webhooks to other systems
 * link:/docs/v1/tech/developer-guide/exposing-instance[Exposing a Local Instance] - How to do this using ngrok, and why you might consider doing so
-* link:/docs/v1/tech/guides[In-Depth Guides] - Guides to set up MFA, SSO and more
+* link:/docs/v1/tech/guides/[In-Depth Guides] - Guides to set up MFA, SSO and more
 * link:/docs/v1/tech/integrations[Third Party Integrations] - Third party integrations
 * link:/docs/v1/tech/tutorials/json-web-tokens[JSON Web Tokens] - Using JWTs with FusionAuth
 * link:/docs/v1/tech/core-concepts/key-master[Key Master] - managing signing keys


### PR DESCRIPTION
Fix the link to in-depth guides from **Developer Guides -> Overview**.

- https://github.com/FusionAuth/fusionauth-site/issues/1781