### PR TITLE
specify the correct token for google, facebook, other oauth2 compatible identity providers

### DIFF
--- a/site/docs/v1/tech/apis/identity-providers/_common-data-code-or-token.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_common-data-code-or-token.adoc
@@ -9,7 +9,7 @@ The redirect URI that was provided to the {idp_display_name} authorization endpo
 When using `code` this field is required.
 
 [field]#data.token# [type]#[String]# [optional]#Optional#::
-When using a popup or other login mode where {idp_display_name} has already returned you an `accessToken` through a JavaScript callback or other mechanism, you will send this value in the `token` parameter. FusionAuth will use this value to request user details and then complete the login.
+When using a popup or other login mode where {idp_display_name} has already returned you {token_for_login_request} through a JavaScript callback or other mechanism, you will send this value in the `token` parameter. FusionAuth will use this value to request user details and then complete the login.
 +
 When using `token` you do not have to supply `redirect_uri`. If `token` is not provided, then `code` will be required.
 

--- a/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
+++ b/site/docs/v1/tech/apis/identity-providers/_identity-provider-login-request-body.adoc
@@ -1,4 +1,15 @@
 ==== Request Body
+ifeval::["{idp_token_or_code}" == "token or code"]
+:token_for_login_request: pass:normal[an `accessToken`]
+endif::[]
+ifeval::["{idp_display_name}" == "Facebook"]
+// Facebook has two kinds of access token, short and long lived. You provide a short lived token to get a long lived one: https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived/
+:token_for_login_request: pass:normal[a short-lived User `accessToken`]
+endif::[]
+// Google is the special snowflake which requires an id token
+ifeval::["{idp_display_name}" == "Google"]
+:token_for_login_request: pass:normal[an `idToken`]
+endif::[]
 
 // default to empty string
 :data_code_since:


### PR DESCRIPTION
Per https://github.com/FusionAuth/fusionauth-site/issues/2507 google doesn't require an access token to complete the login. it requires an id token.

looking more closely, facebook requires a different kind of access token than everyone else.