### PR TITLE
refactor(Docker Compose): replaced Compose V1 with V2 command "docker compose"

### DIFF
--- a/astro/src/content/quickstarts/quickstart-ruby-rails-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-ruby-rails-web.mdx
@@ -63,13 +63,13 @@ cd fusionauth-quickstart-ruby-on-rails-web
 In the root directory of the repo you'll find a Docker compose file (docker-compose.yml) and an environment variables configuration file (.env). Assuming you have Docker installed on your machine, you can stand up FusionAuth up on your machine with:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Here you are using a bootstrapping feature of FusionAuth, called [Kickstart](/docs/v1/tech/installation-guide/kickstart). When FusionAuth comes up for the first time, it will look at the `kickstart/kickstart.json` file and configure FusionAuth to a certain initial state.
 
 <Aside type="note">
-If you ever want to reset the FusionAuth system, delete the volumes created by docker-compose by executing `docker-compose down -v`, then re-run `docker-compose up -d`.
+If you ever want to reset the FusionAuth system, delete the volumes created by docker-compose by executing `docker compose down -v`, then re-run `docker compose up -d`.
 </Aside>
 
 FusionAuth will be initially configured with these settings:


### PR DESCRIPTION
See https://github.com/FusionAuth/fusionauth-site/pull/2310 for more