### PR TITLE
Fixing typos in the Golang API quickstart

### DIFF
--- a/astro/src/content/quickstarts/quickstart-golang-api.mdx
+++ b/astro/src/content/quickstarts/quickstart-golang-api.mdx
@@ -94,7 +94,7 @@ go run main.go
 You can then follow the instructions in the Run the API section started at Get a Token.
 </Aside>
 
-To create the application from scratch, make a directory for this API. 
+To create the application from scratch, make a directory for this API.
 
 ```
 mkdir your-application && cd your-application
@@ -194,7 +194,7 @@ There is a lot of code in this function. Let's break it down:
 Now, you will add the code to set the public key. This function will accept the key Id from the token and call the authorization server to get the public key with that key Id and put it in the proper format to be used.
 
 <Aside type="note">
-Different tokens can be signed with different keys. In this example there is only one key used. If the key is already set, the application will not attempt to set it again. In a production environment you could store this key on the server or set it once on initialization. If your api serves several applications, you will need to get the correct public key for each application if the signing keys are different between applications. It should also be noted that you could use [JWKS](/docs/v1/tech/oauth/endpoints#json-web-key-set-jwks), a standard for retreiving public keys, but this example uses FusionAuth's proprietary APIs.
+Different tokens can be signed with different keys. In this example there is only one key used. If the key is already set, the application will not attempt to set it again. In a production environment you could store this key on the server or set it once on initialization. If your api serves several applications, you will need to get the correct public key for each application if the signing keys are different between applications. It should also be noted that you could use [JWKS](/docs/v1/tech/oauth/endpoints#json-web-key-set-jwks), a standard for retrieving public keys, but this example uses FusionAuth's proprietary APIs.
 </Aside>
 
 <RemoteCode url={frontmatter.coderoot + "/complete-application/main.go"} tags="set-public-key"
@@ -263,7 +263,7 @@ curl --location 'http://localhost:9001/make-change?total=5.12' \
 --header 'Authorization: Bearer <your_token>'
 ```
 
-The response should look look similar to below, however it has been formatted here for readability:
+The response should look similar to below, however it has been formatted here for readability:
 
 ```json
 {
@@ -340,7 +340,7 @@ curl --location 'http://localhost:9001/make-change?total=3.24' \
 --header 'Authorization: Bearer <your_token>'
 ```
 
-The response should look look similar to below, however it has been formatted here for readability:
+The response should look similar to below, however it has been formatted here for readability:
 
 ```json
 {


### PR DESCRIPTION
I've found a few more typos in the Golang API quickstart so I fixed them.