### PR TITLE
Add FAQ to webhook doc page, clarify some

### DIFF
--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -174,7 +174,7 @@ The exceptions to this are the following system events which are not tenant spec
 * `event-log.create`
 * `kickstart.success`
 
-These events are configured at the system level and cannot be limited to a certain tenant.
+These events are configured at the system level and cannot be scoped to a certain tenant.
 
 === Headers
 

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -166,7 +166,7 @@ When this toggle is enabled, events for all tenants will be sent to this webhook
 Tenants::
 When the [field]#All tenants# setting is disabled, this field will be exposed. Select the tenants for which you would like to receive events.
 +
-Most events are considered tenant specific. Selecting one more more tenants will cause FusionAuth to send events only for those tenants.
+Most events are scoped to a tenant. Selecting one more more tenants will cause FusionAuth to send events only for those tenants.
 
 The exceptions to this are the following system events which are not tenant specific:
 

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -22,23 +22,24 @@ See the corresponding link:/docs/v1/tech/apis/webhooks[Webhook APIs] if you'd pr
 
 Here are the topics in this section:
 
-* link:/docs/v1/tech/events-webhooks/events/[Events] - Covers all of the event types that FusionAuth sends to Webhooks
 * link:/docs/v1/tech/events-webhooks/writing-a-webhook[Writing a Webhook] - Covers how to write a Webhook that will process events from FusionAuth.
 * link:/docs/v1/tech/events-webhooks/securing[Securing a Webhook] - Covers how to ensure your webhooks are secured properly.
+* link:/docs/v1/tech/events-webhooks/events/[Events] - Covers all of the event types that FusionAuth sends to Webhooks
 
 Continue reading below to see how the events and webhooks are configured using the FusionAuth user interface.
 
 * <<Tenant Settings>>
 * <<Add Webhook>>
 * <<Test a Webhook>>
+* <<FAQs>>
 
 == Tenant Settings
 
-To prepare to consume FusionAuth events you'll first need to enable the event and select a transaction level that is compatible with your requirements. 
+To prepare to consume FusionAuth events you'll first need to enable the event and select a transaction level that is compatible with your requirements in the tenant. 
 
 [NOTE]
 ====
-You do not need to configure the tenant settings for any instance level webhooks, such as the `Audit Log Create`.
+You do not need to configure the tenant settings for any system level webhooks, such as the `Audit Log Create`.
 ====
 
 To do so, navigate to [breadcrumb]#Tenants -> Webhooks# to enable events and optionally modify the default transaction level for each event type.
@@ -167,13 +168,13 @@ When the [field]#All tenants# setting is disabled, this field will be exposed. S
 +
 Most events are considered tenant specific. Selecting one more more tenants will cause FusionAuth to send events only for those tenants.
 
-The exceptions to this are the following instance events which are not tenant specific:
+The exceptions to this are the following system events which are not tenant specific:
 
 * `audit-log.create`
 * `event-log.create`
 * `kickstart.success`
 
-These events are configured at the instance level and cannot be limited to a certain tenant.
+These events are configured at the system level and cannot be limited to a certain tenant.
 
 === Headers
 
@@ -234,6 +235,16 @@ The selected event type to send to the webhook.
 
 Event::
 The JSON event to send to the webhook. This is a generated example and it may be modified before sending to replicate a specific scenario.
+
+== FAQs
+
+**Q:** I have successfully tested my Webhook, but why am I not recieving specific live events? +
+
+**A:** There are several configurations that need to be enabled to ensure events get delivered:
+
+* Navigate to [breadcrumb]#Tenants -> Webhooks# to enable the specific events
+* Navigate to [breadcrumb]#Settings -> Webhooks -> Tenants# and ensure the Webhook is configured for *All tenants* or checked for the desired tenant
+* Navigate to [breadcrumb]#Settings -> Webhooks -> Events# and ensure the specific events are enabled for the Webhook
 
 ++++
 {% capture relatedTag %}feature-webhooks{% endcapture %}

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -244,7 +244,9 @@ The JSON event to send to the webhook. This is a generated example and it may be
 
 * Set up the Tenant events. Navigate to [breadcrumb]#Tenants -> Webhooks# and enable the specific events.
 * Set up Webhook tenants. Navigate to [breadcrumb]#Settings -> Webhooks -> Tenants# and ensure the Webhook is configured either for [uielement]#All tenants# or your desired tenant or tenants.
-* Navigate to [breadcrumb]#Settings -> Webhooks -> Events# and ensure the specific events are enabled for the Webhook
+* Set up the Webhook events. Navigate to [breadcrumb]#Settings -> Webhooks -> Events# and ensure the specific events are enabled for the Webhook.
+
+Unless all three of these configurations are correct, you won't receive events to your configured endpoint.
 
 ++++
 {% capture relatedTag %}feature-webhooks{% endcapture %}

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -39,7 +39,7 @@ To prepare to consume FusionAuth events you'll first need to enable the event an
 
 [NOTE]
 ====
-You do not need to configure the tenant settings for any system level webhooks, such as the `Audit Log Create`.
+You do not need to configure the tenant settings for any system level webhook events, such as the `Audit Log Create` event.
 ====
 
 To do so, navigate to [breadcrumb]#Tenants -> Webhooks# to enable events and optionally modify the default transaction level for each event type.

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -240,7 +240,7 @@ The JSON event to send to the webhook. This is a generated example and it may be
 
 **Q:** I have successfully tested my Webhook, but why am I not receiving specific live events? +
 
-**A:** There are several configurations that need to be enabled to ensure events get delivered:
+**A:** In order to receive events to your webhook endpoint, ensure the following items are configured:
 
 * Navigate to [breadcrumb]#Tenants -> Webhooks# to enable the specific events
 * Set up Webhook tenants. Navigate to [breadcrumb]#Settings -> Webhooks -> Tenants# and ensure the Webhook is configured either for [uielement]#All tenants# or your desired tenant or tenants.

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -238,7 +238,7 @@ The JSON event to send to the webhook. This is a generated example and it may be
 
 == FAQs
 
-**Q:** I have successfully tested my Webhook, but why am I not recieving specific live events? +
+**Q:** I have successfully tested my Webhook, but why am I not receiving specific live events? +
 
 **A:** There are several configurations that need to be enabled to ensure events get delivered:
 

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -242,7 +242,7 @@ The JSON event to send to the webhook. This is a generated example and it may be
 
 **A:** In order to receive events to your webhook endpoint, ensure the following items are configured:
 
-* Navigate to [breadcrumb]#Tenants -> Webhooks# to enable the specific events
+* Set up the Tenant events. Navigate to [breadcrumb]#Tenants -> Webhooks# and enable the specific events.
 * Set up Webhook tenants. Navigate to [breadcrumb]#Settings -> Webhooks -> Tenants# and ensure the Webhook is configured either for [uielement]#All tenants# or your desired tenant or tenants.
 * Navigate to [breadcrumb]#Settings -> Webhooks -> Events# and ensure the specific events are enabled for the Webhook
 

--- a/site/docs/v1/tech/events-webhooks/index.adoc
+++ b/site/docs/v1/tech/events-webhooks/index.adoc
@@ -243,7 +243,7 @@ The JSON event to send to the webhook. This is a generated example and it may be
 **A:** There are several configurations that need to be enabled to ensure events get delivered:
 
 * Navigate to [breadcrumb]#Tenants -> Webhooks# to enable the specific events
-* Navigate to [breadcrumb]#Settings -> Webhooks -> Tenants# and ensure the Webhook is configured for *All tenants* or checked for the desired tenant
+* Set up Webhook tenants. Navigate to [breadcrumb]#Settings -> Webhooks -> Tenants# and ensure the Webhook is configured either for [uielement]#All tenants# or your desired tenant or tenants.
 * Navigate to [breadcrumb]#Settings -> Webhooks -> Events# and ensure the specific events are enabled for the Webhook
 
 ++++


### PR DESCRIPTION
While discussing https://github.com/FusionAuth/fusionauth-issues/issues/2016, realized updating our docs with guidance could help users.

Rename instance events to system events to be less confusing and consistent with the UI.