### PR TITLE
Adding a note to the Proxy Setup page about HTTP/1.1 version

### DIFF
--- a/site/docs/v1/tech/admin-guide/proxy-setup.adoc
+++ b/site/docs/v1/tech/admin-guide/proxy-setup.adoc
@@ -100,6 +100,11 @@ Never cache FusionAuth non-static asset responses.
 
 The community has provided a number of example configurations for different proxies. You can https://github.com/FusionAuth/fusionauth-contrib/tree/master/Reverse%20Proxy%20Configurations[view them in the GitHub repo].
 
+[NOTE.note]
+====
+Make sure your proxy is using at least HTTP/1.1, as we do not support HTTP/1.0 anymore.
+====
+
 === Chaining Proxies
 
 If needed, you can have multiple proxies for each request. This may be useful if one proxy handles custom domain names for tenants and another handles error pages.

--- a/site/docs/v1/tech/admin-guide/proxy-setup.adoc
+++ b/site/docs/v1/tech/admin-guide/proxy-setup.adoc
@@ -102,7 +102,7 @@ The community has provided a number of example configurations for different prox
 
 [NOTE.note]
 ====
-Make sure your proxy is using at least HTTP/1.1, as we do not support HTTP/1.0 anymore.
+If you are running version `1.41.0` or later, please make sure your proxy is using `HTTP/1.1` instead of `HTTP/1.0`, as we do not support it anymore.
 ====
 
 === Chaining Proxies


### PR DESCRIPTION
Adding a note to the [Proxy Setup page](https://fusionauth.io/docs/v1/tech/admin-guide/proxy-setup#common-proxy-configurations) on HTTP/1.1 version as nginx still uses 1.0 by default.

I also changed nginx config samples and opened a PR in FusionAuth/fusionauth-contrib#12