### PR TITLE
Updated datatype from string to number for latitude and longitude

### DIFF
--- a/site/docs/v1/tech/events-webhooks/events/_event-info.adoc
+++ b/site/docs/v1/tech/events-webhooks/events/_event-info.adoc
@@ -29,7 +29,7 @@ include::../../shared/_premium-edition-blurb-api.adoc[]
 +
 :premium_feature!:
 
-[field]#event.info.location.latitude# [type]#[String]# {event_info_since_threat_detection}::
+[field]#event.info.location.latitude# [type]#[Double]# {event_info_since_threat_detection}::
 The latitude where the event originated.
 +
 :premium_feature: event info location
@@ -37,7 +37,7 @@ include::../../shared/_premium-edition-blurb-api.adoc[]
 +
 :premium_feature!:
 
-[field]#event.info.location.longitude# [type]#[String]# {event_info_since_threat_detection}::
+[field]#event.info.location.longitude# [type]#[Double]# {event_info_since_threat_detection}::
 The longitude where the event originated.
 +
 :premium_feature: event info location


### PR DESCRIPTION
Fix for https://github.com/FusionAuth/fusionauth-site/issues/2111.

Updating data type from String to Double.