### PR TITLE
document sourceApplicationId param in /docs/v1/tech/apis/applications

### DIFF
--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -501,6 +501,9 @@ include::../shared/_advanced-edition-blurb-api.adoc[]
 +
 :advanced_feature!:
 
+[field]#sourceApplicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.43.0#::
+The optional Id of an existing Application to make a copy of. A unique [field]#application.name# is required. If present, the [field]#application.id# value will used for the new Application. All other values will be copied from the source Application to the new Application.
+
 [field]#webhookIds# [type]#[Array<UUID>]# [optional]#Optional# [deprecated]#Deprecated#::
 An array of Webhook Ids. For Webhooks that are not already configured for All Applications, specifying an Id on this request will indicate the associated Webhook should handle events for this application.
 +


### PR DESCRIPTION
Document copy an application from an existing application feature with sourceApplicationId for https://github.com/FusionAuth/fusionauth-issues/issues/1957