### PR TITLE
Doc deactivation scenario

### DIFF
--- a/site/docs/v1/tech/admin-guide/licensing.adoc
+++ b/site/docs/v1/tech/admin-guide/licensing.adoc
@@ -97,15 +97,15 @@ This includes both the ability of users to access such functionality and the abi
 
 For example, consider the scenario where you:
 
-* activate your license
-* enable email MFA on your tenant
-* have users set up email MFA on their accounts
+. Activate your license.
+. Enable email MFA on your tenant.
+. Have users set up email MFA on their accounts.
 
-Then, after some time, you deactivate your license. While your license is deactivated, the following functionality will be affected
+Then, after some time, you deactivate your license. While your license is deactivated, the following functionality will be affected:
 
-* users will not be able to configure email MFA
-* users with configured email MFA will not be prompted for the additional factor at login, but will still be able to log in
-* administrators will not be able to configure additional MFA methods
+* Users will not be able to configure email MFA.
+* Users with configured email MFA will not be prompted for the additional factor at login, but will still be able to log in.
+* Administrators will not be able to configure additional MFA methods.
 
 However, deactivating your license does not remove configuration previously saved while the license was active. In the scenario above, if you were to activate a license, users and admins would immediately be able to access previously disabled functionality and the previous configuration would be active.
 

--- a/site/docs/v1/tech/admin-guide/licensing.adoc
+++ b/site/docs/v1/tech/admin-guide/licensing.adoc
@@ -91,6 +91,24 @@ Should you need to deactivate your license Id, either because you are changing y
 
 image::admin-guide/license-activation/reactor-activated-decommission.png[Decomission Reactor.,width=1200]
 
+Deactivating your license will disable any link:/docs/v1/tech/premium-features/[premium functionality].
+
+This includes both the ability of users to access such functionality and the ability of admins to configure it.
+
+For example, consider the scenario where you:
+
+* activate your license
+* enable email MFA on your tenant
+* have users set up email MFA on their accounts
+
+Then, after some time, you deactivate your license. While your license is deactivated, the following functionality will be affected
+
+* users will not be able to configure email MFA
+* users with configured email MFA will not be prompted for the additional factor at login, but will still be able to log in
+* administrators will not be able to configure additional MFA methods
+
+However, deactivating your license does not remove configuration previously saved while the license was active. In the scenario above, if you were to activate a license, users and admins would immediately be able to access previously disabled functionality and the previous configuration would be active.
+
 == The License API
 
 You can use the link:/docs/v1/tech/apis/reactor[Reactor API] to activate or deactivate your license. 


### PR DESCRIPTION
This addresses https://github.com/FusionAuth/fusionauth-site/issues/1819

Major question for reviewers: is my understanding that if the license is deactivated, mfa for users with advanced mfa methods will be skipped, correct? I based my doc on the logic in DefaultMFAService