### PR TITLE
add doc on how to add an invisible captcha tag

### DIFF
--- a/DocsDevREADME.md
+++ b/DocsDevREADME.md
@@ -191,6 +191,8 @@ For blog posts:
 - curl
 - self-service
 - webview
+- CAPTCHA
+- Google reCAPTCHA
 
 ## Words to avoid
 

--- a/site/docs/v1/tech/apis/_tenant-request-body.adoc
+++ b/site/docs/v1/tech/apis/_tenant-request-body.adoc
@@ -20,10 +20,7 @@ include::../shared/_enterprise-edition-blurb-api.adoc[]
 [field]#tenant.captchaConfiguration.captchaMethod# [type]#[String]# [optional]#Optional# [since]#Available since 1.30.0#::
 The type of captcha method to use.  This field is required when [field]#tenant.captchaConfiguration.enabled# is set to `true`. The possible values are:
 +
- * `GoogleRecaptchaV2` - use Google Recaptcha v2
- * `GoogleRecaptchaV3` - use Google Recaptcha v3
- * `HCaptcha` - use HCaptcha
- * `HCaptchaEnterprise` - use HCaptcha Enterprise - v25
+include::../shared/_recaptcha-values.adoc[]
 +
 :enterprise_feature: CAPTCHA
 include::../shared/_enterprise-edition-blurb-api.adoc[]

--- a/site/docs/v1/tech/core-concepts/tenants.adoc
+++ b/site/docs/v1/tech/core-concepts/tenants.adoc
@@ -664,7 +664,7 @@ include::docs/v1/tech/shared/_enterprise-edition-blurb.adoc[]
 
 [.api]
 [field]#Blocked domains# [optional]#Optional#::
-One or more newline separated email domains for which self service registration will be prohibited.. For example, enter your company email domain (`piedpiper.com`) to prevent employees from using the self-service registration form, or to prevent end users from attempting to create an account using a company email address.
+One or more newline separated email domains for which self service registration will be prohibited. For example, enter your company email domain (`piedpiper.com`) to prevent employees from using the self-service registration form, or to prevent end users from attempting to create an account using a company email address.
 +
 This configuration is applied to all registration API requests and self-service registration pages for all applications in this tenant.
 

--- a/site/docs/v1/tech/core-concepts/tenants.adoc
+++ b/site/docs/v1/tech/core-concepts/tenants.adoc
@@ -606,7 +606,7 @@ The JSON response sent from the Schemas endpoint. This can be customized however
 
 ==== Security
 
-image::core-concepts/tenant-configuration-security-acl-catpcha.png[Tenant Configuration - Security: ACL and Captcha,width=1200,role=bottom-cropped]
+image::core-concepts/tenant-configuration-security-acl-catpcha.png[Tenant Configuration - Security: ACL and CAPTCHA,width=1200,role=bottom-cropped]
 
 ===== Login API settings
 
@@ -626,35 +626,35 @@ The IP access control list that will be used to restrict or allow access to host
 +
 When [field]#Access control list# is configured on an application within the tenant, the application value will override the tenant value for that application.
 
-===== Captcha settings
+===== CAPTCHA settings
 
 include::docs/v1/tech/shared/_enterprise-edition-blurb.adoc[]
 
-Captcha is supported on multiple theme templates, when enabled. You can further control display on a template by template basis with the link:/docs/v1/tech/themes/template-variables[specific theme template variables].
+CAPTCHA is supported on multiple theme templates, when enabled. You can further control display on a template by template basis with the link:/docs/v1/tech/themes/template-variables[specific theme template variables].
 
-See link:/docs/v1/tech/themes/helpers#invisible-recaptcha[invisible reCAPTCHA] for information on enabling an invisible captcha badge on the page.
+See link:/docs/v1/tech/themes/helpers#invisible-recaptcha[invisible reCAPTCHA] for information on enabling an invisible reCAPTCHA badge on the page.
 
 [.api]
 [field]#Enabled# [optional]#Optional# [default]#Defaults to `false`#::
-When enabled, Captcha is used to help increase security of a form submission on the FusionAuth themed pages.
+When enabled, CAPTCHA is used to help increase security of a form submission on the FusionAuth themed pages.
 
 [field]#Method# [required]#Optional# [default]#Defaults to `GoogleRecaptchaV3`#::
-The type of Captcha to use. FusionAuth supports `Google reCAPTCHA v2`, `Google reCAPTCHA v3`, `hCaptcha`, and `hCaptcha Enterprise`.
+The type of CAPTCHA to use. FusionAuth supports `Google reCAPTCHA v2`, `Google reCAPTCHA v3`, `hCaptcha`, and `hCaptcha Enterprise`.
 +
 Required when `enabled` is set to `true`.
 
 [field]#Secret key# [required]#Required#::
-The secret key for this Captcha service.
+The secret key for this CAPTCHA service.
 +
 Required when `enabled` is set to `true`.
 
 [field]#Site key# [required]#Required#::
-The site key for this Captcha service.
+The site key for this CAPTCHA service.
 +
 Required when `enabled` is set to `true`.
 
 [field]#Threat score threshold# [optional]#Optional#::
-The threat score threshold for this Captcha service if required. If it is not used by this Captcha service then the value will be ignored.
+The threat score threshold for this CAPTCHA service if required. If it is not used by this CAPTCHA service then the value will be ignored.
 
 image::core-concepts/tenant-configuration-security-domains-rate-limiting.png[Tenant Configuration - Security: Blocked domains and rate limiting,width=1200,role=top-cropped]
 

--- a/site/docs/v1/tech/core-concepts/tenants.adoc
+++ b/site/docs/v1/tech/core-concepts/tenants.adoc
@@ -632,6 +632,8 @@ include::docs/v1/tech/shared/_enterprise-edition-blurb.adoc[]
 
 Captcha is supported on multiple theme templates, when enabled. You can further control display on a template by template basis with the link:/docs/v1/tech/themes/template-variables[specific theme template variables].
 
+See link:/docs/v1/tech/themes/helpers#invisible-recaptcha[invisible reCAPTCHA] for information on enabling an invisible captcha badge on the page.
+
 [.api]
 [field]#Enabled# [optional]#Optional# [default]#Defaults to `false`#::
 When enabled, Captcha is used to help increase security of a form submission on the FusionAuth themed pages.

--- a/site/docs/v1/tech/shared/_recaptcha-values.adoc
+++ b/site/docs/v1/tech/shared/_recaptcha-values.adoc
@@ -1,4 +1,4 @@
- * `GoogleRecaptchaV2` - use Google Recaptcha v2
- * `GoogleRecaptchaV3` - use Google Recaptcha v3
+ * `GoogleRecaptchaV2` - use Google reCAPTCHA v2
+ * `GoogleRecaptchaV3` - use Google reCAPTCHA v3
  * `HCaptcha` - use HCaptcha
  * `HCaptchaEnterprise` - use HCaptcha Enterprise - v25

--- a/site/docs/v1/tech/shared/_recaptcha-values.adoc
+++ b/site/docs/v1/tech/shared/_recaptcha-values.adoc
@@ -1,0 +1,4 @@
+ * `GoogleRecaptchaV2` - use Google Recaptcha v2
+ * `GoogleRecaptchaV3` - use Google Recaptcha v3
+ * `HCaptcha` - use HCaptcha
+ * `HCaptchaEnterprise` - use HCaptcha Enterprise - v25

--- a/site/docs/v1/tech/themes/helpers.adoc
+++ b/site/docs/v1/tech/themes/helpers.adoc
@@ -161,3 +161,64 @@ The `_helpers.ftl` template provides a couple of macros that help render form el
 * `button`
 ** This macro renders a button that can be used to submit a form. The FusionAuth version of this macro includes an icon and the button text.
 
+== Captcha
+
+The `_helpers.ftl` template provides a macro to embed link:/docs/v1/tech/core-concepts/tenants#captcha-settings[captcha challenges] into your templates. This is
+
+* `captchaBadge`
+** Macro that adds a captcha badge to the template. See link:/docs/v1/tech/themes/template-variables/[template variables] for more information on the template variables. The macro's parameters are:
+
+=== Parameters
+[.api]
+[field]#showCaptcha# [type]#[Boolean]#::
+This determines whether or not to show the captcha badge. Typically supplied by the `tenant.captchaConfiguration.captchaMethod` template variable.
+
+[field]#captchaMethod# [type]#[String]#::
+This is the type of captcha to use. Typically supplied by the `showCaptcha` template variable. Valid values are:
++
+include::/docs/v1/tech/shared/_recaptcha-values.adoc[]
+
+[field]#siteKey# [type]#[String]#::
+The `data-sitekey` value to use for the captcha. Typically supplied by the `tenant.captchaConfiguration.siteKey` template variable. Required if not using `GoogleRecaptchaV3`.
+
+=== Invisible reCAPTCHA
+If you wish to enable an link:https://developers.google.com/recaptcha/docs/invisible[invisible reCAPTCHA] element you may do so by adding the `data-size` and `data-callback` attributes on the tag with the `g-recaptcha` class. In versions >= 1.46.0 these attributes will be present but commented out.
+
+[source,html]
+.Invisible tag
+----
+[#if captchaMethod == "GoogleRecaptchaV2"]
+      <div class="g-recaptcha" data-sitekey="${siteKey!''}"
+        data-size="invisible"
+        data-callback="reCaptchaV2InvisibleCallback"
+      ></div>
+ ...
+----
+
+[NOTE.since]
+====
+On versions of FusionAuth prior to 1.46 you will need to add the `reCaptchaV2InvisibleCallback` function in order to properly handle the callback on form submit from the captcha.
+====
+
+In the `captchaScripts` macro in the `_helpers.ftl` template find the following tag:
+
+[source,html]
+.Existing Captcha.js import
+----
+<script src="${request.contextPath}/js/oauth2/Captcha.js?version=${version}"></script>
+----
+
+and right below it add the following script tag (this is what is included in 1.46):
+
+[source,html]
+.Updated captcha tag handling
+----
+<script>
+  // This is only intended to be used with data-size="invisible"
+  function reCaptchaV2InvisibleCallback(token) {
+    const input = document.querySelector('input[name="captcha_token"]');
+    input.value = token;
+    input.closest('form').submit();
+  }
+</script>
+----

--- a/site/docs/v1/tech/themes/helpers.adoc
+++ b/site/docs/v1/tech/themes/helpers.adoc
@@ -173,7 +173,7 @@ The `_helpers.ftl` template provides a macro to embed link:/docs/v1/tech/core-co
 [field]#captchaMethod# [type]#[String]#::
 This is the type of CAPTCHA to use. Typically supplied by the `tenant.captchaConfiguration.captchaMethod` template variable. Valid values are:
 +
-include::/docs/v1/tech/shared/_recaptcha-values.adoc[]
+include::docs/v1/tech/shared/_recaptcha-values.adoc[]
 
 [field]#showCaptcha# [type]#[Boolean]#::
 This determines whether or not to show the CAPTCHA badge. Typically supplied by the `showCaptcha` template variable.

--- a/site/docs/v1/tech/themes/helpers.adoc
+++ b/site/docs/v1/tech/themes/helpers.adoc
@@ -161,28 +161,28 @@ The `_helpers.ftl` template provides a couple of macros that help render form el
 * `button`
 ** This macro renders a button that can be used to submit a form. The FusionAuth version of this macro includes an icon and the button text.
 
-== Captcha
+== CAPTCHA
 
-The `_helpers.ftl` template provides a macro to embed link:/docs/v1/tech/core-concepts/tenants#captcha-settings[captcha challenges] into your templates. This is
+The `_helpers.ftl` template provides a macro to embed link:/docs/v1/tech/core-concepts/tenants#captcha-settings[CAPTCHA challenges] into your templates.
 
 * `captchaBadge`
-** Macro that adds a captcha badge to the template. See link:/docs/v1/tech/themes/template-variables/[template variables] for more information on the template variables. The macro's parameters are:
+** Macro that adds a CAPTCHA badge to the template. See link:/docs/v1/tech/themes/template-variables/[template variables] for more information on the template variables. The macro's parameters are:
 
 === Parameters
 [.api]
-[field]#showCaptcha# [type]#[Boolean]#::
-This determines whether or not to show the captcha badge. Typically supplied by the `tenant.captchaConfiguration.captchaMethod` template variable.
-
 [field]#captchaMethod# [type]#[String]#::
-This is the type of captcha to use. Typically supplied by the `showCaptcha` template variable. Valid values are:
+This is the type of CAPTCHA to use. Typically supplied by the `tenant.captchaConfiguration.captchaMethod` template variable. Valid values are:
 +
 include::/docs/v1/tech/shared/_recaptcha-values.adoc[]
 
+[field]#showCaptcha# [type]#[Boolean]#::
+This determines whether or not to show the CAPTCHA badge. Typically supplied by the `showCaptcha` template variable.
+
 [field]#siteKey# [type]#[String]#::
-The `data-sitekey` value to use for the captcha. Typically supplied by the `tenant.captchaConfiguration.siteKey` template variable. Required if not using `GoogleRecaptchaV3`.
+The `data-sitekey` value to use for the CAPTCHA. Typically supplied by the `tenant.captchaConfiguration.siteKey` template variable. Required if using `GoogleRecaptchaV3`.
 
 === Invisible reCAPTCHA
-If you wish to enable an link:https://developers.google.com/recaptcha/docs/invisible[invisible reCAPTCHA] element you may do so by adding the `data-size` and `data-callback` attributes on the tag with the `g-recaptcha` class. In versions >= 1.46.0 these attributes will be present but commented out.
+If you wish to enable an https://developers.google.com/recaptcha/docs/invisible[invisible reCAPTCHA] element so that a CAPTCHA will still challenge a submit without a checkbox on the form you may do so by adding the `data-size` and `data-callback` attributes on the tag with the `g-recaptcha` class. In FusionAuth version 1.46.0 and later these attributes will be present in the default template but commented out.
 
 [source,html]
 .Invisible tag
@@ -195,30 +195,7 @@ If you wish to enable an link:https://developers.google.com/recaptcha/docs/invis
  ...
 ----
 
-[NOTE.since]
+[NOTE.note]
 ====
-On versions of FusionAuth prior to 1.46 you will need to add the `reCaptchaV2InvisibleCallback` function in order to properly handle the callback on form submit from the captcha.
+On versions of FusionAuth prior to 1.46.0 you will need to update the JavaScript in order to properly handle the form submit for invisible reCAPTCHA. See https://developers.google.com/recaptcha/docs/invisible[this GitHub issue] for more information.
 ====
-
-In the `captchaScripts` macro in the `_helpers.ftl` template find the following tag:
-
-[source,html]
-.Existing Captcha.js import
-----
-<script src="${request.contextPath}/js/oauth2/Captcha.js?version=${version}"></script>
-----
-
-and right below it add the following script tag (this is what is included in 1.46):
-
-[source,html]
-.Updated captcha tag handling
-----
-<script>
-  // This is only intended to be used with data-size="invisible"
-  function reCaptchaV2InvisibleCallback(token) {
-    const input = document.querySelector('input[name="captcha_token"]');
-    input.value = token;
-    input.closest('form').submit();
-  }
-</script>
-----

--- a/site/docs/v1/tech/themes/helpers.adoc
+++ b/site/docs/v1/tech/themes/helpers.adoc
@@ -197,5 +197,5 @@ If you wish to enable an https://developers.google.com/recaptcha/docs/invisible[
 
 [NOTE.note]
 ====
-On versions of FusionAuth prior to 1.46.0 you will need to update the JavaScript in order to properly handle the form submit for invisible reCAPTCHA. See https://developers.google.com/recaptcha/docs/invisible[this GitHub issue] for more information.
+On versions of FusionAuth prior to 1.46.0 you will need to update the JavaScript in order to properly handle the form submit for invisible reCAPTCHA. See https://github.com/FusionAuth/fusionauth-issues/issues/2237[this GitHub issue] for more information.
 ====


### PR DESCRIPTION
I tested a couple permutations but it looks like we can get away with just including the callback function for the reCAPTCHA on versions prior to 1.46 since the `grecaptcha.getResponse` call still works for invisible.

Not sure about the `[NOTE.since]` if it is clear that this is something to handle only before that version.