### PR TITLE
Fix 404 on Kafka docs

### DIFF
--- a/src/redirects.json
+++ b/src/redirects.json
@@ -495,7 +495,6 @@
     "/docs/extend/code/password-hashes/": true,
     "/docs/extend/events-and-webhooks/": true,
     "/docs/extend/events-and-webhooks/events/": true,
-    "/docs/extend/events-and-webhooks/kafka/": true,
     "/docs/extend/examples/": true,
     "/docs/extend/examples/api-gateways/": true,
     "/docs/get-started/": true,


### PR DESCRIPTION
https://fusionauth.io/docs/extend/events-and-webhooks/kafka/ is returning 404, causing the [link check workflow](https://github.com/FusionAuth/fusionauth-site/blob/master/.github/workflows/linkcheck.yml) to fail.

I tested it locally using the code Andy sent me for the Lambda redirect handler.

I also synced the `development` branch my moving `src/content/docs/extend/events-and-webhooks/kafka/kafka.mdx` to `src/content/docs/extend/events-and-webhooks/kafka/index.mdx` at https://github.com/FusionAuth/fusionauth-site/commit/71b53f673bcc3f4bd7e30672f62281e489eb840b