### PR TITLE
Webhook global parameter description

### DIFF
--- a/site/docs/v1/tech/apis/_webhook-request-body.adoc
+++ b/site/docs/v1/tech/apis/_webhook-request-body.adoc
@@ -31,10 +31,10 @@ The possible event types are:
 include::_event-types.adoc[]
 
 [field]#webhook.global# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
-Whether or not this Webhook is used for all events or just for specific Applications. In almost all cases you want to set this field to `true` and filter on the application Id when processing the webhook.
+Whether or not this Webhook is used for all Tenants or just for specific Tenants.
 +
-[since]#Since 1.37.0#
-This field controls whether this Webhook is used for all events or just for specific _Tenants_ rather than Applications.
+[since]#Before 1.37.0#
+Whether or not this Webhook is used for all events or just for specific Applications. In almost all cases you want to set this field to `true` and filter on the application Id when processing the webhook.
 
 [field]#webhook.headers# [type]#[Map<String, String>]# [optional]#Optional#::
 An object that contains headers that are sent as part of the HTTP request for the events.

--- a/site/docs/v1/tech/apis/_webhook-request-body.adoc
+++ b/site/docs/v1/tech/apis/_webhook-request-body.adoc
@@ -32,6 +32,9 @@ include::_event-types.adoc[]
 
 [field]#webhook.global# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 Whether or not this Webhook is used for all events or just for specific Applications. In almost all cases you want to set this field to `true` and filter on the application Id when processing the webhook.
++
+[since]#Since 1.37.0#
+This field controls whether this Webhook is used for all events or just for specific _Tenants_ rather than Applications.
 
 [field]#webhook.headers# [type]#[Map<String, String>]# [optional]#Optional#::
 An object that contains headers that are sent as part of the HTTP request for the events.

--- a/site/docs/v1/tech/apis/_webhook-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_webhook-response-body-base.adoc
@@ -34,10 +34,10 @@ The possible event types are:
 include::_event-types.adoc[]
 
 [field]#{base_field_name}.global# [type]#[Boolean]#::
-Whether or not this Webhook is used for all events or just for specific Applications.
+Whether or not this Webhook is used for all Tenants or just for specific Tenants.
 +
-[since]#Since 1.37.0#
-This field indicates whether this Webhook is used for all events or just for specific _Tenants_ rather than Applications.
+[since]#Before 1.37.0#
+Whether or not this Webhook is used for all events or just for specific Applications.
 
 [field]#{base_field_name}.headers# [type]#[Map<String, String>]#::
 An object that contains headers that are sent as part of the HTTP request for the events.

--- a/site/docs/v1/tech/apis/_webhook-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_webhook-response-body-base.adoc
@@ -35,6 +35,9 @@ include::_event-types.adoc[]
 
 [field]#{base_field_name}.global# [type]#[Boolean]#::
 Whether or not this Webhook is used for all events or just for specific Applications.
++
+[since]#Since 1.37.0#
+This field indicates whether this Webhook is used for all events or just for specific _Tenants_ rather than Applications.
 
 [field]#{base_field_name}.headers# [type]#[Map<String, String>]#::
 An object that contains headers that are sent as part of the HTTP request for the events.


### PR DESCRIPTION
Starting in version 1.37.0, the `webhook.global` field controls whether the webhook is used for all _Tenants_ rather than Applications.

Update the description for this field to include a note.