### PR TITLE
Clarify sourceApplicationId behavior.  Remove incorrect id refs

### DIFF
--- a/site/docs/v1/tech/apis/_application-request-body.adoc
+++ b/site/docs/v1/tech/apis/_application-request-body.adoc
@@ -510,9 +510,9 @@ include::../shared/_advanced-edition-blurb-api.adoc[]
 [field]#sourceApplicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.43.0#::
 The optional Id of an existing Application from which a copy will be made.
 +
-A unique [field]#application.name# is required. If present, the [field]#application.id# value will used for the new Application. If no Id is specified, a secure random UUID will be generated and used.
+A unique [field]#application.name# is required.
 +
-The Oauth configuration is cleared.  Roles are copied with new ids. All other values will be copied from the source Application to the new Application.
+The `oauthConfiguration.clientSecret` and each role Id will be cleared so new values can be generated. All other values will be copied from the source Application.
 
 [field]#webhookIds# [type]#[Array<UUID>]# [optional]#Optional# [deprecated]#Deprecated#::
 An array of Webhook Ids. For Webhooks that are not already configured for All Applications, specifying an Id on this request will indicate the associated Webhook should handle events for this application.

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -7,7 +7,7 @@
 
 [.api]
 [field]#sourceTenantId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.14.0#::
-The optional Id of an existing Tenant to make a copy of. A unique [field]#tenant.name# is required. If present, the [field]#tenant.id# value will used for the new Tenant. All other values will be copied from the source Tenant to the new Tenant.
+The optional Id of an existing Tenant to make a copy of. A unique [field]#tenant.name# is required. All other values will be copied from the source Tenant to the new Tenant.
 
 [field]#tenant.accessControlConfiguration.uiIPAccessControlListId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.30.0#::
 The Id of the link:/docs/v1/tech/apis/ip-acl[IP Access Control List] limiting access to all applications in this tenant.


### PR DESCRIPTION
Clarify sourceApplicationId behavior.  Remove incorrect references to application.id and tenant.id fields.