### PR TITLE
Fix link in the Dotnet API quickstart

### DIFF
--- a/astro/src/content/quickstarts/quickstart-dotnet-api.mdx
+++ b/astro/src/content/quickstarts/quickstart-dotnet-api.mdx
@@ -96,7 +96,7 @@ cd complete-application
 dotnet run
 ```
 
-You can then follow the instructions in the [Run The API](./#run-the-api) section.
+You can then follow the instructions in the [Run The API](#run-the-api) section.
 </Aside>
 
 Now, create a base ASP.NET API project. 


### PR DESCRIPTION
Fixing link in the Dotnet API quickstart which was causing an error with the linkcheck workflow:

> https://fusionauth.io/docs/quickstarts/quickstart-dotnet-api
> - (3:193) 'Run The ..' => https://fusionauth.io/docs/quickstarts/#run-the-api (HTTP 200 but missing anchor)
> - (3:193) 'Run The ..' => https://fusionauth.io/docs/quickstarts/#run-the-api (HTTP 200 but missing anchor)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206058779054199