### PR TITLE
Correct `emailVerifiedEmailTemplateId` description

### DIFF
--- a/site/docs/v1/tech/apis/_tenant-application-email-configuration.adoc
+++ b/site/docs/v1/tech/apis/_tenant-application-email-configuration.adoc
@@ -28,7 +28,7 @@ include::../shared/_enterprise-edition-blurb-api.adoc[]
 endif::[]
 
 [field]#{base_field_name}.emailConfiguration.emailVerifiedEmailTemplateId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.19.0#::
-The Id of the Email Template used to verify user emails. {application_email_config_override_text}
+The Id of the Email Template used to notify a user that their email address has been verified. {application_email_config_override_text}
 
 [field]#{base_field_name}.emailConfiguration.forgotPasswordEmailTemplateId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.19.0#::
 The Id of the Email Template that is used when a user is sent a forgot password email. {application_email_config_override_text}


### PR DESCRIPTION
Correct API field description for `tenant.emailConfiguration.emailVerifiedEmailTemplateId` (and the related application field).

This field configured the email to send _after_ an email address has been verified.