### PR TITLE
add clarification to the changepass api response when using an api key

### DIFF
--- a/site/docs/v1/tech/apis/users.adoc
+++ b/site/docs/v1/tech/apis/users.adoc
@@ -1355,6 +1355,8 @@ include::docs/src/json/errors/requires-trust-token-response.json[]
 
 To complete this request you must obtain a `trustToken`. To obtain a `trustToken` complete a Two-Factor Login request.
 
+Beginning in version `1.43.0` a status code of `400` may also indicate that the supplied `currentPassword` or `loginId` were incorrect if the call was made with an API key. For security reasons without an API key this will return a `404`.
+
 |401
 |You did not supply a valid Authorization header. The header was omitted or your API key was not valid. The response will be empty. See link:/docs/v1/tech/apis/authentication[Authentication].
 


### PR DESCRIPTION
Quick update to address the changes made in https://github.com/FusionAuth/fusionauth-issues/issues/1897