### PR TITLE
update generate-release-notes-stub.sh to use labels and more MD friendly

### DIFF
--- a/src/generate-release-notes-stub.sh
+++ b/src/generate-release-notes-stub.sh
@@ -5,9 +5,13 @@ if [[ $# < 1 ]]; then
   exit 1
 fi
 
-# If we can get good at tagging things correctly "bug", "enhancement", "feature" we should be able to make this produce the stub
-# for each section in the release notes - or get close.
+# Issues should be labeled with exactly one of: "bug", "enhancement", "feature", "security", or "internals" 
+# Without one of these labels, they won't be included
+# If an issue has multiple labels, it will be repeated
 #
+# An Issue's body should end with a '### Release Notes' section and list items to be included
+# Otherwise, they default to the issue title
+
 milestone=$1
 date=$(date +"%B %-d, %Y" | sed 's/1,/1st,/;s/2,/2nd,/;s/3,/3rd,/;s/\([0-9]\),/\1th,/')
 
@@ -17,21 +21,34 @@ echo "== Version ${milestone}"
 echo "_${date}_"
 echo ""
 echo "=== Known Issues"
-echo "=== Security"
+echo ""
 echo "=== Changed"
-echo "=== Fixed"
-echo "=== Enhancements"
-echo "=== New"
-echo "=== Internal"
 echo ""
 
+gh_issue_list() {
+    label=$1
+    header=$2
+    echo "=== $header"
+    set -o noglob # don't be globbing files in my backticks
+    
+    gh issue list --repo FusionAuth/fusionauth-issues -m $milestone -L 250 --label $label --search "sort:created-asc" --json number,body,title --jq ".[]|[.number,.body,.title] | @tsv" |
+    while IFS=$'\t' read -r number body title; do
+        generated_copy=`echo $body | awk -F'### Release Notes' '{print $2}'`
+        if [[ "${generated_copy}" == "" ]]; then
+            generated_copy=${title}
+        else
+            generated_copy=`echo $generated_copy | sed 's#\\\\r\\\\n#\n#g'`
+        fi
+        echo "* $generated_copy"
+        echo "** Resolves https://github.com/FusionAuth/fusionauth-issues/issues/$number[GitHub Issue #$number]"
+    done
+    echo ""
+}
 
-gh issue list --repo FusionAuth/fusionauth-issues -m $milestone -L 250 --search "sort:created-asc" --json number,body,title --jq ".[]|[.number,.body,.title] | @tsv" |
-while IFS=$'\t' read -r number body title; do
-  generated_title=`echo $body | awk -F'--release-notes--' '{print $2, $3}'`
-  if [[ "${generated_title}" == " " ]]; then
-    generated_title=${title}
-  fi
-  echo "* $generated_title"
-  echo "** Resolves https://github.com/FusionAuth/fusionauth-issues/issues/$number[GitHub Issue #$number]"
-done
+gh_issue_list "feature" "New"
+gh_issue_list "security" "Security"
+gh_issue_list "bug" "Fixed"
+gh_issue_list "enhancement" "Enhancements"
+gh_issue_list "internals" "Internal"
+
+echo ""


### PR DESCRIPTION
Use the issue labels for categorizing.  Some caveats:
* Issues should be labeled with exactly one of: "bug", "enhancement", "feature", "security", or "internals"
* Without one of these labels, they won't be included
* If an issue has multiple labels, it will be repeated

Use `### Release Notes` as a delimeter -- it must be last in the issue.