### PR TITLE
update identity provider links doc

### DIFF
--- a/astro/src/content/docs/apis/identity-providers/_link-response-body-base.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_link-response-body-base.mdx
@@ -18,11 +18,11 @@ import InlineField from 'src/components/InlineField.astro';
   <APIField name={ props.base_field_name + ".identityProviderName" } type="String" since="1.47.0">
     The name of the identity provider.
   </APIField>
-  <APIField name={ props.base_field_name + ".identityProviderType" } type="String" since="1.47.0">
+  <APIField name={ props.base_field_name + ".identityProviderType" } type="String" since="1.46.0">
     The type of the identity provider.
   </APIField>
   <APIField name={ props.base_field_name + ".identityProviderUserId" } type="String">
-    The unique user Id in the 3rd party identity provider. Ideally this value never changes and will always uniquely identify the user in the third party identity provider.
+    The unique user Id in the third party identity provider. Ideally this value never changes and will always uniquely identify the user in the third party identity provider.
   </APIField>
   <APIField name={ props.base_field_name + ".insertInstant" } type="Long">
     The [instant](/docs/reference/data-types#instants) that the Link was created.
@@ -30,7 +30,7 @@ import InlineField from 'src/components/InlineField.astro';
   <APIField name={ props.base_field_name + ".lastLoginInstant" } type="Long">
     The [instant](/docs/reference/data-types#instants) when the User logged in last with this identity provider using this link.
   </APIField>
-  <APIField name={ props.base_field_name + ".tenantId" } type="Long">
+  <APIField name={ props.base_field_name + ".tenantId" } type="UUID">
     The Id of the Tenant that this User belongs to.
   </APIField>
   <APIField name={ props.base_field_name + ".token" } type="String">

--- a/astro/src/content/docs/apis/identity-providers/_link-response-body-base.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_link-response-body-base.mdx
@@ -15,31 +15,31 @@ import InlineField from 'src/components/InlineField.astro';
   <APIField name={ props.base_field_name + ".identityProviderId" } type="UUID">
     The unique Id of the identity provider.
   </APIField>
-  <APIField name={ props.base_field_name + ".identityProviderType" } type="String" since="1.47.0">
+  <APIField name={ props.base_field_name + ".identityProviderName" } type="String" since="1.47.0">
     The name of the identity provider.
   </APIField>
-  <APIField name={ props.base_field_name + ".identityProviderUserId" } type="String">
+  <APIField name={ props.base_field_name + ".identityProviderType" } type="String" since="1.47.0">
     The type of the identity provider.
   </APIField>
-  <APIField name={ props.base_field_name + ".insertInstant" } type="String">
-    The unique user Id in the 3rd party identity provider. Ideally this value never changes and will always uniquely identify the user in the 3rd party identity provider.
+  <APIField name={ props.base_field_name + ".identityProviderUserId" } type="String">
+    The unique user Id in the 3rd party identity provider. Ideally this value never changes and will always uniquely identify the user in the third party identity provider.
   </APIField>
-  <APIField name={ props.base_field_name + ".lastLoginInstant" } type="Long">
+  <APIField name={ props.base_field_name + ".insertInstant" } type="Long">
     The [instant](/docs/reference/data-types#instants) that the Link was created.
   </APIField>
-  <APIField name={ props.base_field_name + ".tenantId" } type="Long">
+  <APIField name={ props.base_field_name + ".lastLoginInstant" } type="Long">
     The [instant](/docs/reference/data-types#instants) when the User logged in last with this identity provider using this link.
   </APIField>
-  <APIField name={ props.base_field_name + ".token" } type="UUID">
+  <APIField name={ props.base_field_name + ".tenantId" } type="Long">
     The Id of the Tenant that this User belongs to.
   </APIField>
-  <APIField type="String">
+  <APIField name={ props.base_field_name + ".token" } type="String">
     The token returned from the identity provider. This is treated as an opaque token as the type varies by identity provider, this value may not be returned by all identity providers. When provided, this token is typically a long lived access or refresh token, but consult individual identity provider documentation for specifics.
 
     **Note:**
     Prior to version `1.28.0`, this value can be retrieved using the [User Registration APIs](/docs/apis/registrations) using the <InlineField>registration.token</InlineField> field.
   </APIField>
-  <APIField type="UUID">
+  <APIField name={ props.base_field_name + ".userId" } type="UUID">
     The FusionAuth User Id that is linked to the identity provider.
   </APIField>
 </APIBlock>

--- a/astro/src/content/docs/apis/identity-providers/_links-post-response-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_links-post-response-body.mdx
@@ -22,9 +22,6 @@ import JSON from 'src/components/JSON.astro';
   <APIField name="identityProviderLink.identityProviderUserId" type="String">
     The Id for the User that is provided by the identity provider.
   </APIField>
-  <APIField name="identityProviderLink.userId" type="UUID">
-    The unique Id of the FusionAuth User that is being linked to the identity provider.
-  </APIField>
   <APIField name="identityProviderLink.insertInstant" type="Long">
     The [instant](/docs/reference/data-types#instants) the Link was created.
   </APIField>

--- a/astro/src/content/json/identity-providers/links/response.json
+++ b/astro/src/content/json/identity-providers/links/response.json
@@ -2,6 +2,8 @@
   "identityProviderLink": {
     "displayName": "richard@piedpiper.com",
     "identityProviderId": "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
+    "identityProviderType": "OpenIDConnect",
+    "identityProviderUserId": "42",
     "identityProviderUserId": "42",
     "insertInstant": 1623183147998,
     "lastLoginInstant": 1623183152224,

--- a/astro/src/content/json/identity-providers/links/response.json
+++ b/astro/src/content/json/identity-providers/links/response.json
@@ -2,8 +2,8 @@
   "identityProviderLink": {
     "displayName": "richard@piedpiper.com",
     "identityProviderId": "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
+    "identityProviderName": "My OpenIDConnect Identity Provider",
     "identityProviderType": "OpenIDConnect",
-    "identityProviderUserId": "42",
     "identityProviderUserId": "42",
     "insertInstant": 1623183147998,
     "lastLoginInstant": 1623183152224,

--- a/astro/src/content/json/identity-providers/links/responses.json
+++ b/astro/src/content/json/identity-providers/links/responses.json
@@ -3,6 +3,8 @@
     {
       "displayName": "richard@piedpiper.com",
       "identityProviderId": "f50dbb83-4cc2-4e5e-aece-9efe068bddd9",
+      "identityProviderName": "My OpenIDConnect Identity Provider",
+      "identityProviderType": "OpenIDConnect",
       "identityProviderUserId": "42",
       "insertInstant": 1623183147998,
       "lastLoginInstant": 1623183152224,
@@ -13,6 +15,8 @@
     {
       "displayName": "richard@hooli.com",
       "identityProviderId": "363ae8d9-dd4d-4473-bdc6-3694f1d0329e",
+      "identityProviderName": "Another OpenIDConnect Identity Provider",
+      "identityProviderType": "OpenIDConnect",
       "identityProviderUserId": "9821123",
       "insertInstant": 1623183147998,
       "lastLoginInstant": 1623183152225,


### PR DESCRIPTION
The doc was a bit messed up.

* the identity provider type and name fields were missing from the sample json
* the links response fields were a bit hosed from the migration

One thing, I think that the  identity provider type and name fields were added in 1.47 based on this: https://github.com/FusionAuth/fusionauth-java-client/blame/master/src/main/java/io/fusionauth/domain/IdentityProviderLink.java but it wasn't mentioned in the release notes that I saw.