### PR TITLE
Fixing `<RemoteCode>` trimming last lines

### DIFF
--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -15,7 +15,7 @@
 				"@astrojs/tailwind": "^5.0.2",
 				"@docsearch/js": "^3.3.3",
 				"@docsearch/react": "^3.3.3",
-				"@fusionauth/astro-components": "^1.1.0",
+				"@fusionauth/astro-components": "^1.1.1",
 				"@tailwindcss/typography": "^0.5.9",
 				"astro": "^3.2.4",
 				"astro-compress": "^2.0.8",
@@ -1055,9 +1055,9 @@
 			}
 		},
 		"node_modules/@fusionauth/astro-components": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@fusionauth/astro-components/-/astro-components-1.1.0.tgz",
-			"integrity": "sha512-die5tm9OvGyjrGLnSqIUTNOZg3kgEHVWnVu9re7I3nfP1zfNRE9pLDNgHrBmomOrJcLGVVL5Mcj/hCyoMQxdhA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fusionauth/astro-components/-/astro-components-1.1.1.tgz",
+			"integrity": "sha512-7BA9yOJ9Yp/FvSMVCs8eff2Hsm7ohJ5oPrQN5F6KT7i+91U2iYStErFFkKaAPs4AOySuGpcFrhqrOB4NPjbjGQ==",
 			"dependencies": {
 				"jsonpath-plus": "^7.2.0"
 			},

--- a/astro/package.json
+++ b/astro/package.json
@@ -19,7 +19,7 @@
 		"@astrojs/tailwind": "^5.0.2",
 		"@docsearch/js": "^3.3.3",
 		"@docsearch/react": "^3.3.3",
-		"@fusionauth/astro-components": "^1.1.0",
+		"@fusionauth/astro-components": "^1.1.1",
 		"@tailwindcss/typography": "^0.5.9",
 		"astro": "^3.2.4",
 		"astro-compress": "^2.0.8",


### PR DESCRIPTION
Due to a bad conversion to String, the `<RemoteCode>` component was trying to extract tags from the file, thus trimming the last line.

This was fixed on https://github.com/FusionAuth/fusionauth-astro-components/commit/05b310a5cb65f0f6274485b63efe5f60c2818b53.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205962906117820