### PR TITLE
Fixing bad placeholders in Java Spring guide

### DIFF
--- a/site/docs/v1/tech/tutorials/integrate-java-spring.adoc
+++ b/site/docs/v1/tech/tutorials/integrate-java-spring.adoc
@@ -85,11 +85,11 @@ mvn compile && mvn exec:java \
   -Dfusionauth.api.key=<your API key>
 ----
 
-== Create Your :technology: Application
+== Create Your {technology} Application
 
-Now you are going to create a :technology: application. While this section uses a
-simple :technology: application, you can use the same configuration to
-integrate your :technology: application with FusionAuth.
+Now you are going to create a {technology} application. While this section uses a
+simple {technology} application, you can use the same configuration to
+integrate your {technology} application with FusionAuth.
 
 First, make a directory:
 


### PR DESCRIPTION
It seems that 09a4706 introduced a bug where the placeholders weren't being properly rendered

![image](https://user-images.githubusercontent.com/1877191/235671210-ae311042-ea7a-45a3-8670-bba84e6821a5.png)
