### PR TITLE
fix device type unresolved directive

### DIFF
--- a/site/docs/v1/tech/apis/_login-metadata-device.adoc
+++ b/site/docs/v1/tech/apis/_login-metadata-device.adoc
@@ -14,7 +14,7 @@ The type of device represented by the `device` parameter.
 +
 Prior to version 1.46.0, this value was restricted to the following types:
 +
-include::docs/v1/tech/apis/_device-type-list.adoc[]
+include::_device-type-list.adoc[]
 +
 In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 +

--- a/site/docs/v1/tech/apis/_users-refresh-tokens-request-body.adoc
+++ b/site/docs/v1/tech/apis/_users-refresh-tokens-request-body.adoc
@@ -24,7 +24,7 @@ The type of device represented by the `device` parameter.
 +
 Prior to version 1.46.0, this value was restricted to the following types:
 +
-include::docs/v1/tech/apis/_device-type-list.adoc[]
+include::_device-type-list.adoc[]
 +
 In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
@@ -147,7 +147,7 @@ The type of device represented by the `device` parameter.
 +
 Prior to version 1.46.0, this value was restricted to the following types:
 +
-include::docs/v1/tech/apis/_device-type-list.adoc[]
+include::_device-type-list.adoc[]
 +
 In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
@@ -147,7 +147,7 @@ The type of device represented by the `device` parameter.
 +
 Prior to version 1.46.0, this value was restricted to the following types:
 +
-include::_device-type-list.adoc[]
+include::../_device-type-list.adoc[]
 +
 In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 

--- a/site/docs/v1/tech/apis/passwordless.adoc
+++ b/site/docs/v1/tech/apis/passwordless.adoc
@@ -234,7 +234,7 @@ The type of device represented by the `device` parameter. This meta data is used
 +
 Prior to version 1.46.0, this value was restricted to the following types:
 +
-include::docs/v1/tech/apis/_device-type-list.adoc[]
+include::_device-type-list.adoc[]
 +
 In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 

--- a/site/docs/v1/tech/apis/passwordless.adoc
+++ b/site/docs/v1/tech/apis/passwordless.adoc
@@ -234,7 +234,7 @@ The type of device represented by the `device` parameter. This meta data is used
 +
 Prior to version 1.46.0, this value was restricted to the following types:
 +
-include::_device-type-list.adoc[]
+include::docs/v1/tech/apis/_device-type-list.adoc[]
 +
 In version `1.46.0` and beyond, this value can be any string value you'd like, have fun with it!
 


### PR DESCRIPTION
The include file was pulling in the full reference. `docs/v1/tech/apis/_device-type-list.adoc`. That is the proper way to do it when you are on a top level page. Unfortunately, these pages are all included themselves. The proper way to include a file when you are in an included file is a relative line. If you are in the same directory, you can just use `_device-type-list.adoc` but if you are in a different one, you'd use something like `../apis/_device-type-list.adoc`.