### PR TITLE
Add `userConsent.status` to Create User Consent Parameters

### DIFF
--- a/site/docs/v1/tech/apis/_user-consent-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-consent-request-body.adoc
@@ -8,6 +8,12 @@ The Id of the Consent being granted to the User.
 [field]#userConsent.giverUserId# [type]#[UUID]# [required]#Required#::
 The Id of the User giving consent. When providing self-consent the [field]#giverUserId# will be the same as the [field]#userId#.
 
+[field]#userConsent.status# [type]#[String]# [optional]#Optional# [default]#defaults to `Active`# [since]#Available since 1.43.0#::
+The status of the User consent. Possible values are:
++
+- `Active`
+- `Revoked`
+
 [field]#userConsent.userId# [type]#[UUID]# [required]#Required#::
 The Id of the User receiving consent. When providing self-consent the [field]#giverUserId# will be the same as the [field]#userId#.
 endif::[]
@@ -16,8 +22,8 @@ ifdef::update[]
 [field]#userConsent.status# [type]#[String]# [required]#Required#::
 The status of the User consent. Possible values are:
 +
-- `Active`
-- `Revoked`
+ - `Active`
+ - `Revoked`
 +
 Setting the status to `Revoked` when the current status is `Active` will revoke the User Consent. Setting the status to `Active` when the current status is `Revoked` will Un-revoke the User Consent and make active again.
 endif::[]

--- a/site/docs/v1/tech/apis/_user-consent-request-body.adoc
+++ b/site/docs/v1/tech/apis/_user-consent-request-body.adoc
@@ -21,6 +21,7 @@ endif::[]
 ifdef::update[]
 [field]#userConsent.status# [type]#[String]# [required]#Required#::
 The status of the User consent. Possible values are:
+// The spaces before the '-' on list items are required to properly align the text after the list
 +
  - `Active`
  - `Revoked`


### PR DESCRIPTION
- Document optional `userConsent.status` parameter when calling `POST /api/user/consent`
- Fix indentation for `userConsent.status` parameter for `PUT /api//user/consent`

Related:
- https://github.com/FusionAuth/fusionauth-issues/issues/1920

Requires internal:
- https://github.com/FusionAuth/fusionauth-app/pull/169