### PR TITLE
Change the default value for api key authentication.

### DIFF
--- a/site/docs/v1/tech/apis/authentication.adoc
+++ b/site/docs/v1/tech/apis/authentication.adoc
@@ -30,20 +30,20 @@ Below you will find a detailed explanation of each type of authentication used i
 
 When an API is marked with a red locked icon such as &nbsp;&nbsp;icon:lock[type=fas,title="Supports API keys"]&nbsp; it means you are required to provide an API key. 
 
-To enable access to a secured API create one or more API keys. The API key is then supplied in the HTTP request using the Authorization header. See <<Managing API Keys>> for more information on adding additional keys.
+To enable access to a secured API, create one or more API keys. The API key is then supplied in the HTTP request using the Authorization header. See <<Managing API Keys>> for more information on adding additional keys.
 
-The following example demonstrates the HTTP Authorization header with an API key of `2524a832-c1c6-4894-9125-41a9ea84e013`.
+The following example demonstrates the HTTP Authorization header with an API key of `7DUrRlA75b5LBRARYoTmScCTk6G6U1nG8R9mr7MGnvzA7AMxEXAMPLE`.
 
 [source,properties]
 ----
-Authorization: 2524a832-c1c6-4894-9125-41a9ea84e013
+Authorization: 7DUrRlA75b5LBRARYoTmScCTk6G6U1nG8R9mr7MGnvzA7AMxEXAMPLE
 ----
 
 The following is a curl example using the Authorization header using the above API key to retrieve a user. The line breaks and spaces are for readability.
 
 [source,shell]
 ----
-curl -H 'Authorization: 2524a832-c1c6-4894-9125-41a9ea84e013' \
+curl -H 'Authorization: 7DUrRlA75b5LBRARYoTmScCTk6G6U1nG8R9mr7MGnvzA7AMxEXAMPLE' \
      'https://local.fusionauth.io/api/user?email=richard@piedpiper.com'
 ----
 
@@ -166,7 +166,7 @@ Create as many API keys as you like, each one may be optionally limited in abili
 
 For example, the User API `/api/user` has five HTTP methods, `GET`, `POST`, `PUT`, `PATCH` and `DELETE`. While each API may have different semantics, in a general sense you can think of these HTTP methods as being retrieve, create, update, partial update, and delete respectively. With that in mind, if you'd like to create an API key that can only retrieve users, limit the API key to the `GET` method on the `/api/user` API.
 
-When you create an API key, the key value is defaulted to a secure random value. However, the API key is simply a string, so you may set the key value to `super-secret-key` if you'd like. A long and random value makes a good API key in that it is unique and difficult to guess, so allowing FusionAuth to create the key value is recommended.
+When you create an API key, the key value is defaulted to a secure random value. However, the API key is a string, so you may set it to `super-secret-key`, a UUID such as `02e56c92-f5e1-4b0f-8298-b5103bc7add7`, or any other string value that you'd like. A long and random value makes a good API key because it is unique and difficult to guess, so allowing FusionAuth to create the key value is recommended.
 
 === Managing API Keys via the API
 


### PR DESCRIPTION
It was confusing to some users.

This addresses issue https://github.com/FusionAuth/fusionauth-issues/issues/2172