### PR TITLE
Adding a Dockerfile to build and serve the site in containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git
+.idea
+.vscode
+.bundle
+node_modules
+_site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.7.5
+
+ARG SAVANT_VERSION="2.0.0-RC.4"
+ARG BUNDLER_VERSION="2.4.6"
+ARG OPENJDK_VERSION="17"
+ENV JAVA_HOME="/usr/lib/jvm/java-${OPENJDK_VERSION}-openjdk-amd64"
+
+WORKDIR /srv/jekyll
+
+RUN wget https://github.com/savant-build/savant-core/releases/download/${SAVANT_VERSION}/savant-${SAVANT_VERSION}.tar.gz -O /tmp/savant.tar.gz && \
+    tar xvf /tmp/savant.tar.gz -C /usr/local/lib && \
+    ln -s /usr/local/lib/savant-${SAVANT_VERSION}/bin/sb /usr/local/bin && \
+    gem install bundler -v ${BUNDLER_VERSION} && \
+    apt-get update && \
+    apt-get install -y openjdk-${OPENJDK_VERSION}-jdk-headless nodejs
+
+# Leveraging cache
+COPY ["Gemfile", "Gemfile.lock", "./"]
+RUN bundle install
+
+COPY . ./
+
+CMD ["sb", "compile"]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,19 @@ Thanks!
 
 If you want to submit a PR or test a change to fix a link, etc it may be helpful for you to build and run locally.
 
+### Building with Docker
+
+If you have Docker installed your machine, you can use it to build and serve the site. To make things easier, there's a [`run-docker`](./run-docker) script to build the container image and mount some cache volumes to speed up future processes.
+
+To build the site and serve it locally, execute `./run-docker --serve` to start the Docker container with a local HTTP server available at [localhost:4000](http://localhost:4000). For more information, see [Build and run a local HTTP server](#build-and-run-a-local-http-server).
+
+You can just build the site with no HTTP server by executing `./run-docker`.
+
+### Building on your host machine
+
 This project is built using jekyll and asciidoc. You'll need to have ruby installed.
 
-### Install
+#### Install
 
 Install these programs:
 
@@ -25,7 +35,7 @@ Install these programs:
 `gem install bundle`
 `bundle install`
 
-#### Build Errors
+##### Build Errors
 On M1 Macs, you may receive an error similar to:
 ```text
 Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
@@ -40,7 +50,7 @@ gem install eventmachine -v '1.2.7' -- --with-ldflags="-Wl,-undefined,dynamic_lo
 bundle install
 ```
 
-### Setup Savant
+#### Setup Savant
 
 We use the Savant build tool. In order to build and run this project, you'll need to first setup Savant.
 

--- a/run-docker
+++ b/run-docker
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+cd $(dirname "$0")
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    echo "Usage: $0 [command]"
+    echo "Tool to help building and running containers to compile (default action) or serve the website"
+    echo "Commands:"
+    echo "  -h, --help  Display this help and exit"
+    echo "  --recreate  Rebuild docker image"
+    echo "  --serve     Serve the website instead of building it"
+    exit
+fi
+
+IMAGE_NAME="fusionauth-site:latest"
+RUBY_CACHE_VOLUME_NAME="fusionauth-site-ruby"
+SAVANT_CACHE_VOLUME_NAME="fusionauth-site-savant"
+
+# Building docker image
+if [ "$1" = "--recreate" ] || [ "$(docker images -q "${IMAGE_NAME}" 2> /dev/null)" = "" ]; then
+    docker build -t "${IMAGE_NAME}" .
+    if [ "$1" = "--recreate" ]; then
+        shift
+    fi
+fi
+
+# Default command is "sb compile" from the image
+COMMAND=""
+if [ "$1" = "--serve" ]; then
+    echo "Will serve at http://localhost:4000/"
+    COMMAND="sb serve"
+fi
+
+docker run --rm \
+    -v "${PWD}:/srv/jekyll" \
+    -v "${RUBY_CACHE_VOLUME_NAME}:/usr/local/bundle" \
+    -v "${SAVANT_CACHE_VOLUME_NAME}:/root/.savant" \
+    -p "4000:4000" -it \
+    "${IMAGE_NAME}" $COMMAND


### PR DESCRIPTION
This `Dockerfile` will create an image with:
- Ruby 2.7.5
- OpenJDK 17
- Savant 2.0.0-RC.4

The default command is `sb compile` to build the website.

To facilitate the process, I also created a `run-docker` script to facilitate building the image and running the container while mounting volumes _(Ruby and Savant caches to speed up the process)_ and exporting port 4000 when serving.

Available commands:
- `./run-docker` to create a container and compile the website
- `./run-docker --serve` to serve the website instead of building it