### PR TITLE
Redirecting old Laravel API tutorial to the new quickstart page

### DIFF
--- a/src/redirects.json
+++ b/src/redirects.json
@@ -396,6 +396,7 @@
     "/docs/v1/tech/tutorials/integrate-angular": "/docs/quickstarts/quickstart-javascript-angular-web",
     "/docs/v1/tech/tutorials/integrate-dotnet": "/docs/quickstarts/quickstart-dotnet-web",
     "/docs/v1/tech/tutorials/integrate-java-spring": "/docs/quickstarts/quickstart-springboot-web",
+    "/docs/v1/tech/tutorials/integrate-laravel-api": "/docs/quickstarts/quickstart-php-laravel-api",
     "/docs/v1/tech/tutorials/integrate-python-django": "/docs/quickstarts/quickstart-python-django-web",
     "/docs/v1/tech/tutorials/integrate-python-flask": "/docs/quickstarts/quickstart-python-flask-web",
     "/docs/v1/tech/tutorials/integrate-react": "/docs/quickstarts/quickstart-javascript-react-web",


### PR DESCRIPTION
Refs #2608

Redirecting old `/docs/v1/tech/tutorials/integrate-laravel-api` tutorial to [the new quickstart page](https://fusionauth.io/docs/quickstarts/quickstart-php-laravel-api).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205821059550207