### PR TITLE
Add notes on overriding Google IdP Properties

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-method-request-parameter.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-method-request-parameter.adoc
@@ -10,7 +10,7 @@ The possible values are:
 ifeval::["{idp_type}" == "Google"]
 +
 [since]#Since 1.44.0#
-**If you are using a version of FusionAuth older than 1.44.0**, `UsePopup` won't work after Mar 31 2023. `UseRedirect` will continue to work after this date. Please see https://github.com/FusionAuth/fusionauth-issues/issues/1939[Issue #1939] for more. This https://fusionauth.io/community/forum/topic/2329/upcoming-google-identity-provider-changes[forum post] has more details on an available workaround and upgrade process.
+**If you are using a version of FusionAuth older than 1.44.0**, `UsePopup` won't work. `UseRedirect` will continue to work after this date. Please see https://github.com/FusionAuth/fusionauth-issues/issues/1939[Issue #1939] for more. This https://fusionauth.io/community/forum/topic/2329/upcoming-google-identity-provider-changes[forum post] has more details on an available workaround and upgrade process.
 endif::[]
 endif::[]
 ifeval::[{idp_since} >= 12800]

--- a/site/docs/v1/tech/apis/identity-providers/_oauth-idp-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_oauth-idp-request-body.adoc
@@ -38,9 +38,17 @@ This is an optional Application specific override for the top level [field]#prop
 
 [field]#identityProvider.applicationConfiguration``[applicationId]``.properties.api# [type]#[String]# [optional]#Optional# [since]#Available since 1.44.0#::
 This is an optional Application specific override for the top level [field]#properties.api#.
++
+If this Application's [field]#loginMethod# is set to `UsePopup`, or the Application configuration is unset and the top level [field]#loginMethod# is set to `UsePopup`, and this value contains the conflicting `ux_mode=redirect` property, that single property will be replaced with `ux_mode=popup`.
++
+[since]#Since 1.45.1#
+The properties specified in this field will override individual properties on the top level [field]#properties.api# rather than overriding the entire [field]#properties.api# value.
 
 [field]#identityProvider.applicationConfiguration``[applicationId]``.properties.button# [type]#[String]# [optional]#Optional# [since]#Available since 1.44.0#::
 This is an optional Application specific override for the top level [field]#properties.button#.
++
+[since]#Since 1.45.1#
+The properties specified in this field will override individual properties on the top level [field]#properties.button# rather than overriding the entire [field]#properties.button# value.
 
 endif::[]
 ifeval::["{idp_type}" != "Steam"]
@@ -108,6 +116,8 @@ An object to hold configuration parameters for the https://developers.google.com
 
 [field]#identityProvider.properties.api# [type]#[String]# [optional]#Optional# [default]#defaults to **[see description]**# [since]#Available since 1.44.0#::
 Google Identity Services login API configuration in a properties file formatted String. Any attribute from https://developers.google.com/identity/gsi/web/reference/html-reference#element_with_id_g_id_onload[Google's documentation] can be added. Properties can be referenced in templates that support Google login to initialize the API via HTML or JavaScript. The properties specified in this field should not include the `data-` prefix on the property name.
++
+If the [field]#identityProvider.loginMethod# is set to `UsePopup` and this value contains the conflicting `ux_mode=redirect` property, that single property will be replaced with `ux_mode=popup`.
 +
 If omitted, this value will default to the following properties:
 +

--- a/site/docs/v1/tech/identity-providers/google.adoc
+++ b/site/docs/v1/tech/identity-providers/google.adoc
@@ -124,7 +124,7 @@ If selected, the `Authorized JavaScript origins` URL *must* be allowed for your 
 Please note if an `idp_hint` is appended to the OAuth Authorize endpoint, then the interaction behavior will be `redirect`, even if popup interaction is explicitly configured.
 +
 [since]#Since 1.44.0#
-**If you are using a version of FusionAuth older than 1.44.0**, `Use popup for login` won't work after Mar 31 2023. `UseRedirect` will continue to work after this date. Please see https://github.com/FusionAuth/fusionauth-issues/issues/1939[Issue #1939] for more. This https://fusionauth.io/community/forum/topic/2329/upcoming-google-identity-provider-changes[forum post] has more details on an available workaround and upgrade process.
+**If you are using a version of FusionAuth older than 1.44.0**, `Use popup for login` won't work. `UseRedirect` will continue to work after this date. Please see https://github.com/FusionAuth/fusionauth-issues/issues/1939[Issue #1939] for more. This https://fusionauth.io/community/forum/topic/2329/upcoming-google-identity-provider-changes[forum post] has more details on an available workaround and upgrade process.
 
 [field]#Button text# [required]#Required#::
 The text to be displayed in the button on the login form. This value is defaulted to `Login with Google` but it may be modified to your preference.


### PR DESCRIPTION
### Description
- Add notes on overriding Google IdP Properties at the application level
- Add note on replacing `ux_mode=redirect` with `ux_mode=popup` when the `loginMethod` conflicts

### Related Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2186