### PR TITLE
Add Deprecated Name

### DIFF
--- a/site/docs/v1/tech/reference/configuration.adoc
+++ b/site/docs/v1/tech/reference/configuration.adoc
@@ -294,6 +294,11 @@ Determines if FusionAuth should use link:/docs/v1/tech/guides/silent-mode[Silent
 
 [field]#fusionauth-app.url# [type]#[String]# [since]#Available since 1.4.0#::
 The FusionAuth App URL that is used to communicate with other FusionAuth nodes. This value is defaulted if not specified to use a localhost address or a site local if available. Unless you have multiple FusionAuth nodes the generated value should always work. You may need to manually specify this value if you have multiple FusionAuth nodes and the only way the nodes can communicate is on a public network.
++
+[.deprecated]
+Deprecated names:
++
+* `fusionauth.url`
 
 [field]#fusionauth-app.user-search-index.name# [type]#[String]# [default]#defaults to `fusionauth_user`# [since]#Available since 1.22.0#::
 The name of the Elasticsearch index that will be created by FusionAuth to index users.


### PR DESCRIPTION
Add deprecated Name   `fusionauth.url` under `fusionauth-app.url `