### PR TITLE
Fix Java path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.7.5
 ARG SAVANT_VERSION="2.0.0-RC.4"
 ARG BUNDLER_VERSION="2.4.6"
 ARG OPENJDK_VERSION="17"
-ENV JAVA_HOME="/usr/lib/jvm/java-${OPENJDK_VERSION}-openjdk-amd64"
+ENV JAVA_HOME="/usr"
 
 WORKDIR /srv/jekyll
 


### PR DESCRIPTION
If I run the Dockerfile as is I get an error

```
fusionauth-site$ ./run-docker
/usr/local/bin/sb: line 33: /usr/lib/jvm/java-17-openjdk-amd64/bin/java: No such file or directory
```

If I ssh into the container and run `which java` it tells me java is in `/usr/bin/java`

Changing this environment variable uses that Java binary (`/bin/java` is added later), and everything builds successfully. I can visit the site on the host machine at localhost:4000 as expected.

Not sure if this is somehow platform specific? I am using an M1 mac.