### PR TITLE
document license text being usable in kickstart

### DIFF
--- a/site/docs/v1/tech/installation-guide/kickstart.adoc
+++ b/site/docs/v1/tech/installation-guide/kickstart.adoc
@@ -334,13 +334,13 @@ In this example, modify the restricted API key example from above to further lim
 
 === Referencing Defaults
 
-There are some items in FusionAuth with default, fixed Ids, such as the default theme or the FusionAuth application.
+There are some items in FusionAuth with default fixed Ids, such as the default theme or the FusionAuth application.
 
 Here are the default items and their Ids:
 
 include::docs/v1/tech/shared/_default-entities.adoc[]
 
-With the known Id, you can build other fields in your Kickstart file that depend on or copy them. For example, you may copy the default theme and modify the copied theme via Kickstart, or you may create a new tenant but set the tenant Id token signing key to one of the shadow keys.
+With these Ids, you can build other requests in your Kickstart file that depend on default items. For example, you can copy the default theme and then modify the copied theme. This is useful if you are only modifying the CSS of your theme.
 
 === Modify the Default Tenant Id
 

--- a/site/docs/v1/tech/installation-guide/kickstart.adoc
+++ b/site/docs/v1/tech/installation-guide/kickstart.adoc
@@ -193,7 +193,7 @@ The optional value of the `Content-Type` request header.
 Currently this is only intended when using the `PATCH` HTTP request [field]#method# for a value of `application/json-patch+json` or `application/merge-patch+json`.
 
 [field]#url# [type]#[String]# [required]#Required#::
-The relative URL of API endpoint, such as `/api/user/registration`.
+The relative URL of the API endpoint, such as `/api/user/registration`.
 
 [field]#tenantId# [type]#[UUID]# [optional]#Optional#::
 The unique Tenant Id.
@@ -343,7 +343,7 @@ Here are the default items and their Ids:
 
 include::docs/v1/tech/shared/_default-entities.adoc[]
 
-With the known Id, you can build other configuration in your Kickstart file that depend on or copy them. For example, you may copy the default theme and modify the copied theme via Kicstart, or you may create a new tenant but set the tenant Id token signing key to one of the shadow keys.
+With the known Id, you can build other fields in your Kickstart file that depend on or copy them. For example, you may copy the default theme and modify the copied theme via Kickstart, or you may create a new tenant but set the tenant Id token signing key to one of the shadow keys.
 
 === Modify the Default Tenant Id
 
@@ -428,7 +428,7 @@ For example, consider the following directory structure:
 ```
 
 
-In this example we are creating an Email template and reading in the values for the text and html values from files in a sub-directory named emails. Reading files in like this allows you to format your emails nicely and Kickstart will handle the necessary JSON escaping to complete the API request.
+In this example we are creating an Email template and reading in the values for the text and html values from files in a subdirectory named `emails`. Using external files for templates like this allows you to format your emails nicely. Kickstart will handle the necessary JSON escaping to complete the API request.
 
 ```json
 {
@@ -577,7 +577,7 @@ There is one special variable that when defined can be used to modify the Id of 
 
 === Environment Variables
 
-The following environment variables provided.
+The following environment variables are provided.
 
 * `FUSIONAUTH_APPLICATION_ID` - The Id of the FusionAuth application.
 * `FUSIONAUTH_TENANT_ID` - The Id of the default Tenant. This is always the Tenant which contains the FusionAuth application.

--- a/site/docs/v1/tech/installation-guide/kickstart.adoc
+++ b/site/docs/v1/tech/installation-guide/kickstart.adoc
@@ -134,7 +134,7 @@ You may find yourself repeating yourself when you build your kickstart file, nob
 
 To use a variable, define the key and value in the `variables` section of the kickstart file and then access that value anywhere outside of the `variables` section using the `#{foo}` notation where `foo` is the name of the variable.
 
-Here is the same example as above, but instead of hard coding the API key, the API key value is a variable which can be reused. This example is not particularly interesting since the value has been moved from the `apiKeys` section to the `variables` section. Never worry! Using variables can come in handy as you'll see in the next few examples.
+Here is the same example as above, but instead of hard coding the API key, a variable is created to hold the API key value. This example is not particularly interesting since the value has been moved from the `apiKeys` section to the `variables` section. Never worry! Using variables can come in handy as you'll see in the next few examples.
 
 ```json
 {
@@ -248,7 +248,7 @@ If you don't create a tenant using the Tenant API in your kickstart file then yo
 
 There is a top level property in the request called `tenantId` and you simply set that value to indicate which Tenant you wish to use.
 
-Create a new application in a second, new tenant. Because you need to know the `tenantId`, generate a new UUID using the `#{UUID()}` function call and assign that value to `secondTenantId`. Now you can re-use this value to create the tenant, and to make the Create Application API request.
+Create a new application in a second, new tenant. Because you need to know the `tenantId`, generate a new UUID using the `#{UUID()}` function call and assign that value to `secondTenantId`. Now, you can re-use this value to create the tenant and to make the Create Application API request.
 
 This kickstart will create a second tenant named `Aviato` which will contain a single application named `My Cool Application`.
 
@@ -425,7 +425,7 @@ For example, consider the following directory structure:
 ```
 
 
-In this example you are creating an Email template and reading in the values for the text and html values from files in a subdirectory named `emails`. Using external files for templates like this allows you to format your emails nicely. Kickstart will handle the necessary JSON escaping to complete the API request.
+In this example you are creating an email template and reading in the values for the text and html values from files in a subdirectory named `emails`. Using external files for templates like this allows you to format your emails nicely. Kickstart will handle the necessary JSON escaping to complete the API request.
 
 ```json
 {

--- a/site/docs/v1/tech/installation-guide/kickstart.adoc
+++ b/site/docs/v1/tech/installation-guide/kickstart.adoc
@@ -76,7 +76,7 @@ Because this value will primarily be used during your integration as an Authoriz
 
 The first API key you specify has to have authority over all tenants and permissions against all endpoints. If you want to create subsequent API keys these can optionally be scoped to a Tenant and have restrictions on which endpoints they can call.
 
-In this example we still have the first API key with global permissions, but we will create a second API key that is restricted.
+In this example you still have the first API key with global permissions, but there is a second, restricted API key.
 
 ```json
 {
@@ -134,7 +134,7 @@ You may find yourself repeating yourself when you build your kickstart file, nob
 
 To use a variable, define the key and value in the `variables` section of the kickstart file and then access that value anywhere outside of the `variables` section using the `#{foo}` notation where `foo` is the name of the variable.
 
-Here is the same example as above, but instead of hard coding the API key, we are using a variable which can be reused. This example is not particularly helpful, we've only moved the value from the `apiKeys` section to the `variables` section, but using variables can come in handy as you'll see in the next few examples.
+Here is the same example as above, but instead of hard coding the API key, the API key value is a variable which can be reused. This example is not particularly interesting since the value has been moved from the `apiKeys` section to the `variables` section. Never worry! Using variables can come in handy as you'll see in the next few examples.
 
 ```json
 {
@@ -156,7 +156,7 @@ It is reasonable to think you may not want to hard code a password or API key in
 
 To use an environment variable prefix the name of the environment variable with `ENV.`.
 
-Here is the same example as above, but instead of hard coding the API key, we are picking it up from an environment variable. Here we will resolve the value of the API key in the environment variable named `FUSIONAUTH_API_KEY`. This value will be set into the variable `apiKey` and then when the API key is constructed the value of the API key will be resolved to the `apiKey` variable value.
+Here is the same example as above, but instead of hard coding the API key, you are picking it up from an environment variable. Here Kickstart will resolve the value of the API key in the environment variable named `FUSIONAUTH_API_KEY`. This value will be set into the variable `apiKey` and then when the API key is constructed the value of the API key will be resolved to the `apiKey` variable value.
 
 ```json
 {
@@ -205,10 +205,7 @@ The JSON object representing the body of the API call.
 
 Here is an example of creating a FusionAuth admin user using the `requests` object array. This example is using the link:/docs/v1/tech/apis/registrations[Registration API] to create the User and registration in a single request.
 
-You'll notice we are using a special variable that we did not define in the `variables` object. This is one of two reserved variables provided for your convenience.
-
-* `FUSIONAUTH_APPLICATION_ID` - The Id of the FusionAuth application
-* `FUSIONAUTH_TENANT_ID` - The Id of the default Tenant which is where the FusionAuth application resides
+You'll notice there is a special variable that you did not define in the `variables` object. This is one of a number of <<Environment Variables>> provided for your convenience.
 
 ```json
 {
@@ -251,7 +248,7 @@ If you don't create a tenant using the Tenant API in your kickstart file then yo
 
 There is a top level property in the request called `tenantId` and you simply set that value to indicate which Tenant you wish to use.
 
-In this example, we'll create a new application and we'll do it in a second tenant that we create. Because I need to know the `tenantId` I am generating a new UUID using the `#{UUID()}` function call and assigning that value to `secondTenantId`. Now I can re-use this value to create the tenant, and to make the Create Application API request.
+Create a new application in a second, new tenant. Because you need to know the `tenantId`, generate a new UUID using the `#{UUID()}` function call and assign that value to `secondTenantId`. Now you can re-use this value to create the tenant, and to make the Create Application API request.
 
 This kickstart will create a second tenant named `Aviato` which will contain a single application named `My Cool Application`.
 
@@ -295,7 +292,7 @@ This kickstart will create a second tenant named `Aviato` which will contain a s
 
 An API key may also be configured to be restricted to a single tenant, as implied above. To do this, add the `tenantId` to the API key configuration.
 
-In this example we will modify the restricted API key example from above to further limit it for use with one tenant.
+In this example, modify the restricted API key example from above to further limit it for use with only one tenant.
 
 ```json
 {
@@ -349,7 +346,7 @@ With the known Id, you can build other fields in your Kickstart file that depend
 
 FusionAuth generates the Id for the default tenant when the database schema is first created. For development and production environments it may be helpful to have a known `tenantId` for consistency across environments.
 
-You may modify the default Tenant Id in your kickstart file by setting a special variable: `defaultTenantId`. In this example we have set the default Tenant Id to `30663132-6464-6665-3032-326466613934`. This value must be a valid UUID.
+You may modify the default Tenant Id in your kickstart file by setting a special variable: `defaultTenantId`. In this example the default Tenant Id is `30663132-6464-6665-3032-326466613934`. This value must be a valid UUID.
 
 The value resolved when using the `FUSIONAUTH_TENANT_ID` variable will reflect this change.
 
@@ -416,7 +413,7 @@ The HTTP read timeout, in milliseconds, when connecting to the API.
 
 When making API requests to create an email template or request which may have lengthy values, it may be helpful to separate these values into separate files. The directories shown here are just examples, and you can use your own convention.
 
-To include a text file in your kickstart definition, use the `@{fileName}` syntax where the `fileName` is a relative path from your kickstart file. For this type of include, we handle all line returns and properly JSON escape them for use in a JSON request body.
+To include a text file in your kickstart definition, use the `@{fileName}` syntax where the `fileName` is a relative path from your kickstart file. For this type of include, Kickstart handles all line returns and properly JSON escapes them for use in a JSON request body.
 
 For example, consider the following directory structure:
 
@@ -428,7 +425,7 @@ For example, consider the following directory structure:
 ```
 
 
-In this example we are creating an Email template and reading in the values for the text and html values from files in a subdirectory named `emails`. Using external files for templates like this allows you to format your emails nicely. Kickstart will handle the necessary JSON escaping to complete the API request.
+In this example you are creating an Email template and reading in the values for the text and html values from files in a subdirectory named `emails`. Using external files for templates like this allows you to format your emails nicely. Kickstart will handle the necessary JSON escaping to complete the API request.
 
 ```json
 {
@@ -465,7 +462,7 @@ Newlines are preserved in included text files, whereas they are not in the kicks
 
 If you're making a lot of API requests, or simply want to manage each API request body separately it may be helpful to read in external JSON files. The directories shown here are just examples, and you can use your own convention.
 
-To include a JSON file in your kickstart definition use the `&{fileName}` syntax where the `fileName` is a relative path from your kickstart file. If this type of include is used, we expect the file to be JSON and we don't do anything with line returns.
+To include a JSON file in your kickstart definition use the `&{fileName}` syntax where the `fileName` is a relative path from your kickstart file. If this type of include is used, Kickstart expects the file to be JSON and doesn't do anything with line returns.
 
 For example, consider the following directory structure:
 
@@ -478,7 +475,7 @@ For example, consider the following directory structure:
 |  |- setup-password.json
 ```
 
-Here are the contents of the `json/setup-password.json` file, you'll see that in this example we are still reading in the values for `defaultHtmlTemplate` and `defaultTextTemplate`.
+Here are the contents of the `json/setup-password.json` file. In this example, the values for `defaultHtmlTemplate` and `defaultTextTemplate` are read from external files.
 
 ```json
 {
@@ -493,7 +490,7 @@ Here are the contents of the `json/setup-password.json` file, you'll see that in
 }
 ```
 
-We will replicate the previous example but the entire JSON body of the request will move to `setup-password.json`.
+You will replicate the previous example but the entire JSON body of the request will move to `setup-password.json`.
 
 ```json
 {

--- a/site/docs/v1/tech/installation-guide/kickstart.adoc
+++ b/site/docs/v1/tech/installation-guide/kickstart.adoc
@@ -369,6 +369,15 @@ include::docs/v1/tech/installation-guide/_kickstart-license-text.adoc[]
 
 If you are using the community edition, you can omit this field.
 
+You can also provide `license` text if you have an air-gapped license. Use the `license` key. Here's an example of that might look like.
+
+```json
+  "apiKeys": [ ... ],
+  "license": "...license text...",
+  "licenseId": "...license id...",
+  "requests": [ ... ]
+```
+
 === Settings
 
 [NOTE.since]

--- a/site/docs/v1/tech/installation-guide/kickstart.adoc
+++ b/site/docs/v1/tech/installation-guide/kickstart.adoc
@@ -369,7 +369,7 @@ include::docs/v1/tech/installation-guide/_kickstart-license-text.adoc[]
 
 If you are using the community edition, you can omit this field.
 
-You can also provide `license` text if you have an air-gapped license. Use the `license` key. Here's an example of that might look like.
+You can also provide `license` text if you have an air-gapped license. Use the `license` key. Here's an example of what that might look like.
 
 ```json
   "apiKeys": [ ... ],


### PR DESCRIPTION
Since I was in here anyway, I also changed from `we` to `you` and fixed a couple of errors.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205549986948390