### PR TITLE
Creating scripts to run Astro in Docker

### DIFF
--- a/astro/.dockerignore
+++ b/astro/.dockerignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/astro/Dockerfile
+++ b/astro/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+RUN apk --no-cache update && \
+    apk --no-cache add chromium
+
+COPY ["package.json", "package-lock.json", "./"]
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/astro/run-docker
+++ b/astro/run-docker
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+cd $(dirname "$0")
+
+IMAGE_NAME="fusionauth-site:latest"
+PORT=${1:-3000}
+
+# Building image
+if [ "$(docker images -q "${IMAGE_NAME}" 2> /dev/null)" = "" ]; then
+    docker build -t "${IMAGE_NAME}" .
+fi
+
+# Running docker
+CID=$(docker run --rm -q -d -v "${PWD}:/app" -p "${PORT}:3000" "${IMAGE_NAME}")
+echo "Started Astro container on http://localhost:${PORT}"
+echo "If you want to see the logs, run:"
+echo "docker logs -f ${CID}"


### PR DESCRIPTION
Created a `run-docker` script to run Astro inside a Docker container.

By default, it publishes local port 3000, so you can browse to `localhost:3000`. If you want to use another port, pass it as an argument, e.g. `./run-docker 8000` to use port 8000.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205885518617332