### PR TITLE
Add Astro ui components  (field, breadcrumb, uielement)

### DIFF
--- a/astro/src/components/Breadcrumb.astro
+++ b/astro/src/components/Breadcrumb.astro
@@ -1,0 +1,6 @@
+---
+const { label } = Astro.props;
+---
+<span class="font-bold py-1">
+    {label}
+</span>

--- a/astro/src/components/Field.astro
+++ b/astro/src/components/Field.astro
@@ -1,0 +1,6 @@
+---
+const { label } = Astro.props;
+---
+<span class="bg-gray-100 border-b border-solid border-orange-600 text-sm dark:bg-gray-700 py-1 px-1 mx-1">
+    {label}
+</span>

--- a/astro/src/components/Uielement.astro
+++ b/astro/src/components/Uielement.astro
@@ -1,0 +1,6 @@
+---
+const { label } = Astro.props;
+---
+<span class="bg-gray-100 border-b border-solid border-orange-500 text-sm dark:bg-gray-700 py-1 px-1 mx-1">
+    {label}
+</span>


### PR DESCRIPTION
Adds some components we had in the old docs that we will also need for the wordpress quickstart guide as it is has some more UI work than the web framework ones.