### PR TITLE
Update refresh token revoke event

### DIFF
--- a/site/docs/src/json/events/jwt-refresh-token-revoke-all-user.json
+++ b/site/docs/src/json/events/jwt-refresh-token-revoke-all-user.json
@@ -5,6 +5,18 @@
     },
     "createInstant": 1505762615056,
     "id": "e502168a-b469-45d9-a079-fd45f83e0406",
+    "info": {
+      "ipAddress" : "42.42.42.42",
+      "location" : {
+        "city" : "Denver",
+        "country" : "US",
+        "displayString" : "Denver, CO, US",
+        "latitude" : 39.77777,
+        "longitude" : -104.9191,
+        "region" : "CO"
+      },
+      "userAgent" : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"
+    },
     "tenantId": "e872a880-b14f-6d62-c312-cb40f22af465",
     "type": "jwt.refresh-token.revoke",
     "userId": "dfdbae16-4e65-42c2-9773-23dfd6f5671d",

--- a/site/docs/src/json/events/jwt-refresh-token-revoke-application.json
+++ b/site/docs/src/json/events/jwt-refresh-token-revoke-application.json
@@ -6,6 +6,18 @@
     },
     "createInstant": 1505762615056,
     "id": "e502168a-b469-45d9-a079-fd45f83e0406",
+    "info": {
+      "ipAddress" : "42.42.42.42",
+      "location" : {
+        "city" : "Denver",
+        "country" : "US",
+        "displayString" : "Denver, CO, US",
+        "latitude" : 39.77777,
+        "longitude" : -104.9191,
+        "region" : "CO"
+      },
+      "userAgent" : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"
+    },
     "tenantId": "e872a880-b14f-6d62-c312-cb40f22af465",
     "type": "jwt.refresh-token.revoke"
   }

--- a/site/docs/src/json/events/jwt-refresh-token-revoke-user.json
+++ b/site/docs/src/json/events/jwt-refresh-token-revoke-user.json
@@ -6,6 +6,37 @@
     },
     "createInstant": 1505762615056,
     "id": "e502168a-b469-45d9-a079-fd45f83e0406",
+    "info": {
+      "ipAddress" : "42.42.42.42",
+      "location" : {
+        "city" : "Denver",
+        "country" : "US",
+        "displayString" : "Denver, CO, US",
+        "latitude" : 39.77777,
+        "longitude" : -104.9191,
+        "region" : "CO"
+      },
+      "userAgent" : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"
+    },
+    "refreshToken": {
+      "applicationId": "21a8893c-51b3-4964-8a50-6afb66ee8acd",
+      "id": "8b765761-5c7b-4f49-be88-af4eabcf4903",
+      "insertInstant": 1505762505056,
+      "metaData": {
+        "device": {
+          "lastAccessedAddress": "65.133.53.42",
+          "lastAccessedInstant": 1675457978462,
+          "name": "Richard's Hooli Phone",
+          "type": "MOBILE"
+        },
+        "scopes": [
+          "offline_access"
+        ]
+      },
+      "startInstant": 1675457978462,
+      "token": "ZxhAMC-Xr78DUnnuWhvADjUUXpMHUSGuahkA-EXAMPLE",
+      "userId": "dfdbae16-4e65-42c2-9773-23dfd6f5671d"
+    },
     "tenantId": "e872a880-b14f-6d62-c312-cb40f22af465",
     "type": "jwt.refresh-token.revoke",
     "userId": "dfdbae16-4e65-42c2-9773-23dfd6f5671d",


### PR DESCRIPTION
On the events page, there were some missing fields from the example json.

On the single refresh token event, the `refreshToken` and `info` fields were missing.

On all other refresh token events, the `info` fields were missing.