### PR TITLE
Fix Breadcrumb formatting

### DIFF
--- a/site/docs/v1/tech/email-templates/_email-troubleshooting.adoc
+++ b/site/docs/v1/tech/email-templates/_email-troubleshooting.adoc
@@ -46,7 +46,7 @@ To enable SMTP logging prior to `1.37.0` follow these steps:
 
 To enable SMTP logging for version `1.37.0` or later follow these steps:
 
-. Enable debugging by navigating to [breadcrumb]#Tenants -> Your Tenant -> Edit -> Email -> Debug.
+. Enable debugging by navigating to [breadcrumb]#Tenants -> Your Tenant -> Edit -> Email -> Debug#.
 . Save the tenant.
 . Send an email.
 . View the Event Logs by navigating to [breadcrumb]#System -> Event Logs#.


### PR DESCRIPTION
Fixed an instance of breadcrumb formatting where there was no closing `#`.