### PR TITLE
remove last newline.

### DIFF
--- a/astro/src/components/RemoteCode.astro
+++ b/astro/src/components/RemoteCode.astro
@@ -54,7 +54,7 @@ function selectTagged(content: string, tags: string): string {
 
   const startLine = lines.findIndex((line) => line.includes(`tag::${tags}`));
   const endLine = lines.findIndex((line) => line.includes(`end::${tags}`));
-  return lines.slice(startLine + 1, endLine).join("\n");
+  return lines.slice(startLine + 1, endLine).join("\n").replace(/\s+$/g, '');
 }
 
 function selectLines(content: string, lineNum: string, lineEnd: string): string {


### PR DESCRIPTION
When we import a code section via tags, we had an extra newline hanging around.

This fix obliterates all the whitespace at the end of the content