### PR TITLE
Add release nicknames v2

### DIFF
--- a/astro/src/components/docs/release-notes/ReleaseNoteHeading.astro
+++ b/astro/src/components/docs/release-notes/ReleaseNoteHeading.astro
@@ -1,9 +1,9 @@
 ---
 import { refCase } from 'src/tools/string/refCase';
 
-const { version, releaseDate } = Astro.props;
+const { version, releaseDate, name } = Astro.props;
 ---
 
-<h2 id={`version-${version.replaceAll('.', '-').replaceAll(' ', '-').toLowerCase()}`} class="release-note mb-2">Version {version}</h2>
+<h2 id={`version-${version.replaceAll('.', '-').replaceAll(' ', '-').toLowerCase()}`} class="release-note mb-2">Version {version}{ name !== undefined ? " - " + name : ""} </h2>
 <p class="italic">{ releaseDate}</p>
 

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -25,7 +25,7 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
   * Resolves [GitHub Issue #2535](https://github.com/FusionAuth/fusionauth-issues/issues/2535)
 
 
-<ReleaseNoteHeading version="1.48.0" releaseDate="October 27th, 2023" />
+<ReleaseNoteHeading version="1.48.0" releaseDate="October 27th, 2023" name="Webhook Walrus" />
 
 <DatabaseMigrationWarning/>
 
@@ -134,7 +134,7 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
  * Resolves [GitHub Issue #2392](https://github.com/FusionAuth/fusionauth-issues/issues/2392), thanks to [@pigletto](https://github.com/pigletto) and [@patricknwn](https://github.com/patricknwn) for reporting.
 
 
-<ReleaseNoteHeading version="1.47.0" releaseDate="July 25th, 2023" />
+<ReleaseNoteHeading version="1.47.0" releaseDate="July 25th, 2023" name="Performance Panther" />
 
 <GeneralMigrationWarning >
 Please be sure to read the notes in the **Changed** section before upgrading.

--- a/astro/src/tools/docs/getReleaseNoteRssItems.ts
+++ b/astro/src/tools/docs/getReleaseNoteRssItems.ts
@@ -6,7 +6,7 @@ export const getReleaseNoteRssItems = async () => {
   const releaseLines = releaseNotes.body.split("\n");
   const archiveLines = archive.body.split("\n");
   const lines = [...releaseLines, ...archiveLines];
-  const items = lines.map(line => line.match(/ReleaseNoteHeading version="(.*)" releaseDate="(.*)"/))
+  const items = lines.map(line => line.match(/ReleaseNoteHeading version="([^"]*)" releaseDate="([^"]*)"/))
       .filter(line => !!line)
       .map(match => ({version: match[1], date: match[2]}))
       .map(version => ({


### PR DESCRIPTION
This fixes the issue that caused us to need #2652 . 

Basically, the regular expression was too greedy and picked up the nicknames. Then it tried to parse the string including the nickname as a date, which failed. This caused the RSS feed generation to fail.

