### PR TITLE
Update to new location

### DIFF
--- a/site/docs/v1/tech/client-libraries/react-sdk.adoc
+++ b/site/docs/v1/tech/client-libraries/react-sdk.adoc
@@ -15,7 +15,7 @@ This is in beta testing. Please https://github.com/FusionAuth/fusionauth-react-s
 You can track the progress towards release in https://github.com/FusionAuth/fusionauth-issues/issues/2049[this GitHub issue].
 ====
 
-include::https://raw.githubusercontent.com/FusionAuth/fusionauth-react-sdk/main/README.adoc[tags=forDocSite]
+include::https://raw.githubusercontent.com/FusionAuth/fusionauth-react-sdk/main/generated/README.adoc[tags=forDocSite]
 
 == Source Code
 


### PR DESCRIPTION
Due to https://github.com/FusionAuth/fusionauth-react-sdk/pull/37 we are now pulling the adoc file from a different location.

Note that we have to have a markdown file at the root README in the react-sdk for npm to be happy.