### PR TITLE
Updating doc for three node default

### DIFF
--- a/site/docs/v1/tech/installation-guide/cloud.adoc
+++ b/site/docs/v1/tech/installation-guide/cloud.adoc
@@ -294,8 +294,7 @@ The exact duration of system downtime depends on the type of deployment, amount 
 
 |===
 
-HA has a drastically lower downtime because the system has two nodes. 
-They are upgraded one at a time and can continue to receive traffic during the upgrade. 
+HA systems have significantly lower downtime during an upgrade because the system has two or more nodes. They are upgraded one at a time and can continue to receive traffic during the upgrade. 
 
 === Upgrade Considerations
 


### PR DESCRIPTION
In the last few months, we migrated to three nodes for our HA clusters, due to increased stability and improved Elasticsearch master election. 

This PR updates the doco for that reality, while still applying to some older HA setups that are only two node.