### PR TITLE
Make API Authentication Lock Icons Consistent

### DIFF
--- a/site/docs/v1/tech/apis/integrations.adoc
+++ b/site/docs/v1/tech/apis/integrations.adoc
@@ -25,7 +25,7 @@ This API is used to retrieve integrations.
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Retrieve Integrations
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Retrieve Integrations
 [.endpoint]
 .URI
 --
@@ -56,7 +56,7 @@ include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Update Integrations
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Update Integrations
 [.endpoint]
 .URI
 --

--- a/site/docs/v1/tech/apis/user-actions.adoc
+++ b/site/docs/v1/tech/apis/user-actions.adoc
@@ -34,7 +34,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 --
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Create a User Action with the provided unique Id
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Create a User Action with the provided unique Id
 [.endpoint]
 .URI
 --
@@ -65,7 +65,7 @@ This API is used to retrieve one or all of the configured User Actions. Specifyi
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Retrieve all of the User Actions
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Retrieve all of the User Actions
 [.endpoint]
 .URI
 --
@@ -73,7 +73,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red
 --
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Retrieve a User Action by Id
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Retrieve a User Action by Id
 [.endpoint]
 .URI
 --
@@ -107,7 +107,7 @@ include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Update a User Action by Id
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Update a User Action by Id
 [.endpoint]
 .URI
 --
@@ -141,7 +141,7 @@ This API is used to delete an User Action. You must specify the Id of the User A
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Soft delete a User Action. This operation can be reversed by re-activating the User Action.
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Soft delete a User Action. This operation can be reversed by re-activating the User Action.
 [.endpoint]
 .URI
 --
@@ -149,7 +149,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red
 --
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Permanently delete a User Action. This operation cannot be reversed.
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Permanently delete a User Action. This operation cannot be reversed.
 [.endpoint]
 .URI
 --
@@ -179,7 +179,7 @@ This API is used to reactivate an inactive User Action. You must specify the Id 
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Reactivate the User Action
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Reactivate the User Action
 [.endpoint]
 .URI
 --

--- a/site/docs/v1/tech/apis/user-comments.adoc
+++ b/site/docs/v1/tech/apis/user-comments.adoc
@@ -19,7 +19,7 @@ This API is used to add a User Comment to a User's account. User Comments are us
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Add a User Comment
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Add a User Comment
 [.endpoint]
 .URI
 --
@@ -87,7 +87,7 @@ This API is used to retrieve all of the User Comments on a User's account. User 
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Retrieve all Comments for a User by Id
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Retrieve all Comments for a User by Id
 [.endpoint]
 .URI
 --

--- a/site/docs/v1/tech/apis/webhooks.adoc
+++ b/site/docs/v1/tech/apis/webhooks.adoc
@@ -75,7 +75,7 @@ link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas
 --
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Retrieve a single Webhook by Id
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Retrieve a single Webhook by Id
 [.endpoint]
 .URI
 --
@@ -109,7 +109,7 @@ include::docs/v1/tech/apis/_generic-update-explanation-fragment.adoc[]
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Update a Webhook by Id
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Update a Webhook by Id
 [.endpoint]
 .URI
 --
@@ -143,7 +143,7 @@ This API is used to delete a Webhook.
 === Request
 
 [.api-authentication]
-link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[role=red,type=far]] Delete a Webhook by Id
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Delete a Webhook by Id
 [.endpoint]
 .URI
 --


### PR DESCRIPTION
Some API auth lock icons were using outlines instead of filled icons. These changes make them consistent.

Issue
- https://github.com/FusionAuth/fusionauth-site/issues/1908