### PR TITLE
Update APIs for missing content from migration

### DIFF
--- a/astro/src/content/docs/apis/entities/_entity-grant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/entities/_entity-grant-response-body-base.mdx
@@ -10,6 +10,9 @@ import JSON from 'src/components/JSON.astro';
   <APIField name={props.base_field_name + ".data"} type="Object">
     An object that can hold any information about the Grant that should be persisted.
   </APIField>
+  <APIField name={props.base_field_name + ".entity"} type="Object">
+    The Entity to which access is granted. See the [Entity API](/docs/apis/entities/entities) for property definitions and example JSON.
+  </APIField>
   <APIField name={props.base_field_name + ".id"} type="UUID">
     The unique Id of the Grant.
   </APIField>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/jwt-public-key-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/jwt-public-key-update.mdx
@@ -38,4 +38,8 @@ export const eventType = 'jwt.public-key.update';
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 
+  <APIField slot="trailing-fields" name="event.type" type="String">
+    The event type, this value will always be <code>{eventType}</code>.
+  </APIField>
+
 </EventBody>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/jwt-refresh.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/jwt-refresh.mdx
@@ -53,7 +53,7 @@ export const eventType = 'jwt.refresh';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.userId" type="UUID">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/kickstart-success.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/kickstart-success.mdx
@@ -36,7 +36,7 @@ export const eventType = 'kickstart.success';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
 </EventBody>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-actions.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-actions.mdx
@@ -122,7 +122,7 @@ A temporal action is one that has a start time and and a duration. When a phase 
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 </EventBody>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-bulk-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-bulk-create.mdx
@@ -37,7 +37,7 @@ export const eventType = 'user.bulk.create';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.users" type="Array<Object>">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-bulk-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-bulk-create.mdx
@@ -32,7 +32,7 @@ export const eventType = 'user.bulk.create';
     The unique Id of the event. You may receive an event more than once based upon your transaction settings. This Id may be used to identify a duplicate event.
   </APIField>
 
-  <APIField slot="custom-fields" name="event.tenantId" type="UUID" since="1.8.0">
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-create-complete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-create-complete.mdx
@@ -36,10 +36,6 @@ export const eventType = 'user.create.complete';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.tenantId" type="UUID">
-    The unique tenant identifier. This value may not be returned if not applicable.a
-  </APIField>
-
-  <APIField slot="trailing-fields" name="event.tenantId" type="UUID">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-create-complete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-create-complete.mdx
@@ -36,6 +36,10 @@ export const eventType = 'user.create.complete';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.tenantId" type="UUID">
+    The unique tenant identifier. This value may not be returned if not applicable.a
+  </APIField>
+
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-create-complete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-create-complete.mdx
@@ -44,7 +44,7 @@ export const eventType = 'user.create.complete';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-create.mdx
@@ -40,7 +40,7 @@ export const eventType = 'user.create';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-create.mdx
@@ -35,7 +35,7 @@ export const eventType = 'user.create';
     The unique Id of the event.
   </APIField>
 
-  <APIField slot="custom-fields" name="event.tenantId" type="UUID" since="1.8.0">
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-deactivate.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-deactivate.mdx
@@ -37,7 +37,7 @@ export const eventType = 'user.deactivate';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-deactivate.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-deactivate.mdx
@@ -32,7 +32,7 @@ export const eventType = 'user.deactivate';
     The unique Id of the event. You may receive an event more than once based upon your transaction settings. This Id may be used to identify a duplicate event.
   </APIField>
 
-  <APIField slot="custom-fields" name="event.tenantId" type="UUID" since="1.8.0">
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-delete-complete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-delete-complete.mdx
@@ -38,7 +38,7 @@ This event is only generated after a `user.delete` transaction has completed.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-delete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-delete.mdx
@@ -32,7 +32,7 @@ export const eventType = 'user.delete';
     The unique Id of the event. You may receive an event more than once based upon your transaction settings. This Id may be used to identify a duplicate event.
   </APIField>
 
-  <APIField slot="custom-fields" name="event.tenantId" type="UUID" since="1.8.0">
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-delete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-delete.mdx
@@ -37,7 +37,7 @@ export const eventType = 'user.delete';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-email-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-email-update.mdx
@@ -40,7 +40,7 @@ export const eventType = 'user.email.update';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-email-verified.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-email-verified.mdx
@@ -38,7 +38,7 @@ export const eventType = 'user.email.verified';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-identity-provider-link.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-identity-provider-link.mdx
@@ -42,7 +42,7 @@ export const eventType = 'user.identity-provider.link';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="User">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-identity-provider-unlink.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-identity-provider-unlink.mdx
@@ -40,7 +40,7 @@ export const eventType = 'user.identity-provider.unlink';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="User">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
@@ -52,7 +52,7 @@ export const eventType = 'user.login.failed';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
@@ -47,7 +47,7 @@ export const eventType = 'user.login.failed';
     Moved to <InlineField>event.info</InlineField> in 1.30.0
   </APIField>
 
-  <APIField slot="custom-fields" name="event.tenantId" type="UUID" since="1.8.0">
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-create.mdx
@@ -51,7 +51,7 @@ export const eventType = 'user.loginId.duplicate.create';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-update.mdx
@@ -51,7 +51,7 @@ export const eventType = 'user.loginId.duplicate.update';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-new-device.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-new-device.mdx
@@ -60,8 +60,9 @@ export const eventType = 'user.login.new-device';
   </APIField>
 
   <APIField slot="leading-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
+
   <APIField slot="leading-fields" name="event.user" type="Object">
     The user that completed the login request. See the [Users API](/docs/apis/users) for property definitions and example JSON
   </APIField>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-success.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-success.mdx
@@ -59,7 +59,7 @@ export const eventType = 'user.login.success';
     Moved to <InlineField>event.info</InlineField> in 1.30.0
   </APIField>
 
-  <APIField slot="custom-fields" name="event.tenantId" type="UUID" since="1.8.0">
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-success.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-success.mdx
@@ -64,7 +64,7 @@ export const eventType = 'user.login.success';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-suspicious.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-suspicious.mdx
@@ -67,7 +67,7 @@ export const eventType = 'user.login.suspicious';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-password-breach.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-password-breach.mdx
@@ -40,7 +40,7 @@ export const eventType = 'user.password.breach';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-password-reset-send.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-password-reset-send.mdx
@@ -38,7 +38,7 @@ export const eventType = 'user.password.reset.send';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-password-reset-start.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-password-reset-start.mdx
@@ -38,7 +38,7 @@ export const eventType = 'user.password.reset.start';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-password-reset-success.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-password-reset-success.mdx
@@ -38,7 +38,7 @@ export const eventType = 'user.password.reset.success';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-password-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-password-update.mdx
@@ -25,11 +25,11 @@ export const eventType = 'user.password.update';
 <EventBody eventType={eventType}
            jsonFile="user-password-update.json">
 
-  <APIField name="event.createInstant" type="Long">
+  <APIField slot="leading-fields" name="event.createInstant" type="Long">
     The [instant](/docs/reference/data-types#instants) that the event was generated.
   </APIField>
 
-  <APIField name="event.id" type="UUID">
+  <APIField slot="leading-fields" name="event.id" type="UUID">
     The unique Id of the event. You may receive an event more than once based upon your transaction settings. This Id may be used to identify a duplicate event.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-password-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-password-update.mdx
@@ -38,7 +38,7 @@ export const eventType = 'user.password.update';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-reactivate.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-reactivate.mdx
@@ -38,7 +38,7 @@ export const eventType = 'user.reactivate';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-reactivate.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-reactivate.mdx
@@ -33,7 +33,7 @@ export const eventType = 'user.reactivate';
     The unique Id of the event. You may receive an event more than once based upon your transaction settings. This Id may be used to identify a duplicate event.
   </APIField>
 
-  <APIField slot="custom-fields" name="event.tenantId" type="UUID" since="1.8.0">
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-create-complete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-create-complete.mdx
@@ -45,7 +45,7 @@ export const eventType = 'user.registration.create.complete';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-create.mdx
@@ -50,7 +50,7 @@ export const eventType = 'user.registration.create';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-delete-complete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-delete-complete.mdx
@@ -45,7 +45,7 @@ export const eventType = 'user.registration.delete.complete';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-delete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-delete.mdx
@@ -47,7 +47,7 @@ export const eventType = 'user.registration.delete';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-update-complete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-update-complete.mdx
@@ -51,7 +51,7 @@ This event is only generated after a `user.registration.update` transaction has 
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-update.mdx
@@ -51,7 +51,7 @@ export const eventType = 'user.registration.update';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-verified.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-registration-verified.mdx
@@ -47,7 +47,7 @@ export const eventType = 'user.registration.verified';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-two-factor-method-add.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-two-factor-method-add.mdx
@@ -40,7 +40,7 @@ export const eventType = 'user.two-factor.method.add';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-two-factor-method-remove.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-two-factor-method-remove.mdx
@@ -39,7 +39,7 @@ export const eventType = 'user.two-factor.method.remove';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-update-complete.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-update-complete.mdx
@@ -41,7 +41,7 @@ export const eventType = 'user.update.complete';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-update.mdx
@@ -47,7 +47,7 @@ export const eventType = 'user.update';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be `{type}`.
+    The event type, this value will always be <code>{eventType}</code>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">


### PR DESCRIPTION
We missed a few fields in the migration. This corrects them.