### PR TITLE
fixed breaking external links

### DIFF
--- a/astro/src/components/nav/BlogNav.astro
+++ b/astro/src/components/nav/BlogNav.astro
@@ -7,7 +7,7 @@ const headerItems = [
   {name: 'Comparison', href: '/blog/category/compare/'},
   {name: 'Community', href: '/blog/category/community/', foldsIntoMenu: true},
   {name: 'Education', href: '/blog/category/education/', foldsIntoMenu: true},
-  {name: 'News', href: '/blog/category/announcement/', foldsIntoMenu: true},
+  {name: 'News', href: '/blog/category/news/', foldsIntoMenu: true},
   {name: 'Tech Docs', href: '/docs/', hideOnMobile: true},
 ];
 

--- a/src/cloudfront/fusionauth-website-request-handler.js
+++ b/src/cloudfront/fusionauth-website-request-handler.js
@@ -142,7 +142,7 @@ var redirectsByPrefix = [
 // order matters
 var redirectsByRegex = [
   ['^/blog/(category|tag|author)/([^/]*)$', '$&/'],
-  ['/blog/archive/', '/blog/'],
+  ['/blog/archive/tag/', '/blog/tag/'],
   ['/blog/\\d\\d\\d\\d/\\d\\d/\\d\\d/', '/blog/']
 ]
 

--- a/src/cloudfront/fusionauth-website-request-handler.js
+++ b/src/cloudfront/fusionauth-website-request-handler.js
@@ -142,6 +142,7 @@ var redirectsByPrefix = [
 // order matters
 var redirectsByRegex = [
   ['^/blog/(category|tag|author)/([^/]*)$', '$&/'],
+  ['/blog/archive/', '/blog/'],
   ['/blog/\\d\\d\\d\\d/\\d\\d/\\d\\d/', '/blog/']
 ]
 

--- a/src/cloudfront/fusionauth-website-request-handler.js
+++ b/src/cloudfront/fusionauth-website-request-handler.js
@@ -2,6 +2,8 @@ var d="/docs/v1/tech";
 var a="/articles";
 var ex="/learn/expert-advice";
 var idp="/identity-providers";
+var bc="/blog/category";
+var bac="/blog/archive/category";
 
 var ip = {};
 ip['/']=true;
@@ -67,6 +69,12 @@ ip['/quickstarts/']=true;
 ip['/blog/latest/']=true;
 
 var rd = {};
+rd[bac+'/announcement']=bc+'/news';
+rd[bac+'/article']=bc+'/education';
+rd[bac+'/comparison']=bc+'/compare';
+rd[bac+'/community-story']=bc+'/community';
+rd[bac+'/features']=bc+'/product';
+rd[bac+'/tutorial']=bc+'/tutorial';
 rd['/cognito']=d+'/migration-guide/cognito';
 rd['/cognito/']=d+'/migration-guide/cognito';
 rd[a+'/oauth/what-is-oauth']=a+'/oauth/modern-guide-to-oauth';


### PR DESCRIPTION
So google has links like

https://fusionauth.io/blog/archive/tag/magic-links/
and 
https://fusionauth.io/blog/archive/category/community-story/

This PR fixes the former (just remove the `archive` segment) and maps the old categories into our new categories.

For grins, it also fixes an existing 404 on our nav.