### PR TITLE
:bug: Fixing Python setup URL after it was reanemd in the libraries repo

### DIFF
--- a/site/docs/v1/tech/tutorials/integrate-python-django.adoc
+++ b/site/docs/v1/tech/tutorials/integrate-python-django.adoc
@@ -61,7 +61,7 @@ Then copy and paste the following code into the `setup.py` file.
 
 [source,python]
 ----
-include::https://raw.githubusercontent.com/FusionAuth/fusionauth-example-client-libraries/main/python/setup.py[]
+include::https://raw.githubusercontent.com/FusionAuth/fusionauth-example-client-libraries/main/python/setup-django.py[]
 ----
 
 Then, you can run the setup script. You'll use `venv` to keep your workspace clean. This will create FusionAuth


### PR DESCRIPTION
Commit FusionAuth/fusionauth-example-client-libraries@e3e039be1b74a0d3165ecb30ae8ae53f9e033090 renamed `setup.py` to `setup-django.py` and we were receiving this error when building and visiting the "Integrate your Python Django app" page:

![image](https://github.com/FusionAuth/fusionauth-site/assets/1877191/a924fe78-c4d4-46fe-8ebe-e1836f8bee46)

PS: this was fixed on PR #2126 but as it wasn't approved yet, I'm doing this now
