### PR TITLE
Make it clearer that the JWT reconcile behavior should only be used b…

### DIFF
--- a/site/docs/v1/tech/apis/jwt.adoc
+++ b/site/docs/v1/tech/apis/jwt.adoc
@@ -9,7 +9,7 @@ description: APIs that allow you to manage Refresh Tokens, verify Access Tokens 
 JSON Web Tokens (JWTs) are portable identity tokens. A JWT is issued after completing a link:/docs/v1/tech/apis/login#authenticate-a-user[Login] request and is used to identify a user. JWTs can be used to call various FusionAuth APIs or they can be used to authenticate and authorize your APIs. In this document the term JWT and access token are used interchangeably.
 
 * <<Issue a JWT>>
-* <<Reconcile a JWT>>
+* <<Reconcile a JWT Using the External JWT Provider>>
 * <<Retrieve Public Keys>>
 * <<Refresh a JWT>>
 * <<Retrieve Refresh Tokens>>
@@ -92,10 +92,12 @@ The refresh token expiration policy as defined by [field]#jwtConfiguration.refre
 include::docs/src/json/jwt/issue-get-response.json[]
 ----
 
-== Reconcile a JWT
+== Reconcile a JWT Using the External JWT Provider
 
-The Reconcile API is used to take a JWT issued by a third party identity provider as described by an link:/docs/v1/tech/apis/identity-providers/[Identity Provider]
+The Reconcile API is used to take a JWT issued by a third party identity provider as described by an link:/docs/v1/tech/apis/identity-providers/external-jwt/[External JWT Identity Provider]
 configuration and reconcile the User represented by the JWT to FusionAuth.
+
+include::docs/v1/tech/shared/_external-jwt-provider-warning.adoc[]
 
 === Request
 


### PR DESCRIPTION
…y folks with an external JWT identity provider

This is based on comments here: https://github.com/FusionAuth/fusionauth-issues/issues/1503 

> This endpoint is really only intended to work with the ExternalJWT IdP.