### PR TITLE
added correct URL

### DIFF
--- a/astro/src/components/nav/ComposableNav.astro
+++ b/astro/src/components/nav/ComposableNav.astro
@@ -123,7 +123,7 @@ const {sectionTitle, breadcrumbs, sectionTitleHref, categoryItems, moreItems, ca
            class="block font-semibold hover:ease-linear hover:text-indigo-500 hover:transition-colors px-5 py-4 rounded-md text-base text-white">
           Talk To An Expert
         </a>
-        <a href="/account"
+        <a href="https://account.fusionauth.io/account"
            class="block font-semibold hover:ease-linear hover:text-indigo-500 hover:transition-colors px-5 mb-4 rounded-md text-base text-white">
           Login
         </a>


### PR DESCRIPTION
This was previously pointing to a URL that 404ed.

```
There's a weird issue on the header across all pages that is causing the link checker to freak out. There's a hidden node. Not sure why it is there.

Anyway, it references /account which 404s. Can we either remove this section (if it isn't needed) or have the Login link point to https://account.fusionauth.com/account
<div class="lg:hidden"><a href="/contact" class="block font-semibold text-white hover:ease-linear hover:text-indigo-500 hover:transition-colors text-base px-5 rounded-md py-4">Talk To An Expert </a><a href="/account" class="block font-semibold text-white hover:ease-linear hover:text-indigo-500 hover:transition-colors text-base px-5 rounded-md mb-4">Login</a></div>
Easiest way to find this is to inspect any page (I looked here: https://fusionauth.io/articles/ ) and then search for account. You'll see that string two times, one for the visible Login button which goes to the correct URL, the other which is in the above hidden div.
```