### PR TITLE
Adding React Native quickstart

### DIFF
--- a/astro/src/components/IconButton.astro
+++ b/astro/src/components/IconButton.astro
@@ -23,6 +23,9 @@ switch (color) {
   :global(.fa-duotone::before) {
     --fa-primary-color: #cbd5e1;
   }
+  :global(li > .btn-icon) {
+    margin: 0 !important;
+  }
   .btn-icon {
     --color: #fff;
     padding: 5px 7px 7px;

--- a/astro/src/components/IconButton.astro
+++ b/astro/src/components/IconButton.astro
@@ -29,28 +29,28 @@ switch (color) {
     border-radius: 3px;
     background-color: var(--color);
     border: 1px solid var(--color);
-  }
-  .btn-icon:after {
-    color: #fff;
-    opacity: 1;
-  }
-  .btn-icon.btn-icon-blue {
-    --color: #3998db;
-  }
-  .btn-icon.btn-icon-green {
-    --color: #0bb796;
-  }
-  .btn-icon.btn-icon-red {
-    --color: #ee3e54;
-  }
-  .btn-icon.btn-icon-purple {
-    --color: #34485e;
-  }
-  .btn-icon.btn-icon-gray {
-    border-color: #bfbfbf;
-    --color: #f7f7f7;
-  }
-  .btn-icon.btn-icon-gray:after {
-    color: #262626;
+    &:after {
+      color: #fff;
+      opacity: 1;
+    }
+    &.btn-icon-blue {
+      --color: #3998db;
+    }
+    &.btn-icon-green {
+      --color: #0bb796;
+    }
+    &.btn-icon-red {
+      --color: #ee3e54;
+    }
+    &.btn-icon-purple {
+      --color: #34485e;
+    }
+    &.btn-icon-gray {
+      border-color: #bfbfbf;
+      --color: #f7f7f7;
+      &:after {
+        color: #262626;
+      }
+    }
   }
 </style>

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -16,6 +16,8 @@ import IconButton from '../../components/IconButton.astro';
 import LoginAfter from '../../diagrams/quickstarts/login-after.astro';
 import LoginBefore from '../../diagrams/quickstarts/login-before.astro';
 import RemoteCode from '../../components/RemoteCode.astro';
+import RemoteValue from '../../components/RemoteValue/RemoteValue.astro';
+export const GITHUB_URL = 'https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/';
 
 In this quickstart you are going to build an application with React Native and integrate it with FusionAuth.
 You'll be building it for [ChangeBank](https://www.youtube.com/watch?v=CXDxNCzUspM), a global leader in converting dollars into coins.
@@ -76,10 +78,10 @@ Here you are using a bootstrapping feature of FusionAuth, called [Kickstart](/do
 
 FusionAuth will be initially configured with these settings:
 
-* Your client Id is `e9fdb985-9173-4e01-9d73-ac2d60d1dc8e`.
-* Your client secret is `super-secret-secret-that-should-be-regenerated-for-production`.
-* Your example username is `richard@example.com` and the password is `password`.
-* Your admin username is `admin@example.com` and the password is `password`.
+* Your client Id is <code><RemoteValue url={`${GITHUB_URL}kickstart/kickstart.json`} selector="$.variables.applicationId" /></code>
+* Your client secret is <code><RemoteValue url={`${GITHUB_URL}kickstart/kickstart.json`} selector="$.variables.clientSecret" /></code>.
+* Your example username is <code><RemoteValue url={`${GITHUB_URL}kickstart/kickstart.json`} selector="$.variables.userEmail" /></code> and the password is <code><RemoteValue url={`${GITHUB_URL}kickstart/kickstart.json`} selector="$.variables.userPassword" /></code>.
+* Your admin username is <code><RemoteValue url={`${GITHUB_URL}kickstart/kickstart.json`} selector="$.variables.adminEmail" /></code> and the password is <code><RemoteValue url={`${GITHUB_URL}kickstart/kickstart.json`} selector="$.variables.adminPassword" /></code>.
 * The base URL of FusionAuth `http://localhost:9011/`.
 
 You can log into the [FusionAuth admin UI](http://localhost:9011/admin) and look around if you want, but with Docker/Kickstart you don't need to.
@@ -195,7 +197,7 @@ Wait a few seconds and Expo will build and install the app in your device. You s
   If it is your first time running the app, ngrok will ask if you really want to continue to that page, so click `Visit Site`.
 </Aside>
 
-You'll finally arrive at the FusionAuth login screen. Fill in `richard@example.com` and `password` and click on `Submit` to be redirected back to the logged-in ChangeBank page.
+You'll finally arrive at the FusionAuth login screen. Fill in <code><RemoteValue url={`${GITHUB_URL}kickstart/kickstart.json`} selector="$.variables.userEmail" /></code> and <code><RemoteValue url={`${GITHUB_URL}kickstart/kickstart.json`} selector="$.variables.userPassword" /></code> and click on `Submit` to be redirected back to the logged-in ChangeBank page.
 
 ## Next Steps
 This quickstart is a great way to get a proof of concept up and running quickly, but to run your application in production, there are some things you're going to want to do.

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -1,0 +1,184 @@
+---
+title: React Native
+description: Quickstart integration of React Native application with FusionAuth
+navcategory: getting-started
+prerequisites: Node, npx, Android Studio and/or Xcode
+section: native
+technology: React Native
+language: JavaScript
+icon: /img/icons/react.svg
+faIcon: fa-r
+color: indigo
+cta: EmailListCTA
+---
+import Aside from '../../components/Aside.astro';
+import LoginAfter from '../../diagrams/quickstarts/login-after.astro';
+import LoginBefore from '../../diagrams/quickstarts/login-before.astro';
+import RemoteCode from '../../components/RemoteCode.astro';
+
+In this quickstart you are going to build an application with React Native and integrate it with FusionAuth.
+You'll be building it for [ChangeBank](https://www.youtube.com/watch?v=CXDxNCzUspM), a global leader in converting dollars into coins.
+It'll have areas reserved for users who have logged in as well as public facing sections.
+
+The docker compose file and source code for a complete application are available at
+https://github.com/FusionAuth/fusionauth-quickstart-react-native
+
+## Prerequisites
+
+- [Node](https://nodejs.org): This will be used to set up your project.
+- [Docker](https://www.docker.com): The quickest way to stand up FusionAuth. (There are [other ways](/docs/v1/tech/installation-guide/)).
+- To test on Android devices, you can either connect a physical device or [Android Studio](https://developer.android.com/studio) to set up an emulator.
+- To test on iOS devices, you'll need a Mac and install [Xcode](https://developer.apple.com/xcode/) to set up an emulator.
+
+This app has been tested with React Native 0.72.4 and Node 20. This example should work with other compatible versions of React Native.
+
+## General Architecture
+
+While this sample application doesn't have login functionality without FusionAuth, a more typical integration will replace an existing login system with FusionAuth.
+
+In that case, the system might look like this before FusionAuth is introduced.
+
+<LoginBefore alt={"Request flow during login before FusionAuth"}/>
+
+The login flow will look like this after FusionAuth is introduced.
+
+<LoginAfter alt={"Request flow during login after FusionAuth"}/>
+
+In general, you are introducing FusionAuth in order to normalize and consolidate user data. This helps make sure it is consistent and up-to-date as well as offloading your login security and functionality to FusionAuth.
+
+## Getting Started
+
+In this section, you'll get FusionAuth up and running and use `npx` to create a new application.
+
+### Clone the Code
+
+First off, grab the code from the repository and change into that directory.
+
+```
+git clone https://github.com/FusionAuth/fusionauth-quickstart-react-native.git
+cd fusionauth-quickstart-react-native
+```
+
+### Run FusionAuth via Docker
+
+In the root directory of the repo you'll find a Docker compose file (`docker-compose.yml`) and an environment variables configuration file (`.env`). Assuming you have Docker installed on your machine, you can stand up FusionAuth up on your machine with:
+
+```
+docker compose up -d
+```
+
+Here you are using a bootstrapping feature of FusionAuth, called [Kickstart](/docs/v1/tech/installation-guide/kickstart). When FusionAuth comes up for the first time, it will look at the `kickstart/kickstart.json` file and configure FusionAuth to a certain initial state.
+
+<Aside type="note">
+  If you ever want to reset the FusionAuth system, delete the volumes created by Docker Compose by executing `docker compose down -v`, then re-run `docker compose up -d`.
+</Aside>
+
+FusionAuth will be initially configured with these settings:
+
+* Your client Id is `e9fdb985-9173-4e01-9d73-ac2d60d1dc8e`.
+* Your client secret is `super-secret-secret-that-should-be-regenerated-for-production`.
+* Your example username is `richard@example.com` and the password is `password`.
+* Your admin username is `admin@example.com` and the password is `password`.
+* The base URL of FusionAuth `http://localhost:9011/`.
+
+You can log into the [FusionAuth admin UI](http://localhost:9011/admin) and look around if you want, but with Docker/Kickstart you don't need to.
+
+### Expose your Instance
+
+You need [to expose your local FusionAuth instance](/docs/v1/tech/developer-guide/exposing-instance) and copy the address `ngrok` gave you. Your app will use it to access the FusionAuth instance in your machine.
+
+### Create your React Native Application and copy the address `ngrok` gave you. Your app will use it to access the FusionAuth instance in your machine.
+Now you are going to create a React Native application. While this section builds a simple React Native application, you can use the same configuration to integrate your existing React Native application with FusionAuth.
+
+To make things easier, you're going to use `create-expo-app`, a library that sets up the enviroment using [Expo](https://docs.expo.dev/), a platform that runs natively on all your users' devices
+
+```shell
+npx create-expo-app my-react-native-app && cd my-react-native-app
+```
+
+<Aside type="note">
+  If this is your first time setting up a React Native application, you'll receive a message asking if you want to install `create-expo-app`, so press `y` to confirm.
+</Aside>
+
+## Authentication
+
+We'll use the [Expo AuthSession library](https://docs.expo.dev/versions/latest/sdk/auth-session/), which simplifies integrating with FusionAuth and creating a secure web application.
+
+### Configure Expo AuthSession
+
+Install `expo-auth-session` and its dependency `expo-crypto`.
+
+```shell
+npx expo install expo-auth-session expo-crypto
+```
+
+Create a `.env` file to hold information about your FusionAuth instance and application, replacing the value in `EXPO_PUBLIC_FUSIONAUTH_URL` with the address you copied from `ngrok` when [exposing your instance](#Expose-your-instance).
+
+<RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/.env"
+            lang="ini"/>
+
+Add a new scheme to the `app.json` file. This will be used when redirecting back to your application after logging in on out of FusionAuth.
+
+<RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/app.json"
+            lang="json"/>
+
+## App Customization
+
+In this section, you'll turn your application into a trivial banking application with some styling.
+
+### Add Styling
+
+First, run the command below to install some libraries needed for theming.
+
+```shell
+npm install expo-image expo-constants react-native-currency-input
+```
+
+Instead of using CSS, React Native has its own concept of [stylesheets](https://reactnative.dev/docs/stylesheet). Create a file named `changebank.style.js` with the contents below to style your ChangeBank app.
+
+<RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/changebank.style.js"
+            lang="javascript"/>
+
+## Finish Setting up the App
+
+Change the existing `App.js` to integrate `expo-auth-session`, add the ChangeBank template and stitch up everything.
+
+<RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/App.js"
+            lang="javascript"/>
+
+## Run the App
+
+If you want to test on an Android device, connect a physical device via USB or install [Android Studio](https://developer.android.com/studio) to set up an emulator.
+
+If you want to test on an iOS device and are running a Mac, install [Xcode](https://developer.apple.com/xcode/) to set up an emulator.
+Start up the React Native application using this command:
+
+```shell
+npx expo start
+```
+
+To test on the connected or emulated Android device, press `a`. Otherwise, press `i` to run on the emulated iOS device.
+
+## Next Steps
+This quickstart is a great way to get a proof of concept up and running quickly, but to run
+your application in production, there are some things you're going to want to do.
+
+### FusionAuth Customization
+FusionAuth gives you the ability to customize just about everything with the user's experience and your application's integration. This includes
+* [Hosted pages](/docs/v1/tech/themes/) such as login, registration, email verification, and many more
+* [Email templates](/docs/v1/tech/email-templates/email-templates)
+* [User data and custom claims in access token JWTs](/articles/tokens/jwt-components-explained)
+
+### Security
+* [Expo AuthSession](https://docs.expo.dev/versions/latest/sdk/auth-session/) handles token validation and refresh
+* You may want to customize the [token expiration times and policies](/docs/v1/tech/oauth/#configure-application-oauth-settings) in FusionAuth
+* Choose [password rules](/docs/v1/tech/core-concepts/tenants#password) and a [hashing algorithm](/docs/v1/tech/reference/password-hashes) that meet your security needs
+
+### Tenant and Application Management
+* Model your application topology using [Applications](/docs/v1/tech/core-concepts/applications), [Roles](/docs/v1/tech/core-concepts/roles), [Groups](/docs/v1/tech/core-concepts/groups), [Entities](/docs/v1/tech/core-concepts/groups), and more
+* Set up [MFA](/docs/v1/tech/guides/multi-factor-authentication), [Social login](/docs/v1/tech/identity-providers/), and/or [SAML](/docs/v1/tech/identity-providers/samlv2/) integrations
+* Integrate with external systems using [Webhooks](/docs/v1/tech/events-webhooks/), [SCIM](/docs/v1/tech/core-concepts/scim), and [Lambdas](/docs/v1/tech/lambdas/)
+
+## Troubleshooting
+
+> @TODO

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -12,6 +12,7 @@ color: indigo
 cta: EmailListCTA
 ---
 import Aside from '../../components/Aside.astro';
+import IconButton from '../../components/IconButton.astro';
 import LoginAfter from '../../diagrams/quickstarts/login-after.astro';
 import LoginBefore from '../../diagrams/quickstarts/login-before.astro';
 import RemoteCode from '../../components/RemoteCode.astro';
@@ -85,9 +86,10 @@ You can log into the [FusionAuth admin UI](http://localhost:9011/admin) and look
 
 ### Expose your Instance
 
-You need [to expose your local FusionAuth instance](/docs/v1/tech/developer-guide/exposing-instance) and copy the address `ngrok` gave you. Your app will use it to access the FusionAuth instance in your machine.
+You need to [expose your local FusionAuth instance](/docs/v1/tech/developer-guide/exposing-instance) and copy the address `ngrok` gave you. Your app will use it to access the FusionAuth instance in your machine.
 
-### Create your React Native Application and copy the address `ngrok` gave you. Your app will use it to access the FusionAuth instance in your machine.
+### Create your React Native Application
+
 Now you are going to create a React Native application. While this section builds a simple React Native application, you can use the same configuration to integrate your existing React Native application with FusionAuth.
 
 To make things easier, you're going to use `create-expo-app`, a library that sets up the enviroment using [Expo](https://docs.expo.dev/), a platform that runs natively on all your users' devices
@@ -106,18 +108,18 @@ We'll use the [Expo AuthSession library](https://docs.expo.dev/versions/latest/s
 
 ### Configure Expo AuthSession
 
-Install `expo-auth-session` and its dependency `expo-crypto`.
+Install `expo-auth-session`, its dependency `expo-crypto` to handle cryptographic operations and `expo-web-browser` to interact with the device Browser in order to log the user in or out.
 
 ```shell
-npx expo install expo-auth-session expo-crypto
+npx expo install expo-auth-session expo-crypto expo-web-browser
 ```
 
-Create a `.env` file to hold information about your FusionAuth instance and application, replacing the value in `EXPO_PUBLIC_FUSIONAUTH_URL` with the address you copied from `ngrok` when [exposing your instance](#Expose-your-instance).
+Create a `.env` file to hold information about your FusionAuth instance and application, replacing the value in `EXPO_PUBLIC_FUSIONAUTH_URL` with the address you copied from `ngrok` when [exposing your instance](#expose-your-instance).
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/.env"
             lang="ini"/>
 
-Add a new scheme to the `app.json` file. This will be used when redirecting back to your application after logging in on out of FusionAuth.
+Edit `app.json` to add a `scheme` that will be used when redirecting back to your application after logging in and out of FusionAuth.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/app.json"
             lang="json"/>
@@ -157,11 +159,26 @@ Start up the React Native application using this command:
 npx expo start
 ```
 
-To test on the connected or emulated Android device, press `a`. Otherwise, press `i` to run on the emulated iOS device.
+After waiting a few moments, you should see a QR Code and a menu with some actions. Right below the QR Code, you'll see a message like this one _(the real address may vary)_.
+
+```
+› Metro waiting on exp://192.168.1.2:8081
+```
+
+To use [Expo Go](https://docs.expo.dev/get-started/expo-go/), a client for testing your apps on Android and iOS devices without building anything locally, you need to:
+
+* Copy that listening address (`exp://192.168.1.2:8081`).
+* Navigate to your FusionAuth instance on [localhost:9011](http://localhost:9011).
+* Browse to **Applications**.
+* Click on <IconButton icon="edit" color="blue" /> in your `ExampleReactNativeApp` to edit it.
+* Go to the **OAuth** tab.
+* Add that address to **Authorized redirect URLs**.
+* Click on <IconButton icon="save" color="blue" /> to save your changes.
+
+Go back to the terminal with the Expo menu. To test on the connected or emulated Android device, press `a`. Otherwise, press `i` to run on the emulated iOS device.
 
 ## Next Steps
-This quickstart is a great way to get a proof of concept up and running quickly, but to run
-your application in production, there are some things you're going to want to do.
+This quickstart is a great way to get a proof of concept up and running quickly, but to run your application in production, there are some things you're going to want to do.
 
 ### FusionAuth Customization
 FusionAuth gives you the ability to customize just about everything with the user's experience and your application's integration. This includes
@@ -179,6 +196,12 @@ FusionAuth gives you the ability to customize just about everything with the use
 * Set up [MFA](/docs/v1/tech/guides/multi-factor-authentication), [Social login](/docs/v1/tech/identity-providers/), and/or [SAML](/docs/v1/tech/identity-providers/samlv2/) integrations
 * Integrate with external systems using [Webhooks](/docs/v1/tech/events-webhooks/), [SCIM](/docs/v1/tech/core-concepts/scim), and [Lambdas](/docs/v1/tech/lambdas/)
 
+### Build your App for Distribution
+
+Follow [Expo's "Create your first build" tutorial](https://docs.expo.dev/build/setup/) to learn how to create a build for your app.
+
 ## Troubleshooting
 
-> @TODO
+* I keep receiving an `invalid_redirect_uri` when running the app with Expo Go
+
+Make sure you have updated the **Authorized redirect URLs** in your [FusionAuth instance](http://localhost:9011) like shown on the [Run the App](#run-the-app) step.

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -92,7 +92,7 @@ You need to [expose your local FusionAuth instance](/docs/v1/tech/developer-guid
 
 Now you are going to create a React Native application. While this section builds a simple React Native application, you can use the same configuration to integrate your existing React Native application with FusionAuth.
 
-To make things easier, you're going to use `create-expo-app`, a library that sets up the enviroment using [Expo](https://docs.expo.dev/), a platform that runs natively on all your users' devices
+To make things easier, you're going to use `create-expo-app`, a library that sets up the environment using [Expo](https://docs.expo.dev/), a platform that runs natively on all your users' devices
 
 ```shell
 npx create-expo-app my-react-native-app && cd my-react-native-app

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -90,8 +90,7 @@ To make the FusionAuth instance running on your machine accessible to the app, y
 
 ### Create your React Native Application
 
-Now you are going to create a React Native application. While this section builds a simple React Native application, you can use the same configuration to integrate your existing React Native application with FusionAuth.
-
+Now you're going to create a React Native application. While this section builds a simple React Native application, you can use the same configuration to integrate your existing React Native application with FusionAuth.
 To make things easier, you're going to use `create-expo-app`, a library that sets up the environment using [Expo](https://docs.expo.dev/), a platform that runs natively on all your users' devices
 
 ```shell
@@ -153,7 +152,7 @@ wget -O assets/changebank.svg https://raw.githubusercontent.com/FusionAuth/fusio
 
 ## Finish Setting up the App
 
-Replace the existing `App.js` to integrate `expo-auth-session`, add the ChangeBank template and stitch everything up.
+Replace the existing `App.js` to integrate `expo-auth-session`, add the ChangeBank template, and stitch everything up.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/App.js"
             lang="javascript"/>

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -86,7 +86,7 @@ You can log into the [FusionAuth admin UI](http://localhost:9011/admin) and look
 
 ### Expose your Instance
 
-To make the FusionAuth instance running on your machine accessible to the app, you need to [expose it to the Internet following these instructions](/docs/v1/tech/developer-guide/exposing-instance). Then, copy the address `ngrok` gave you as you'll need it shortly.
+To make the FusionAuth instance running on your machine accessible to the app, you need to [expose it to the Internet following these instructions](/docs/v1/tech/developer-guide/exposing-instance). Then, copy the address `ngrok` gave you as you'll need it shortly. It looks something like `https://SOME-RANDOM-STRINGS.ngrok-free.app`.
 
 ### Create your React Native Application
 
@@ -145,6 +145,12 @@ Instead of using CSS, React Native has its own concept of [stylesheets](https://
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/changebank.style.js"
             lang="javascript"/>
 
+Run the command below to download the ChangeBank logo into the `assets` folder.
+
+```shell
+wget -O assets/changebank.svg https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/assets/changebank.svg
+```
+
 ## Finish Setting up the App
 
 Replace the existing `App.js` to integrate `expo-auth-session`, add the ChangeBank template and stitch everything up.
@@ -174,6 +180,7 @@ To use [Expo Go](https://docs.expo.dev/get-started/expo-go/), a client for testi
 
 * Copy that listening address (`exp://192.168.1.2:8081`).
 * Navigate to your FusionAuth instance on [localhost:9011](http://localhost:9011).
+* Log in with the email `admin@example.com` and password `password`.
 * Browse to **Applications**.
 * Click on <IconButton icon="edit" color="blue" /> in your `ExampleReactNativeApp` to edit it.
 * Go to the **OAuth** tab.

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -147,7 +147,7 @@ Instead of using CSS, React Native has its own concept of [stylesheets](https://
 
 ## Finish Setting up the App
 
-Change the existing `App.js` to integrate `expo-auth-session`, add the ChangeBank template and stitch everything up.
+Replace the existing `App.js` to integrate `expo-auth-session`, add the ChangeBank template and stitch everything up.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/App.js"
             lang="javascript"/>

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -172,7 +172,8 @@ To use [Expo Go](https://docs.expo.dev/get-started/expo-go/), a client for testi
 * Browse to **Applications**.
 * Click on <IconButton icon="edit" color="blue" /> in your `ExampleReactNativeApp` to edit it.
 * Go to the **OAuth** tab.
-* Add that address to **Authorized redirect URLs**.
+* Add that address to **Authorized redirect URLs** and append `/--/redirect` to it
+  * Example: for `exp://192.168.1.2:8081`, you'd need to add `exp://192.168.1.2:8081/--/redirect` as a redirect URL
 * Click on <IconButton icon="save" color="blue" /> to save your changes.
 
 Go back to the terminal with the Expo menu. To test on the connected or emulated Android device, press `a`. Otherwise, press `i` to run on the emulated iOS device.

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -188,7 +188,15 @@ To use [Expo Go](https://docs.expo.dev/get-started/expo-go/), a client for testi
   * Example: for `exp://192.168.1.2:8081`, you'd need to add `exp://192.168.1.2:8081/--/redirect` as a redirect URL
 * Click on <IconButton icon="save" color="blue" /> to save your changes.
 
-Go back to the terminal with the Expo menu. To test on the connected or emulated Android device, press `a`. Otherwise, press `i` to run on the emulated iOS device.
+Go back to the terminal with the Expo menu. To test on the connected or emulated Android device, press `a`. Otherwise, press `i` to run on the iOS device.
+
+Wait a few seconds and Expo will build and install the app in your device. You should then see the ChangeBank welcome page. Click the `Log in` button in the top right corner of that screen.
+
+<Aside type="note">
+  If it is your first time running the app, ngrok will ask if you really want to continue to that page, so click `Visit Site`.
+</Aside>
+
+You'll finally arrive at the FusionAuth login screen. Fill in `richard@example.com` and `password` and click on `Submit` to be redirected back to the logged-in ChangeBank page.
 
 ## Next Steps
 This quickstart is a great way to get a proof of concept up and running quickly, but to run your application in production, there are some things you're going to want to do.

--- a/astro/src/content/quickstarts/quickstart-react-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-react-native.mdx
@@ -86,7 +86,7 @@ You can log into the [FusionAuth admin UI](http://localhost:9011/admin) and look
 
 ### Expose your Instance
 
-You need to [expose your local FusionAuth instance](/docs/v1/tech/developer-guide/exposing-instance) and copy the address `ngrok` gave you. Your app will use it to access the FusionAuth instance in your machine.
+To make the FusionAuth instance running on your machine accessible to the app, you need to [expose it to the Internet following these instructions](/docs/v1/tech/developer-guide/exposing-instance). Then, copy the address `ngrok` gave you as you'll need it shortly.
 
 ### Create your React Native Application
 
@@ -97,6 +97,8 @@ To make things easier, you're going to use `create-expo-app`, a library that set
 ```shell
 npx create-expo-app my-react-native-app && cd my-react-native-app
 ```
+
+You'll have to create all files in the root directory for your application.
 
 <Aside type="note">
   If this is your first time setting up a React Native application, you'll receive a message asking if you want to install `create-expo-app`, so press `y` to confirm.
@@ -119,7 +121,9 @@ Create a `.env` file to hold information about your FusionAuth instance and appl
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/.env"
             lang="ini"/>
 
-Edit `app.json` to add a `scheme` that will be used when redirecting back to your application after logging in and out of FusionAuth.
+Replace `app.json` with the contents below to add some details about your app:
+- A `scheme` that will be used when redirecting back to your application after logging in and out of FusionAuth.
+- The package name for both Android (`expo.android.package`) and iOS (`expo.ios.bundleIdentifier`) builds.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/app.json"
             lang="json"/>
@@ -143,17 +147,18 @@ Instead of using CSS, React Native has its own concept of [stylesheets](https://
 
 ## Finish Setting up the App
 
-Change the existing `App.js` to integrate `expo-auth-session`, add the ChangeBank template and stitch up everything.
+Change the existing `App.js` to integrate `expo-auth-session`, add the ChangeBank template and stitch everything up.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-react-native/main/complete-application/App.js"
             lang="javascript"/>
 
 ## Run the App
 
-If you want to test on an Android device, connect a physical device via USB or install [Android Studio](https://developer.android.com/studio) to set up an emulator.
+Depending on where you want to test your app, follow these instructions.
+- For Android devices: you can either [connect a physical device](https://developer.android.com/studio/run/device) or install [Android Studio](https://developer.android.com/studio) to [set up an emulator](https://developer.android.com/studio/run/emulator).
+- For iOS devices: if you are running a Mac, you can install [Xcode](https://developer.apple.com/xcode/) to [set up an emulator or run on a physical device](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device/).
 
-If you want to test on an iOS device and are running a Mac, install [Xcode](https://developer.apple.com/xcode/) to set up an emulator.
-Start up the React Native application using this command:
+Now that you have a device connected or an emulator running, start up the React Native application from the root `my-react-native-app` directory using the command below.
 
 ```shell
 npx expo start

--- a/astro/src/pages/docs/quickstarts/quickstart-sections.ts
+++ b/astro/src/pages/docs/quickstarts/quickstart-sections.ts
@@ -87,13 +87,6 @@ const qsSections: QuickStartSection[] = [
         faIcon: 'fa-snake',
         navColor: 'indigo'
       },
-      {
-        href: '/blog/2020/08/19/securing-react-native-with-oauth',
-        title: 'React Native',
-        icon: '/img/icons/react.svg',
-        faIcon: 'fa-r',
-        navColor: 'indigo'
-      },
     ],
   },
   {


### PR DESCRIPTION
Adding a React Native quickstart with a custom ChangeBank theme as small changes were needed due to React Native  restrictions (e.g. the coins image, layout responsiveness etc).

Demo app located at https://github.com/FusionAuth/fusionauth-quickstart-react-native

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205273462533551