### PR TITLE
note about providing hosted backend with cookies

### DIFF
--- a/site/docs/v1/tech/apis/hosted-backend.adoc
+++ b/site/docs/v1/tech/apis/hosted-backend.adoc
@@ -29,6 +29,8 @@ Be sure to review the link:/docs/v1/tech/core-concepts/applications#oauth[Applic
 
 These endpoints will set the following cookies which are `Secure` and have a `SameSite` value of `Lax`. This follows our link:/learn/expert-advice/oauth/oauth-token-storage#client-side-storage[expert advice on client-side storage].
 
+When you are making requests against these endpoints from your JavaScript application, ensure that you are sending cookies as well. The exact syntax varies, but for many frameworks you want to make sure you set `withCredentials` to `true` when you make the request.
+
 .Cookies Set By the Hosted Backend
 [cols="1,1,3"]
 |===

--- a/site/docs/v1/tech/apis/hosted-backend.adoc
+++ b/site/docs/v1/tech/apis/hosted-backend.adoc
@@ -29,7 +29,7 @@ Be sure to review the link:/docs/v1/tech/core-concepts/applications#oauth[Applic
 
 These endpoints will set the following cookies which are `Secure` and have a `SameSite` value of `Lax`. This follows our link:/learn/expert-advice/oauth/oauth-token-storage#client-side-storage[expert advice on client-side storage].
 
-When you are making requests against these endpoints from your JavaScript application, ensure that you are sending cookies as well. The exact syntax varies, but for many frameworks you want to make sure you set `withCredentials` to `true` when you make the request.
+When you are making requests against these endpoints from your JavaScript application, ensure that you are sending cookies as well. The exact syntax varies, but for many frameworks, you must set `withCredentials` to `true` when you make the request.
 
 .Cookies Set By the Hosted Backend
 [cols="1,1,3"]


### PR DESCRIPTION
From https://github.com/FusionAuth/fusionauth-issues/issues/2442#issuecomment-1734471863 

Wanted to make sure we capture that folks making requests to the hosted backend needed to pass cookies along.