### PR TITLE
Removing simplecloud link

### DIFF
--- a/site/docs/v1/tech/core-concepts/scim.adoc
+++ b/site/docs/v1/tech/core-concepts/scim.adoc
@@ -46,7 +46,6 @@ SCIM lets you provision and deprovision users from external identity stores into
 
 The links below include details about the SCIM specification as well as detailed information about the protocols and schemas.
 
-- http://www.simplecloud.info/[Overview of the specification and links to all relevant RFCs]
 - https://datatracker.ietf.org/doc/html/rfc7642[The RFC defining the overall concepts and requirements]
 - https://datatracker.ietf.org/doc/html/rfc7644[The RFC defining the protocol]
 - https://datatracker.ietf.org/doc/html/rfc7643[The RFC defining the core schema definitions]


### PR DESCRIPTION
Looks like simplecloud.info is down (https://github.com/erdtman/simplecloud.info/issues/69) so removing the link for now.