### PR TITLE
add device-user-code

### DIFF
--- a/site/docs/v1/tech/apis/_login-metadata-device.adoc
+++ b/site/docs/v1/tech/apis/_login-metadata-device.adoc
@@ -10,9 +10,13 @@ endif::[]
 A human readable name of the device used.  This meta data is used to describe the refresh token that may be generated for this request.
 
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional#::
-The type of device used. The following types may be specified:
+The type of device represented by the `device` parameter.
 +
-include::./_device-type-list.adoc[]
+Prior to version 1.46.0, this value was restricted to the following types:
++
+include::docs/v1/tech/apis/_device-type-list.adoc[]
++
+In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 +
 This meta data is used to describe the refresh token that may be generated for this request.
 

--- a/site/docs/v1/tech/apis/_reconcile-request-body.adoc
+++ b/site/docs/v1/tech/apis/_reconcile-request-body.adoc
@@ -32,9 +32,13 @@ The IP address of this login request.
 A human readable name of the device represented by the `device` parameter.
 
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional#::
-The type of device represented by the `device` parameter. The following types may be specified:
+The type of device represented by the `device` parameter.
 +
-include::./_device-type-list.adoc[]
+Prior to version 1.46.0, this value was restricted to the following types:
++
+include::docs/v1/tech/apis/_device-type-list.adoc[]
++
+In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 
 [source,json]
 .Example Request JSON

--- a/site/docs/v1/tech/apis/_refresh-token-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/_refresh-token-response-body-base.adoc
@@ -26,9 +26,13 @@ The link:/docs/v1/tech/reference/data-types#instants[instant] this Refresh Token
 The name of the device, for example `Richard's Hooli Phone`.
 
 [field]#{base_field_name}.metaData.device.type# [type]#[String]#::
-The type of device represented by the `device` parameter. The following are possible types:
+The type of device represented by the `device` parameter.
 +
-include::_device-type-list.adoc[]
+Prior to version 1.46.0, this value was restricted to the following types:
++
+include::docs/v1/tech/apis/_device-type-list.adoc[]
++
+In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 
 [field]#{base_field_name}.metaData.scopes# [type]#[Array<String>]#::
 The scopes associated with this Refresh Token. These are set at authentication when when the Refresh Token is first created.

--- a/site/docs/v1/tech/apis/_users-refresh-tokens-request-body.adoc
+++ b/site/docs/v1/tech/apis/_users-refresh-tokens-request-body.adoc
@@ -20,9 +20,13 @@ The link:/docs/v1/tech/reference/data-types#instants[instant] of this login requ
 A human readable name of the device represented by the `device` parameter.
 
 [field]#refreshTokens``[x]``.metaData.device.type# [type]#[String]# [optional]#Optional#::
-The type of device represented by the `device` parameter. The following types may be specified:
+The type of device represented by the `device` parameter.
 +
-include::./_device-type-list.adoc[]
+Prior to version 1.46.0, this value was restricted to the following types:
++
+include::docs/v1/tech/apis/_device-type-list.adoc[]
++
+In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 
 [field]#refreshTokens``[x]``.startInstant# [type]#[String]# [required]#Required#::
 The link:/docs/v1/tech/reference/data-types#instants[instant] of the start of this token. This value will be used to calculate the token expiration.
@@ -40,7 +44,7 @@ Set this value to `true` in order to perform additional validation of the reques
 +
 If this is `false`, any errors such as duplicated refresh token values will return a `500` error without any additional messages.  If this is `true`, additional validation will be performed on the input request and a `400` response will be returned with a JSON body indicating duplicate values or other error conditions encountered.
 +
-Setting this value to `true` will dramatically decrease the performance of this request. If importing large numbers of tokens in a single request you may need to increase request timeouts to ensure this request does not timeout before it has completed. 
+Setting this value to `true` will dramatically decrease the performance of this request. If importing large numbers of tokens in a single request you may need to increase request timeouts to ensure this request does not timeout before it has completed.
 
 [source,json]
 .Example Request JSON

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
@@ -1,7 +1,7 @@
 ==== Request Body
 
 // default to empty string
-:data_code_since: 
+:data_code_since:
 ifeval::["{idp_display_name}" == "Google"]
 :data_code_since: pass:normal[[since]#Available since 1.28.0#]
 endif::[]
@@ -143,17 +143,13 @@ The IP address of this login request.
 A human readable name of the device represented by the `device` parameter.
 
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional#::
-The type of device represented by the `device` parameter. The following types may be specified:
+The type of device represented by the `device` parameter.
 +
-* `BROWSER`
-* `DESKTOP`
-* `LAPTOP`
-* `MOBILE`
-* `OTHER`
-* `SERVER`
-* `TABLET`
-* `TV`
-* `UNKNOWN`
+Prior to version 1.46.0, this value was restricted to the following types:
++
+include::docs/v1/tech/apis/_device-type-list.adoc[]
++
+In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 
 [field]#noJWT# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 When this value is set to true a JWT will not be issued as part of this request. The response body will not contain the `token` field, and the `access_token` and `refresh_token` cookies will not be written to the HTTP response.

--- a/site/docs/v1/tech/apis/identity-providers/_link-response-body-base.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_link-response-body-base.adoc
@@ -12,6 +12,12 @@ Please note, that this value will always be overwritten during login to reflect 
 [field]#{base_field_name}.identityProviderId# [type]#[UUID]#::
 The unique Id of the identity provider.
 
+[field]#{base_field_name}.identityProviderName# [type]#[String]# [since]#Available since 1.46.0#::
+The name of the identity provider.
+
+[field]#{base_field_name}.identityProviderType# [type]#[String]#
+The type of the identity provider.
+
 [field]#{base_field_name}.identityProviderUserId# [type]#[String]#::
 The unique user Id in the 3rd party identity provider. Ideally this value never changes and will always uniquely identify the user in the 3rd party identity provider.
 

--- a/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_links-post-response-body.adoc
@@ -9,6 +9,12 @@ Please note, that this value will always be overwritten during login to reflect 
 [field]#identityProviderLink.identityProviderId# [type]#[UUID]#::
 The unique Id of the identity provider.
 
+[field]#identityProviderLink.identityProviderName# [type]#[String]# [since]#Available since 1.47.0#::
+The name of the identity provider.
+
+[field]#identityProviderLink.identityProviderType# [type]#[String]#::
+The type of the identity provider.
+
 [field]#identityProviderLink.identityProviderUserId# [type]#[String]#::
 The Id for the User that is provided by the identity provider.
 
@@ -26,6 +32,9 @@ The Id of the Tenant that this User belongs to.
 
 [field]#identityProviderLink.token# [type]#[String]# ::
 The token returned from the identity provider. This is treated as an opaque token as the type varies by identity provider, this value may not be returned by all identity providers. When provided, this token is typically a long lived access or refresh token, but consult individual identity provider documentation for specifics.
+
+[field]#identityProviderLink.userId# [type]#[UUID]#::
+The unique Id of the FusionAuth User that is linked to the identity provider.
 
 [source,json]
 .Example Response JSON

--- a/site/docs/v1/tech/apis/passwordless.adoc
+++ b/site/docs/v1/tech/apis/passwordless.adoc
@@ -230,11 +230,13 @@ A human readable description of the device used during login. This meta data is 
 A human readable name of the device used during login.  This meta data is used to describe the refresh token that may be generated for this login request.
 
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional#::
-The type of device used during login. The following types may be specified:
+The type of device represented by the `device` parameter. This meta data is used to describe the refresh token that may be generated for this login request.
++
+Prior to version 1.46.0, this value was restricted to the following types:
 +
 include::docs/v1/tech/apis/_device-type-list.adoc[]
 +
-This meta data is used to describe the refresh token that may be generated for this login request.
+In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 
 [field]#noJWT# [type]#[Boolean]# [optional]#Optional# [default]#defaults to `false`#::
 When this value is set to true a JWT will not be issued as part of this request. The response body will not contain the `token` or `refreshToken` fields, and the `access_token` and `refresh_token` cookies will not be written to the HTTP response.

--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -640,18 +640,13 @@ iOS Safari
 +
 
 [field]#metaData.device.type# [type]#[String]# [optional]#Optional# [since]#Available since 1.20.1#::
-The type of device used during login.
-This metadata is used to describe the type of device represented by the refresh token that may be generated for this login request.
+The type of device represented by the `device` parameter. This metadata is used to describe the type of device represented by the refresh token that may be generated for this login request.
 +
-* `BROWSER`
-* `DESKTOP`
-* `LAPTOP`
-* `MOBILE`
-* `OTHER`
-* `SERVER`
-* `TABLET`
-* `TV`
-* `UNKNOWN`
+Prior to version 1.46.0, this value was restricted to the following types:
++
+include::docs/v1/tech/apis/_device-type-list.adoc[]
++
+In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 
 [field]#username# [type]#[String]# [required]#Required#::
 The login identifier of the user.

--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -20,6 +20,7 @@ In support of https://tools.ietf.org/html/rfc6749[OAuth 2.0 IETF RFC 6749], http
 ** <<Refresh Token Grant Request>>
 ** <<Client Credentials Grant Request>>
 * <<Device>>
+* <<Device User Code>>
 * <<Device Validate>>
 * <<Introspect>>
 
@@ -1135,9 +1136,6 @@ client_id=3c219e58-ed0e-4b18-ad48-f4f92793ae32&scope=offline_access
 
 |500
 |There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
-
-|503
-|The search index is not available or encountered an exception so the request cannot be completed. The response will contain a JSON body.
 |===
 
 ==== Response Body
@@ -1175,6 +1173,161 @@ This can be used to build a QR code or provide a clickable link that may pre-pop
   "user_code": "FBGLLF",
   "verification_uri": "https://piedpiper.com/device",
   "verification_uri_complete": "https://piedpiper.com/device?user_code=FBGLLF"
+}
+----
+
+== Device User Code
+
+[NOTE.since]
+====
+This endpoint has been available since 1.46.0
+====
+
+This endpoint is intended to validate the end-user provided [field]#user_code# and return meta-data useful when building your own interactive workflow.
+
+This endpoint is equivalent to the <<Device Validate>> endpoint, but it will return meta-data for the [field]#user_code# in a JSON body.
+
+[.api-authentication]
+Validate and retrieve a user_code using client credentials
+[.endpoint]
+.URI
+--
+[method]#POST# [uri]#/oauth2/device/user-code#
+--
+
+==== Request Headers
+
+[.api]
+include::docs/v1/tech/oauth/_authorization-header.adoc[]
+
+[field]#Content-Type# [type]#[String]# [required]#Required#::
+This value must be set to `application/x-www-form-urlencoded`.
+
+==== Request Parameters
+
+Ensure you are sending these parameters as form encoded data in the request body, do not send these parameters in a query string.
+
+[.api]
+[field]#client_id# [type]#[String]# [optional]#Optional#::
+The unique client identifier.
+The client Id is the Id of the FusionAuth Application in which you are attempting to authenticate.
++
+This parameter is optional when the `Authorization` header is provided.
+When the `Authorization` header is not provided, this parameter is then required.
+Prior to version `1.46.0` this parameter was always required.
+
+[field]#client_secret# [type]#[String]# [optional]#Optional#::
+The client secret.
+This parameter is optional when the `Authorization` header is provided.
+Please see the link:#client-secret-table[the Client Secret table] for more details.
+
+[field]#user_code# [type]#[String]# [required]#Required#::
+The end-user verification code.
+This is the code that a user entered during the Device Authorization grant which you are requesting to be validated.
+
+[.api-authentication]
+link:/docs/v1/tech/apis/authentication#api-key-authentication[icon:lock[type=fas]] Validate and retrieve a user_code using an API key
+[.endpoint]
+.URI
+--
+[method]#POST# [uri]#/oauth2/device/user-code#
+--
+
+==== Request Headers
+
+[.api]
+[field]#Content-Type# [type]#[String]# [required]#Required#::
+This value must be set to `application/x-www-form-urlencoded`.
+
+==== Request Parameters
+
+Ensure you are sending these parameters as form encoded data in the request body, do not send these parameters in a query string.
+
+[.api]
+[field]#user_code# [type]#[String]# [required]#Required#::
+The end-user verification code.
+This is the code that a user entered during the Device Authorization grant which you are requesting to be validated.
+
+=== Response
+
+[cols="1a,9a"]
+.Response Codes
+|===
+|Code |Description
+
+|200
+|The request was successful. The response will contain a JSON body.
+
+|400
+|The request was invalid and/or malformed. The response will contain a JSON message with the specific errors. The error response JSON is covered in the link:#oautherror[OAuth Error section] of the API documentation.
+
+|500
+|There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
+|===
+
+==== Response Body
+
+[.api]
+[field]#client_id# [type]#[String]#::
+The unique client identifier provided on the Device Authorize request.
+
+[field]#deviceInfo.description# [type]#[String]#::
+The optional device description provided on the Device Authorize request.
+
+[field]#deviceInfo.name# [type]#[String]#::
+The optional device name provided on the Device Authorize request.
+
+[field]#deviceInfo.type# [type]#[String]#::
+The optional device type provided on the Device Authorize request.
+
+[field]#expires_in# [type]#[Integer]#::
+The number of seconds the [field]#device_code# and [field]#user_code# tokens will remain active.
++
+This is how long you have to complete the Device grant.
+
+[field]#pendingIdPLink.displayName# [type]#[String]#::
+The human readable name of the user represented by the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
+
+[field]#pendingIdPLink.identityProviderId# [type]#[String]#::
+The unique Identity Provider Id associated with the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
+
+[field]#pendingIdPLink.identityProviderName# [type]#[String]#::
+The name of the Identity Provider associated with the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
+
+[field]#pendingIdPLink.identityProviderType# [type]#[String]#::
+The type of the Identity Provider associated with the the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
+
+[field]#pendingIdPLink.identityProviderUserId# [type]#[String]#::
+The unique user Id of the user represented by the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
++
+This is the value that FusionAuth will use to uniquely link a FusionAuth User to a user in the 3rd party identity provider.
+
+[field]#tenantId# [type]#[UUID]#::
+The unique Id of the Tenant.
+
+[field]#user_code# [type]#[String]#::
+The end-user verification code. This is the same value that was provided in the request body.
+
+[source,json]
+.Example JSON Response
+----
+{
+  "client_id": "3c219e58-ed0e-4b18-ad48-f4f92793ae32",
+  "deviceInfo": {
+    "description": "Johny's Xbox"
+    "name": "Xbox",
+    "type": "Console"
+  },
+  "expires_in": 600,
+  "pendingIdPLink": {
+    "displayName": "jmoney42",
+    "identityProviderId": "af53ab21-34c3-468a-8ba2-ecb3905f67f2",
+    "identityProviderName": "Xbox",
+    "identityProviderType": "Xbox",
+    "identityProviderUserId": "af53ab21-34c3-468a-8ba2-ecb3905f67f2"
+  },
+  "tenantId": "5f35237d-d036-4aaa-a917-17039d4697e6",
+  "user_code": "FBGLLF",
 }
 ----
 
@@ -1221,9 +1374,6 @@ This is the code that a user entered during the Device Authorization grant which
 
 |500
 |There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
-
-|503
-|The search index is not available or encountered an exception so the request cannot be completed. The response will contain a JSON body.
 |===
 
 == Introspect

--- a/site/docs/v1/tech/oauth/endpoints.adoc
+++ b/site/docs/v1/tech/oauth/endpoints.adoc
@@ -20,8 +20,10 @@ In support of https://tools.ietf.org/html/rfc6749[OAuth 2.0 IETF RFC 6749], http
 ** <<Refresh Token Grant Request>>
 ** <<Client Credentials Grant Request>>
 * <<Device>>
-* <<Device User Code>>
-* <<Device Validate>>
+** <<Device Authorize>>
+** <<Device User Code>>
+** <<Device Validate>>
+** <<Device Approve>>
 * <<Introspect>>
 
 In support of http://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect], the following endpoints are provided:
@@ -756,6 +758,9 @@ The following response applies to the <<Complete the Authorization Code Grant Re
 |400
 |The request was invalid and/or malformed. The response will contain a JSON message with the specific errors. The error response JSON is covered in the link:#oautherror[OAuth Error section] of the API documentation.
 
+|401
+|The client could not be verified. Verify your `client_id` and `client_secret` are valid and authorized for this request.
+
 |500
 |There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
 
@@ -894,6 +899,9 @@ client_id=3c219e58-ed0e-4b18-ad48-f4f92793ae32&grant_type=refresh_token&refresh_
 
 |400
 |The request was invalid and/or malformed. The response will contain a JSON message with the specific errors. The error response JSON is covered in the link:#oautherror[OAuth Error section] of the API documentation.
+
+|401
+|The client could not be verified. Verify your `client_id` and `client_secret` are valid and authorized for this request.
 
 |500
 |There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
@@ -1040,6 +1048,9 @@ grant_type=client_credentials
 |400
 |The request was invalid and/or malformed. The response will contain a JSON message with the specific errors. The error response JSON is covered in the link:#oautherror[OAuth Error section] of the API documentation.
 
+|401
+|The client could not be verified. Verify your `client_id` and `client_secret` are valid and authorized for this request.
+
 |500
 |There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
 
@@ -1078,6 +1089,9 @@ This endpoint been available since 1.11.0
 ====
 
 This is an implementation of the Device Authorization endpoint as defined by the https://tools.ietf.org/html/rfc8628#section-3.1[IETF RFC 8628 Section 3.1].
+
+=== Device Authorize
+
 To begin the Device Authorization Grant you will make a request to the Device Authorization endpoint from the device.
 
 [.endpoint]
@@ -1176,7 +1190,7 @@ This can be used to build a QR code or provide a clickable link that may pre-pop
 }
 ----
 
-== Device User Code
+=== Device User Code
 
 [NOTE.since]
 ====
@@ -1261,6 +1275,9 @@ This is the code that a user entered during the Device Authorization grant which
 |400
 |The request was invalid and/or malformed. The response will contain a JSON message with the specific errors. The error response JSON is covered in the link:#oautherror[OAuth Error section] of the API documentation.
 
+|401
+|The provided client credentials are invalid, or the API key if provided is not valid.
+
 |500
 |There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
 |===
@@ -1331,7 +1348,7 @@ The end-user verification code. This is the same value that was provided in the 
 }
 ----
 
-== Device Validate
+=== Device Validate
 
 [NOTE.since]
 ====
@@ -1339,6 +1356,7 @@ This endpoint has been available since 1.11.0
 ====
 
 This endpoint validates the end-user provided [field]#user_code# from the user-interaction of the Device Authorization Grant.
+
 If you build your own activation form you should validate the user provided code prior to beginning the Authorization grant.
 If you choose to redirect to the FusionAuth provided form `/oauth2/device` then it is not necessary for you to validate the [field]#user_code#.
 
@@ -1375,6 +1393,142 @@ This is the code that a user entered during the Device Authorization grant which
 |500
 |There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
 |===
+
+
+=== Device Approve
+
+[NOTE.since]
+====
+This endpoint has been available since 1.46.0
+====
+
+Approve a [field]#user_code# returned from the <<Device Authorize>>. If you are using the FusionAuth themed page for `/oauth2/device` you do not need to use this because the grant will be automatically approved once the user has completed authentication and the OAuth2 Grant has completed.
+
+If you are building your own integration to collect the `user_code` from the end user, and wish to approve the Device Grant after authenticating the user, use this API to approve the device code allowing the Device Grant to complete.
+
+[.endpoint]
+.URI
+--
+[method]#POST# [uri]#/oauth2/device/approve#
+--
+
+==== Request Headers
+
+[.api]
+include::docs/v1/tech/oauth/_authorization-header.adoc[]
+
+[field]#Content-Type# [type]#[String]# [required]#Required#::
+This value must be set to `application/x-www-form-urlencoded`.
+
+==== Request Parameters
+
+Ensure you are sending these parameters as form encoded data in the request body, do not send these parameters in a query string.
+
+[.api]
+[field]#client_id# [type]#[String]# [optional]#Optional#::
+The unique client identifier.
+The client Id is the Id of the FusionAuth Application in which you are attempting to authenticate.
++
+This parameter is optional when the `Authorization` header is provided.
+When the `Authorization` header is not provided, this parameter is then required.
+Prior to version `1.3.1` this parameter was always required.
+
+[field]#client_secret# [type]#[String]# [optional]#Optional#::
+The client secret.
+This parameter is optional when the `Authorization` header is provided.
+Please see the link:#client-secret-table[the Client Secret table] for more details.
+
+[field]#token# [type]#[String]# [required]#Required#::
+The access token returned by this OAuth provider as the result of a successful authentication. This token must contain a `sub` claim which will be used to identify the FusionAuth User.
+
+[field]#user_code# [type]#[String]# [required]#Required#::
+The end-user verification code.
+
+=== Response
+
+[cols="1a,9a"]
+.Response Codes
+|===
+|Code |Description
+
+|200
+|The request was successful. The response will contain a JSON body.
+
+|400
+|The request was invalid and/or malformed. The response will contain a JSON message with the specific errors. The error response JSON is covered in the link:#oautherror[OAuth Error section] of the API documentation.
+
+|401
+|The client could not be verified. Verify your `client_id` and `client_secret` are valid and authorized for this request.
+
+|500
+|There was a FusionAuth internal error. A stack trace is provided and logged in the FusionAuth log files.
+|===
+
+==== Response Body
+
+[.api]
+[field]#deviceGrantStatus# [type]#[String]#::
+The device grant status. This will always be `Approved`.
+
+[field]#deviceInfo.description# [type]#[String]#::
+The optional device description provided on the Device Authorize request.
+
+[field]#deviceInfo.name# [type]#[String]#::
+The optional device name provided on the Device Authorize request.
+
+[field]#deviceInfo.type# [type]#[String]#::
+The optional device type provided on the Device Authorize request.
+
+[field]#identityProviderLink.displayName# [type]#[String]#::
+The human readable name of the user represented by the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
+
+[field]#identityProviderLink.identityProviderId# [type]#[String]#::
+The unique Identity Provider Id associated with the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
+
+[field]#identityProviderLink.identityProviderName# [type]#[String]# [since]#Available since 1.47.0#::
+The name of the Identity Provider associated with the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
+
+[field]#identityProviderLink.identityProviderType# [type]#[String]#::
+The type of the Identity Provider associated with the the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
+
+[field]#identityProviderLink.identityProviderUserId# [type]#[String]#::
+The unique user Id of the user represented by the linking token provided in the `idp-link:` scope value optionally provided on the Device Authorize request.
++
+This is the value that FusionAuth will use to uniquely link a FusionAuth User to a user in the 3rd party identity provider.
+
+[field]#identityProviderLink.insertInstant# [type]#[Long]#::
+The link:/docs/v1/tech/reference/data-types#instants[instant] when the identity provider link was created.
+
+[field]#identityProviderLink.lastLoginInstant# [type]#[Long]#::
+The link:/docs/v1/tech/reference/data-types#instants[instant] when the User logged in last using this identity provider.
+
+[field]#tenantId# [type]#[UUID]#::
+The unique Id of the Tenant.
+
+[field]#userId# [type]#[UUID]#::
+The unique Id of the User.
+
+[source,json]
+.Example JSON Response
+----
+{
+  "deviceGrantStatus": "Approved",
+  "deviceInfo": {
+    "description": "Johny's Xbox"
+    "name": "Xbox",
+    "type": "Console"
+  },
+  "identityProviderLink": {
+    "displayName": "jmoney42",
+    "identityProviderId": "af53ab21-34c3-468a-8ba2-ecb3905f67f2",
+    "identityProviderName": "Xbox",
+    "identityProviderType": "Xbox",
+    "identityProviderUserId": "af53ab21-34c3-468a-8ba2-ecb3905f67f2"
+  },
+  "tenantId": "5f35237d-d036-4aaa-a917-17039d4697e6",
+  "userId": "3b6d2f70-4821-4694-ac89-60333c9c4165",
+}
+----
 
 == Introspect
 


### PR DESCRIPTION
1. New endpoint, `/oauth2/device/user-code`
2. New endpoint `/oauth2/device/approve`
3. Device type is no longer an enum
4. Other cleanup
5. Add `identityProviderType` and identityProviderName` to some APIs

### Issue

- https://github.com/FusionAuth/fusionauth-issues/issues/2218