### PR TITLE
Fixing bad import in the TypeScript SDK doc

### DIFF
--- a/astro/src/content/docs/sdks/typescript.mdx
+++ b/astro/src/content/docs/sdks/typescript.mdx
@@ -50,7 +50,7 @@ The following examples all use `retrieveUserByEmail` as a basic use case of Fusi
 #### NodeJS
 
 ```typescript
-import {FusionAuthClient} from 'FusionAuthClient'
+import {FusionAuthClient} from '@fusionauth/typescript-client';
 const client = new FusionAuthClient('bf69486b-4733-4470-a592-f1bfce7af580', 'https://local.fusionauth.io');
 client.retrieveUserByEmail('user@example.com')
       .then(clientResponse => {


### PR DESCRIPTION
Credits to **Ákos K** on the FusionAuth Slack for pointing a bad import in the TypeScript docs.

https://fusionauth.slack.com/archives/CG00HG935/p1701273820418569