### PR TITLE
Update auth0 migration guide to reflect embedded login mistake

### DIFF
--- a/site/docs/v1/tech/migration-guide/auth0.adoc
+++ b/site/docs/v1/tech/migration-guide/auth0.adoc
@@ -22,7 +22,7 @@ This guide assumes you have installed FusionAuth. If you have not, please link:/
 ** <<Mapping User Attributes>>
 ** <<Social Logins>>
 ** <<Other Entities>>
-** <<Universal Login>>
+** <<Embedded Login>>
 * <<Exporting Users>>
 ** <<Add the Extension>>
 ** <<Run the Extension>>
@@ -87,9 +87,11 @@ Auth0, in contrast, gives users access to all Auth0 applications in a tenant by 
 
 include::docs/v1/tech/migration-guide/_identifiers.adoc[]
 
-=== Universal Login
+=== Embedded Login
 
-Auth0 provides https://auth0.com/docs/universal-login[Universal Login]. This is a complex, configurable login component that works with SPAs, native applications and web applications. 
+Auth0 provides https://auth0.com/docs/authenticate/login/embedded-login[Embedded Login]. This is a complex, configurable login component that works with SPAs, native applications and web applications. It is also not recommended by Auth0:
+
+> https://auth0.com/docs/authenticate/login/embedded-login["We do not recommend using Embedded Login."]
 
 FusionAuth's login experience is less complicated. You can choose to build your own login pages or use FusionAuth's hosted login pages. link:/docs/v1/tech/core-concepts/integration-points#login-options[Read more about these choices].
 

--- a/site/docs/v1/tech/migration-guide/auth0.adoc
+++ b/site/docs/v1/tech/migration-guide/auth0.adoc
@@ -93,7 +93,11 @@ Auth0 provides https://auth0.com/docs/authenticate/login/embedded-login[Embedded
 
 > https://auth0.com/docs/authenticate/login/embedded-login["We do not recommend using Embedded Login."]
 
-FusionAuth's login experience is simpler. You can choose to build your own login pages or use FusionAuth's hosted login pages. link:/docs/v1/tech/core-concepts/integration-points#login-options[Read more about these choices]. FusionAuth's hosted login pages are very similar to https://auth0.com/docs/authenticate/login/auth0-universal-login[Auth0's Universal Login].
+FusionAuth's login experience is simpler. You can choose to build your own login pages or use FusionAuth's hosted login pages. link:/docs/v1/tech/core-concepts/integration-points#login-options[Read more about these choices].
+
+FusionAuth's hosted login pages are very similar to https://auth0.com/docs/authenticate/login/auth0-universal-login[Auth0's Universal Login].
+
+You can build an experience similar to Auth0's Embedded Login using the link:/docs/v1/tech/apis/login[FusionAuth Login API], but FusionAuth does not offer any widgets or SDKs that use that API.
 
 Once you've planned your migration, the next step is to export your user data from Auth0.
 

--- a/site/docs/v1/tech/migration-guide/auth0.adoc
+++ b/site/docs/v1/tech/migration-guide/auth0.adoc
@@ -93,7 +93,7 @@ Auth0 provides https://auth0.com/docs/authenticate/login/embedded-login[Embedded
 
 > https://auth0.com/docs/authenticate/login/embedded-login["We do not recommend using Embedded Login."]
 
-FusionAuth's login experience is less complicated. You can choose to build your own login pages or use FusionAuth's hosted login pages. link:/docs/v1/tech/core-concepts/integration-points#login-options[Read more about these choices].
+FusionAuth's login experience is simpler. You can choose to build your own login pages or use FusionAuth's hosted login pages. link:/docs/v1/tech/core-concepts/integration-points#login-options[Read more about these choices]. FusionAuth's hosted login pages are very similar to https://auth0.com/docs/authenticate/login/auth0-universal-login[Auth0's Universal Login].
 
 Once you've planned your migration, the next step is to export your user data from Auth0.
 


### PR DESCRIPTION
I said "universal login" when I meant "embedded login".