### PR TITLE
Added includeArchived param to system log export

### DIFF
--- a/site/docs/v1/tech/apis/_system-logs-request-body.adoc
+++ b/site/docs/v1/tech/apis/_system-logs-request-body.adoc
@@ -6,6 +6,11 @@ The format string used to format the date and time columns in the export result.
 +
 When this parameter is omitted a default format of `M/d/yyyy hh:mm:ss a z` will be used. See the https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[DateTimeFormatter patterns] for additional examples.
 
+[field]#includeArchived# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
+Whether to include rotated, compressed logs in addition to the set of active logs in the export result. The default behavior is to only export the set of logs actively being written.
++
+When this parameter is included with a value of `true`, the `lastNBytes` parameter is ignored and all logs are exported with all log data.
+
 [field]#lastNBytes# [type]#[Long]# [optional]#Optional# [default]#defaults to `65,536`#::
 The number of bytes to retrieve from the end of each of the system logs.  When this value is `-1`, the entire log will be downloaded.
 

--- a/site/docs/v1/tech/apis/_system-logs-request-body.adoc
+++ b/site/docs/v1/tech/apis/_system-logs-request-body.adoc
@@ -1,18 +1,18 @@
-==== Request Body
-
 [.api]
 [field]#dateTimeSecondsFormat# [type]#[String]#  [optional]#Optional# [default]#defaults to **[see description]**#::
 The format string used to format the date and time columns in the export result.
 +
 When this parameter is omitted a default format of `M/d/yyyy hh:mm:ss a z` will be used. See the https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[DateTimeFormatter patterns] for additional examples.
 
-[field]#includeArchived# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
+[field]#includeArchived# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`# [since]#Available since 1.43.0#::
 Whether to include rotated, compressed logs in addition to the set of active logs in the export result. The default behavior is to only export the set of logs actively being written.
 +
-When this parameter is included with a value of `true`, the `lastNBytes` parameter is ignored and all logs are exported with all log data.
+When this parameter is `true`, all available logs are exported. Additionally, if provided, the `lastNBytes` parameter is ignored.
 
 [field]#lastNBytes# [type]#[Long]# [optional]#Optional# [default]#defaults to `65,536`#::
 The number of bytes to retrieve from the end of each of the system logs.  When this value is `-1`, the entire log will be downloaded.
++
+This parameter is ignored when `includeArchived` is `true` .
 
 [field]#zoneId# [type]#[String]# [optional]#Optional# [default]#defaults to **[see description]**#::
 The link:/docs/v1/tech/reference/data-types#time-zone[time zone] used to adjust the stored UTC time in the export result.
@@ -25,9 +25,3 @@ For example:
 &nbsp;
 +
 When this parameter is omitted the configured default report time zone will be used. See [field]#reportTimezone# in the link:/docs/v1/tech/apis/system[System Configuration API].
-
-[source,json]
-.Example Request JSON
-----
-include::../../../src/json/system-logs/post-request.json[]
-----

--- a/site/docs/v1/tech/apis/system.adoc
+++ b/site/docs/v1/tech/apis/system.adoc
@@ -108,7 +108,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 [.endpoint]
 .URI
 --
-[method]#GET# [uri]#/api/system/log/export``?dateTimeSecondsFormat=\{dateTimeSecondsFormat\}&includeArchived=true&lastNBytes=\{lastNBytes\}&zoneId=\{zoneId\}``#
+[method]#GET# [uri]#/api/system/log/export``?dateTimeSecondsFormat=\{dateTimeSecondsFormat\}&includeArchived=true&zoneId=\{zoneId\}``#
 --
 
 When calling the API using a `GET` request you will send the export criteria on the URL using request parameters.

--- a/site/docs/v1/tech/apis/system.adoc
+++ b/site/docs/v1/tech/apis/system.adoc
@@ -108,38 +108,14 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 [.endpoint]
 .URI
 --
-[method]#GET# [uri]#/api/system/log/export``?dateTimeSecondsFormat=\{dateTimeSecondsFormat\}&lastNBytes=\{lastNBytes\}&zoneId=\{zoneId\}``#
+[method]#GET# [uri]#/api/system/log/export``?dateTimeSecondsFormat=\{dateTimeSecondsFormat\}&includeArchived=true&lastNBytes=\{lastNBytes\}&zoneId=\{zoneId\}``#
 --
 
 When calling the API using a `GET` request you will send the export criteria on the URL using request parameters.
 
 ==== Request Parameters
 
-[.api]
-[field]#dateTimeSecondsFormat# [type]#[String]#  [optional]#Optional# [default]#defaults to **[see description]**#::
-The format string used to format the date and time columns in the export result.
-+
-When this parameter is omitted a default format of `M/d/yyyy hh:mm:ss a z` will be used. See the https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[DateTimeFormatter patterns] for additional examples.
-
-[field]#includeArchived# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
-Whether to include rotated, compressed logs in addition to the set of active logs in the export result. The default behavior is to only export the set of logs actively being written.
-+
-When this parameter is included with a value of `true`, the `lastNBytes` parameter is ignored and all logs are exported with all log data.
-
-[field]#lastNBytes# [type]#[Long]# [optional]#Optional# [default]#defaults to `65,536`#::
-The number of bytes to retrieve from the end of each of the system logs. When this value is `-1`, the entire log will be downloaded.
-
-[field]#zoneId# [type]#[String]# [optional]#Optional# [default]#defaults to **[see description]**#::
-The link:/docs/v1/tech/reference/data-types#time-zone[time zone] used to calculate the current time and build the filename.
-+
-For example:
-+
-[quote]
-`America/Denver` or `US/Mountain`
-+
-&nbsp;
-+
-When this parameter is omitted the configured default report time zone will be used. See [field]#reportTimezone# in the link:/docs/v1/tech/apis/system[System Configuration API].
+include::docs/v1/tech/apis/_system-logs-request-body.adoc[]
 
 [.api-authentication]
 link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Export the System Logs
@@ -151,7 +127,15 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 
 When calling the API using a `POST` request you will send the export criteria in a JSON request body.
 
+==== Request Body
+
 include::docs/v1/tech/apis/_system-logs-request-body.adoc[]
+
+[source,json]
+.Example Request JSON
+----
+include::docs/src/json/system-logs/post-request.json[]
+----
 
 === Response
 

--- a/site/docs/v1/tech/apis/system.adoc
+++ b/site/docs/v1/tech/apis/system.adoc
@@ -121,6 +121,11 @@ The format string used to format the date and time columns in the export result.
 +
 When this parameter is omitted a default format of `M/d/yyyy hh:mm:ss a z` will be used. See the https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[DateTimeFormatter patterns] for additional examples.
 
+[field]#includeArchived# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
+Whether to include rotated, compressed logs in addition to the set of active logs in the export result. The default behavior is to only export the set of logs actively being written.
++
+When this parameter is included with a value of `true`, the `lastNBytes` parameter is ignored and all logs are exported with all log data.
+
 [field]#lastNBytes# [type]#[Long]# [optional]#Optional# [default]#defaults to `65,536`#::
 The number of bytes to retrieve from the end of each of the system logs. When this value is `-1`, the entire log will be downloaded.
 
@@ -141,7 +146,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 [.endpoint]
 .URI
 --
-[method]#POST# [uri]#/api/system/system-log/export#
+[method]#POST# [uri]#/api/system/log/export#
 --
 
 When calling the API using a `POST` request you will send the export criteria in a JSON request body.


### PR DESCRIPTION
Updated GET and POST methods for /api/system/log/export, adding documentation for the `includeArchived` param.