### PR TITLE
removed flutter and .net api

### DIFF
--- a/astro/src/pages/docs/quickstarts/quickstart-sections.ts
+++ b/astro/src/pages/docs/quickstarts/quickstart-sections.ts
@@ -73,13 +73,6 @@ const qsSections: QuickStartSection[] = [
     anchorTag: 'mobile-app',
     desc: 'Mobile application that runs natively on a device',
     articles: [
-      {
-        href: '/docs/quickstarts/quickstart-flutter-native',
-        title: 'Flutter',
-        icon: '/img/icons/flutter.svg',
-        faIcon: 'fa-snake',
-        navColor: 'indigo'
-      },
     ],
   },
   {
@@ -91,13 +84,6 @@ const qsSections: QuickStartSection[] = [
     anchorTag: 'api',
     desc: 'An API or service protected by FusionAuth and access tokens',
     articles: [
-      {
-        href: '/docs/quickstarts/quickstart-dotnet-api',
-        title: '.NET Core',
-        icon: '/img/icons/dotnet-c.svg',
-        faIcon: 'fa-hashtag',
-        navColor: 'blue',
-      },
     ],
   },
   {


### PR DESCRIPTION
Fix for https://github.com/FusionAuth/fusionauth-site/issues/2631

The issue is that these were in the old docs site, but not in the blog. We decided not to port the content over because we have quickstarts in the new format already in review. When they are approved and merged, these quickstarts will show back up.