### PR TITLE
Fix some typos in the Golang Quickstart

### DIFF
--- a/astro/src/content/quickstarts/quickstart-golang-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-golang-web.mdx
@@ -133,7 +133,7 @@ access it with a browser, since you haven't created any pages yet.
 The next step is to get a basic home page up and running. We'll take this opportunity to copy in all 
 of the static assets that you'll need for the application, including web page templates, images, and CSS.
 
-Run the following copy commads to copy these files from the quickstart repo into your project. This assumes
+Run the following copy commands to copy these files from the quickstart repo into your project. This assumes
 that you checked the quickstart repo out into the parent directory. If that's not the case, replace the
 `..` below with your actual repo location.
 
@@ -143,7 +143,7 @@ cp -r ../fusionauth-quickstart-go-web/complete-application/static .
 ```
 
 <Aside type="tip">
-With the home page template in place, you can view the home page in your brower at http://localhost:8080!
+With the home page template in place, you can view the home page in your browser at http://localhost:8080!
 </Aside>
 
 ## Authentication
@@ -260,7 +260,7 @@ Click the `Logout` button and watch the browser first go to FusionAuth to log ou
 
 ## Next Steps
 This quickstart is a great way to get a proof of concept up and running quickly, but to run
-you application in production, there are some things you're going to want to do.
+your application in production, there are some things you're going to want to do.
 
 ### FusionAuth Customization
 FusionAuth gives you the ability to customize just about everything with the user's experience and your application's integration. This includes


### PR DESCRIPTION
Just some typos I stumbled upon while writing the Angular Quickstart.