### PR TITLE
Fixing bad variables interpolation in Astro templates

### DIFF
--- a/astro/src/content/docs/_shared/_securing_http_requests.mdx
+++ b/astro/src/content/docs/_shared/_securing_http_requests.mdx
@@ -40,7 +40,7 @@ Providing this certificate will build a custom SSL context for requests made for
 ### Firewalls
 In addition to using TLS and a security header, you might also want to put a firewall in front of your {props.request_entity}. In most cases, this firewall will only allow traffic to your {props.request_entity} that originated from your FusionAuth instance. Depending on how you are hosting your {props.request_entity}, you might be able to lock down the URL for your {props.request_entity} specifically. You might also leverage an API gateway or a proxy to ensure that only traffic coming from FusionAuth is routed to your {props.request_entity}. The exact specifics of deploying and configuring a Firewall are outside the scope of this document, but you can consult the documentation for your proxy, API Gateway or hosting provider to determine how to manage it.
 
-As an example, you can configure an AWS Application Load Balancer so that traffic coming from the IP address of your FusionAuth servers with a URL of `https://apis.mycompany.com/fusionauth-{props.request_entity_lc}` is routed through. You can then configure the Application Load Balancer so that all other traffic to that URL is rejected.
+As an example, you can configure an AWS Application Load Balancer so that traffic coming from the IP address of your FusionAuth servers with a URL of <code>{`https://apis.mycompany.com/fusionauth-${props.request_entity_lc}`}</code> is routed through. You can then configure the Application Load Balancer so that all other traffic to that URL is rejected.
 
 ### Controlling Traffic with a Proxy
 

--- a/astro/src/content/docs/lifecycle/migrate-users/bulk/_create-test-application.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/bulk/_create-test-application.mdx
@@ -1,7 +1,7 @@
 import InlineUIElement from 'src/components/InlineUIElement.astro';
 import InlineField from 'src/components/InlineField.astro';
 
-Applications are anything a user can log in to. In FusionAuth there's no differentiation between web applications, SaaS applications, APIs and native apps. To add an application, navigate to <strong>Applications</strong> and click on the <InlineUIElement>Add</InlineUIElement> button (the green plus sign). Give the application a descriptive name like `{props.migration_source_name} application`.
+Applications are anything a user can log in to. In FusionAuth there's no differentiation between web applications, SaaS applications, APIs and native apps. To add an application, navigate to <strong>Applications</strong> and click on the <InlineUIElement>Add</InlineUIElement> button (the green plus sign). Give the application a descriptive name like <code>{props.migration_source_name} application</code>.
 
 Select your new tenant, created above, in the dropdown for the <InlineField>Tenant</InlineField> field.
 

--- a/astro/src/content/docs/lifecycle/migrate-users/bulk/_create-test-tenant.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/bulk/_create-test-tenant.mdx
@@ -7,11 +7,11 @@ It is best to create a separate tenant for migration testing. Tenants logically 
 
 <img src={`/img/docs/lifecycle/migrate-users/bulk/${props.migration_source_dir}/list-of-tenants-add-highlighted.png`} alt="Adding a tenant." width="1200" role="bottom-cropped" />
 
-Give it a descriptive <InlineField>Name</InlineField> like `{props.migration_source_name} import test`. You shouldn't need to modify any of the other configuration options to test importing users.
+Give it a descriptive <InlineField>Name</InlineField> like <code>{props.migration_source_name} import test</code>. You shouldn't need to modify any of the other configuration options to test importing users.
 
 Save the tenant.
 
-<img src={`/img/docs/lifecycle/migrate-users/bulk/${props.migration_source_dir}/add-tenant.png`} alt="The tenant creation screen." width="1200" role="{props.add-tenant-image-role}" />
+<img src={`/img/docs/lifecycle/migrate-users/bulk/${props.migration_source_dir}/add-tenant.png`} alt="The tenant creation screen." width="1200" role={props.add_tenant_image_role} />
 
 Record the Id of the tenant, which will be a UUID. It will look something like `25c9d123-8a79-4edd-9f76-8dd9c806b0f3`. You'll use this later.
 

--- a/astro/src/content/docs/lifecycle/migrate-users/bulk/_get-script.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/bulk/_get-script.mdx
@@ -1,12 +1,12 @@
+import {Code} from 'astro/components';
+
 FusionAuth provides an import script under a permissive open source license. It requires ruby (tested with ruby 2.7). To get the script, clone the git repository:
 
 ```shell title="Getting the import scripts"
 git clone https://github.com/FusionAuth/fusionauth-import-scripts
 ```
 
-Navigate to the `{props.migration_source_dir}` directory:
+Navigate to the <code>{props.migration_source_dir}</code> directory:
 
-```shell title="Navigate to the correct directory"
-cd fusionauth-import-scripts/{props.migration_source_dir}
-```
+<Code lang="shell" code={`cd fusionauth-import-scripts/${props.migration_source_dir}`}/>
 


### PR DESCRIPTION
@mark-robustelli realized that we have some components that aren't handling variables interpolation pretty well, rendering things like this:

![image](https://github.com/FusionAuth/fusionauth-site/assets/1877191/c6f81f19-aa83-4b90-a147-985f80c4f733)

# One backtick

We can't use variables inside backticks like this:

```mdx
`{props.migration_source_name} application`
```

We need to use `<code>` from standard HTML instead:

```mdx
<code>{props.migration_source_name} application</code>
```

# Three backticks

Instead of the 3 backticks:

    ```shell
    cd fusionauth-import-scripts/{props.migration_source_dir}
    ```

You'd need to use Astro's Code component:

```mdx
<Code lang="shell" code={`cd fusionauth-import-scripts/${props.migration_source_dir}`}/>
```

# Headers

We also may have to change the way we create headers. For instance, in [`_oauth-idp-operations.mdx`](https://github.com/FusionAuth/fusionauth-site/blob/master/astro/src/content/docs/apis/identity-providers/_oauth-idp-operations.mdx#L48), we have a header like:

```mdx
## Create the {props.idp_display_name} Identity Provider
```

Even though it renders the text correctly, the Id for the heading is wrong: https://fusionauth.io/docs/apis/identity-providers/google#create-the-propsidp_display_name-identity-provider

It looks more like an Astro bug though, so I'll open an issue against their repo.