### PR TITLE
docs(hosted-backend): Missing hashtag for field

### DIFF
--- a/site/docs/v1/tech/apis/hosted-backend.adoc
+++ b/site/docs/v1/tech/apis/hosted-backend.adoc
@@ -250,7 +250,7 @@ include::docs/v1/tech/shared/_hosted-backend-response-cookies.adoc[]
 
 == Refresh
 
-This endpoint will extract the `app.rt` cookie if present and use it to make a `refresh_token` request from `/oauth/token`. The configuration rules for your Application configuration apply; ensure that [field]Refresh token# grant is enabled. If successful a new set of cookies will be set on the response that will continue to allow access to the application. You can call this any time or you can review the value of `app.at_exp` and call it when the access token is about to expire.
+This endpoint will extract the `app.rt` cookie if present and use it to make a `refresh_token` request from `/oauth/token`. The configuration rules for your Application configuration apply; ensure that [field]#Refresh token# grant is enabled. If successful a new set of cookies will be set on the response that will continue to allow access to the application. You can call this any time or you can review the value of `app.at_exp` and call it when the access token is about to expire.
 
 This API request is made from the client application. The browser must *NOT* be redirected to this endpoint.
 


### PR DESCRIPTION
There is a hashtag missing for field `Refresh Token`