### PR TITLE
check for missing directive string

### DIFF
--- a/.github/workflows/asciidocheck.yml
+++ b/.github/workflows/asciidocheck.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           ! find _site/docs -type f|xargs grep -l 'BROKEN LINK'
         shell: bash
+      - name: Check for broken includes or other directive issues
+        run: |
+          ! find _site/docs -type f|xargs grep -l 'Unresolved directive'
+        shell: bash
       - name: Check for broken external asciidoctor links in source
         run: |
           ! find site/docs -type f -name "*.adoc"|xargs egrep '^/docs/v1/|[^:]/docs/v1/'|grep -v RSS|grep -v '{% include'


### PR DESCRIPTION
This often happens when an include is incorrect.