### PR TITLE
Two factor email template variable updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 fusionauth-site.iws
 httpRequests
 *.swp
+.savant/cache
 
 # Daniel doesn't like any of the new format files and my ide keeps creating them
 .idea

--- a/site/docs/v1/tech/apis/two-factor.adoc
+++ b/site/docs/v1/tech/apis/two-factor.adoc
@@ -296,56 +296,6 @@ include::docs/v1/tech/apis/_standard-post-response-codes.adoc[]
 
 include::docs/v1/tech/apis/_two-factor-start-response-body.adoc[]
 
-== Send a Multi-Factor Code During Login or Step Up
-
-This operation allows you to send a message with a code to finish a Multi-Factor flow, and requires an existing [field]#twoFactorId#. No API key is required.
-
-This should only be used if you want FusionAuth to send the code. Do not use this if you are sending a code out of band or are using a TOTP based authentication method.
-
-You can use this to re-send a code with the same or a different method. Using this API will invalidate all other codes previously associated with the provided [field]#twoFactorId#.
-
-Sending a code invalidates all previous codes for the provided `twoFactorId`.
-
-=== Request
-
-[.api-authentication]
-link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[type=fas]] Send a multi-factor code to complete Multi-Factor Login
-[.endpoint]
-.URI
---
-[method]#POST# [uri]#/api/two-factor/send/`{twoFactorId}`#
---
-
-==== Request Parameters
-
-[.api]
-[field]#twoFactorId# [type]#[String]# [required]#Required#::
-The [field]#twoFactorId# returned by the Login API or the Start multi-factor request.
-
-include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[]
-
-==== Request Body
-
-[.api]
-[field]#methodId# [type]#[String]# [required]#Required#::
-The Id of the MFA method to be used.
-
-[source,json]
-.Example Request JSON
-----
-include::docs/src/json/two-factor/send/twoFactorId-request.json[]
-----
-
-=== Response
-
-This API does not return a JSON response body.
-
-:success_code: 200
-:success_message: The request was successful.
-include::docs/v1/tech/apis/_standard-post-response-codes.adoc[]
-:success_code!:
-:success_message!:
-
 == Retrieve Multi-Factor Status
 
 Retrieves a user's multi-factor status. This is helpful to understand if a user has multi-factor authentication enabled, and if the user will be required to perform a multi-factor challenge during the next login request.
@@ -414,6 +364,56 @@ The value provided in the [field]#twoFactorTrustId# on the request.
 ----
 include::docs/src/json/two-factor/status/response.json[]
 ----
+
+== Send a Multi-Factor Code During Login or Step Up
+
+This operation allows you to send a message with a code to finish a Multi-Factor flow, and requires an existing [field]#twoFactorId#. No API key is required.
+
+This should only be used if you want FusionAuth to send the code. Do not use this if you are sending a code out of band or are using a TOTP based authentication method.
+
+You can use this to re-send a code with the same or a different method. Using this API will invalidate all other codes previously associated with the provided [field]#twoFactorId#.
+
+Sending a code invalidates all previous codes for the provided `twoFactorId`.
+
+=== Request
+
+[.api-authentication]
+link:/docs/v1/tech/apis/authentication#no-authentication-required[icon:unlock[type=fas]] Send a multi-factor code to complete Multi-Factor Login
+[.endpoint]
+.URI
+--
+[method]#POST# [uri]#/api/two-factor/send/`{twoFactorId}`#
+--
+
+==== Request Parameters
+
+[.api]
+[field]#twoFactorId# [type]#[String]# [required]#Required#::
+The [field]#twoFactorId# returned by the Login API or the Start multi-factor request.
+
+include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[]
+
+==== Request Body
+
+[.api]
+[field]#methodId# [type]#[String]# [required]#Required#::
+The Id of the MFA method to be used.
+
+[source,json]
+.Example Request JSON
+----
+include::docs/src/json/two-factor/send/twoFactorId-request.json[]
+----
+
+=== Response
+
+This API does not return a JSON response body.
+
+:success_code: 200
+:success_message: The request was successful.
+include::docs/v1/tech/apis/_standard-post-response-codes.adoc[]
+:success_code!:
+:success_message!:
 
 
 == Send a Multi-Factor Code When Enabling MFA

--- a/site/docs/v1/tech/apis/two-factor.adoc
+++ b/site/docs/v1/tech/apis/two-factor.adoc
@@ -436,7 +436,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.46.0#::
-The Application Id. Provide this value to use an application-specific email template and make `application` available as a template variable.
+An optional Application Id. When this value is provided, it will be used to resolve an application-specific email template and make `application` available as a template variable.
++
+If not provided, only the tenant configuration will be used when resolving email templates, and `application` will not be available as a template variable.
 
 [field]#email# [type]#[String]# [optional]#Optional#::
 The email to which send Multi-Factor codes. If the [field]#method# is equal to `email`, this is required.
@@ -476,7 +478,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.46.0#::
-The Application Id. Provide this value to use an application-specific email template and make `application` available as a template variable.
+An optional Application Id. When this value is provided, it will be used to resolve an application-specific email template and make `application` available as a template variable.
++
+If not provided, only the tenant configuration will be used when resolving email templates, and `application` will not be available as a template variable.
 
 [field]#email# [type]#[String]# [optional]#Optional#::
 The email to which send Multi-Factor codes. If the [field]#method# is equal to `email`, this is required.
@@ -529,7 +533,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.46.0#::
-The Application Id. Provide this value to use an application-specific email template and make `application` available as a template variable.
+An optional Application Id. When this value is provided, it will be used to resolve an application-specific email template and make `application` available as a template variable.
++
+If not provided, only the tenant configuration will be used when resolving email templates, and `application` will not be available as a template variable.
 
 [field]#methodId# [type]#[String]# [required]#Required#::
 The Id of the MFA method which will be removed.
@@ -557,7 +563,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[
 
 [.api]
 [field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.46.0#::
-The Application Id. Provide this value to use an application-specific email template and make `application` available as a template variable.
+An optional Application Id. When this value is provided, it will be used to resolve an application-specific email template and make `application` available as a template variable.
++
+If not provided, only the tenant configuration will be used when resolving email templates, and `application` will not be available as a template variable.
 
 [field]#methodId# [type]#[String]# [required]#Required#::
 The Id of the MFA method which will be removed.

--- a/site/docs/v1/tech/apis/two-factor.adoc
+++ b/site/docs/v1/tech/apis/two-factor.adoc
@@ -435,6 +435,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[
 ==== Request Body
 
 [.api]
+[field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.46.0#::
+The Application Id. Provide this value to use an application-specific email template and make `application` available as a template variable.
+
 [field]#email# [type]#[String]# [optional]#Optional#::
 The email to which send Multi-Factor codes. If the [field]#method# is equal to `email`, this is required.
 
@@ -472,6 +475,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[
 ==== Request Body
 
 [.api]
+[field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.46.0#::
+The Application Id. Provide this value to use an application-specific email template and make `application` available as a template variable.
+
 [field]#email# [type]#[String]# [optional]#Optional#::
 The email to which send Multi-Factor codes. If the [field]#method# is equal to `email`, this is required.
 
@@ -522,6 +528,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[
 ==== Request Body
 
 [.api]
+[field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.46.0#::
+The Application Id. Provide this value to use an application-specific email template and make `application` available as a template variable.
+
 [field]#methodId# [type]#[String]# [required]#Required#::
 The Id of the MFA method which will be removed.
 
@@ -547,6 +556,9 @@ include::docs/v1/tech/apis/_x-fusionauth-tenant-id-header-scoped-operation.adoc[
 ==== Request Body
 
 [.api]
+[field]#applicationId# [type]#[UUID]# [optional]#Optional# [since]#Available since 1.46.0#::
+The Application Id. Provide this value to use an application-specific email template and make `application` available as a template variable.
+
 [field]#methodId# [type]#[String]# [required]#Required#::
 The Id of the MFA method which will be removed.
 

--- a/site/docs/v1/tech/email-templates/templates-replacement-variables.adoc
+++ b/site/docs/v1/tech/email-templates/templates-replacement-variables.adoc
@@ -700,6 +700,9 @@ ${code}
 [.api]
 [field]#application# [type]#[Application]# [since]#Available since 1.28.0#::
 The Application object, see the link:/docs/v1/tech/apis/applications[Application API] for field definitions.
++
+*Note*:
+This object may not be available depending upon when this template is constructed. If you utilize this object in your template, ensure you first check to see if it is defined. You can check for this variable safely in freemarker by wrapping the variable as such: `${(application)!""}`.
 
 [field]#code# [type]#[String]#::
 A code that the user must provide to complete multi-factor authentication.

--- a/site/docs/v1/tech/email-templates/templates-replacement-variables.adoc
+++ b/site/docs/v1/tech/email-templates/templates-replacement-variables.adoc
@@ -700,11 +700,21 @@ ${code}
 The Application object, see the link:/docs/v1/tech/apis/applications[Application API] for field definitions.
 +
 *Note*:
-This object may not be available depending upon when this template is constructed. If you utilize this object in your template, ensure you first check to see if it is defined. You can check for this variable safely in freemarker by wrapping the variable as such: `${(application)!""}`. This object is not available on the email template when:
+This object may not be available depending upon when this template is constructed. If you utilize this object in your template, ensure you first check to see if it is defined. You can check for this variable safely in FreeMarker using the missing value test operator and an `if` statement:
 +
-* The multi-factor workflow was link:/docs/v1/tech/apis/two-factor#start-multi-factor[started] without providing the `applicationId` on that request.
-* Multi-factor authentication is required during a call to the link:/docs/v1/tech/apis/login#authenticate-a-user[login API] without providing the `applicationId` parameter. That documentation points out that there is likely no production use case where calling the API without the `applicationId` parameter is useful.
-* The message is being sent to link:/docs/v1/tech/apis/two-factor#send-a-multi-factor-code-when-enabling-mfa[enable] or link:/docs/v1/tech/apis/two-factor#send-a-multi-factor-code-when-disabling-mfa[disable] a multi-factor method without providing the `applicationId` on the request.
+[source,text]
+.Example missing value test
+----
+[#if application??]
+  [#-- Use application here --]
+[/#if]
+----
++
+This object is not available on the email template when:
++
+ * The multi-factor workflow was link:/docs/v1/tech/apis/two-factor#start-multi-factor[started] without providing the `applicationId` on that request.
+ * Multi-factor authentication is required during a call to the link:/docs/v1/tech/apis/login#authenticate-a-user[login API] without providing the `applicationId` parameter. That documentation points out that there is likely no production use case where calling the API without the `applicationId` parameter is useful.
+ * The message is being sent to link:/docs/v1/tech/apis/two-factor#send-a-multi-factor-code-when-enabling-mfa[enable] or link:/docs/v1/tech/apis/two-factor#send-a-multi-factor-code-when-disabling-mfa[disable] a multi-factor method without providing the `applicationId` on the request.
 
 [field]#code# [type]#[String]#::
 A code that the user must provide to complete multi-factor authentication.

--- a/site/docs/v1/tech/email-templates/templates-replacement-variables.adoc
+++ b/site/docs/v1/tech/email-templates/templates-replacement-variables.adoc
@@ -31,8 +31,6 @@ Below you will find each stock template that FusionAuth ships for reference. The
 ** <<Two Factor Authentication Method Added>>
 ** <<Two Factor Authentication Method Removed>>
 
-The following 
-
 [WARNING.warning]
 ====
 If you create a template with content and template variables for one type of email template (Forgot Password), but assign it to another type of email template (Passwordless Login, for example), the email will not be sent as expected.
@@ -698,11 +696,15 @@ ${code}
 === Replacement Variables
 
 [.api]
-[field]#application# [type]#[Application]# [since]#Available since 1.28.0#::
+[field]#application# [type]#[Application]# [since]#Available since 1.46.0#::
 The Application object, see the link:/docs/v1/tech/apis/applications[Application API] for field definitions.
 +
 *Note*:
-This object may not be available depending upon when this template is constructed. If you utilize this object in your template, ensure you first check to see if it is defined. You can check for this variable safely in freemarker by wrapping the variable as such: `${(application)!""}`.
+This object may not be available depending upon when this template is constructed. If you utilize this object in your template, ensure you first check to see if it is defined. You can check for this variable safely in freemarker by wrapping the variable as such: `${(application)!""}`. This object is not available on the email template when:
++
+* The multi-factor workflow was link:/docs/v1/tech/apis/two-factor#start-multi-factor[started] without providing the `applicationId` on that request.
+* Multi-factor authentication is required during a call to the link:/docs/v1/tech/apis/login#authenticate-a-user[login API] without providing the `applicationId` parameter. That documentation points out that there is likely no production use case where calling the API without the `applicationId` parameter is useful.
+* The message is being sent to link:/docs/v1/tech/apis/two-factor#send-a-multi-factor-code-when-enabling-mfa[enable] or link:/docs/v1/tech/apis/two-factor#send-a-multi-factor-code-when-disabling-mfa[disable] a multi-factor method without providing the `applicationId` on the request.
 
 [field]#code# [type]#[String]#::
 A code that the user must provide to complete multi-factor authentication.


### PR DESCRIPTION
Add a caveat to the two factor email variable updates that `application` may not be available depending on the workflow (similar to other two factor-related emails).