### PR TITLE
fix for busted 'id' field defn in response

### DIFF
--- a/astro/src/content/docs/apis/_tenant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_tenant-response-body-base.mdx
@@ -304,7 +304,9 @@ import JSON from 'src/components/JSON.astro';
 
   <APIField name={props.base_field_name + '.httpSessionMaxInactiveInterval'} type="Integer" since="1.8.0">
     Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
-    <InlineField>{props.base_field_name}.id</InlineField> [type]#[UUID]#::
+  </APIField>
+
+  <APIField name={props.base_field_name + '.id'} type="UUID">
     The unique identifier for this Tenant.
   </APIField>
 


### PR DESCRIPTION
The `tenant.id` field was not properly displayed in the response.