### PR TITLE
Adds NOTE that hasher samples have been moved

### DIFF
--- a/site/docs/v1/tech/plugins/custom-password-hashing.adoc
+++ b/site/docs/v1/tech/plugins/custom-password-hashing.adoc
@@ -111,6 +111,11 @@ If you are looking to write your own custom password hashing algorithm, this pro
 There is also a https://github.com/FusionAuth/fusionauth-contrib/tree/master/Password%20Hashing%20Plugins[selection of contributed plugins], provided by the community and made available without warranty.
 That may also be useful to you, as someone may already have written the hasher you need.
 
+[NOTE]
+====
+All sample hashers have been moved over with the community contributed plugins.
+====
+
 === Rehashing User Passwords
 
 include::docs/v1/tech/shared/_rehashing-user-passwords.adoc[]

--- a/site/docs/v1/tech/plugins/custom-password-hashing.adoc
+++ b/site/docs/v1/tech/plugins/custom-password-hashing.adoc
@@ -111,7 +111,7 @@ If you are looking to write your own custom password hashing algorithm, this pro
 There is also a https://github.com/FusionAuth/fusionauth-contrib/tree/master/Password%20Hashing%20Plugins[selection of contributed plugins], provided by the community and made available without warranty.
 That may also be useful to you, as someone may already have written the hasher you need.
 
-[NOTE]
+[NOTE.note]
 ====
 All community contributed hashing plugins have been moved over to the https://github.com/FusionAuth/fusionauth-contrib/[fusionauth-contrib project].
 ====

--- a/site/docs/v1/tech/plugins/custom-password-hashing.adoc
+++ b/site/docs/v1/tech/plugins/custom-password-hashing.adoc
@@ -113,7 +113,7 @@ That may also be useful to you, as someone may already have written the hasher y
 
 [NOTE]
 ====
-All sample hashers have been moved over with the community contributed plugins.
+All community contributed hashing plugins have been moved over to the https://github.com/FusionAuth/fusionauth-contrib/[fusionauth-contrib project].
 ====
 
 === Rehashing User Passwords

--- a/site/docs/v1/tech/plugins/writing-a-plugin.adoc
+++ b/site/docs/v1/tech/plugins/writing-a-plugin.adoc
@@ -61,6 +61,11 @@ In the example code you are beginning from, you will find the Plugin `MyExampleP
 
 Your project is now ready for you to start coding.
 
+[NOTE.note]
+====
+All community contributed hashing plugins including `MyExamplePasswordEncryptor` have been moved over to the https://github.com/FusionAuth/fusionauth-contrib/[fusionauth-contrib project].
+====
+
 == Edit Your Build File
 
 To modify the name of your plugin, edit your build file.  Below is a small portion of the build file, you may change whatever you like, but to start with you will want to change the `groupId` and the `artifactId`. These values are used to name the jar that will be built later.


### PR DESCRIPTION
Adds NOTE that hasher samples have been moved.

It was not evident to a customer that the sample hasher referenced in the doc tutorial had been moved so adding a note to call attention to this.