### PR TITLE
Use cache, specify node version.

### DIFF
--- a/.github/workflows/dev-astro.yml
+++ b/.github/workflows/dev-astro.yml
@@ -43,6 +43,7 @@ jobs:
           role-session-name: site_publisher_session
           aws-region: ${{ env.AWS_REGION }}
       - name: Install modules
+        uses: actions/setup-node@v3
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/dev-astro.yml
+++ b/.github/workflows/dev-astro.yml
@@ -43,6 +43,10 @@ jobs:
           role-session-name: site_publisher_session
           aws-region: ${{ env.AWS_REGION }}
       - name: Install modules
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'astro/package-lock.json'
         run: npm ci
       - name: Build application
         run: npm run build

--- a/.github/workflows/prod-astro.yml
+++ b/.github/workflows/prod-astro.yml
@@ -42,6 +42,10 @@ jobs:
           role-session-name: site_publisher_session
           aws-region: ${{ env.AWS_REGION }}
       - name: Install modules
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: 'astro/package-lock.json'
         run: npm ci
       - name: Build application
         run: npm run build

--- a/.github/workflows/prod-astro.yml
+++ b/.github/workflows/prod-astro.yml
@@ -42,6 +42,7 @@ jobs:
           role-session-name: site_publisher_session
           aws-region: ${{ env.AWS_REGION }}
       - name: Install modules
+        uses: actions/setup-node@v3
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/prod-astro.yml
+++ b/.github/workflows/prod-astro.yml
@@ -43,7 +43,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name: Install modules
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'astro/package-lock.json'
         run: npm ci


### PR DESCRIPTION
This allows us to cache the npm installation, making the deploy a bit quicker.

It also specifies use of the node LTS version