### PR TITLE
Remove API suffix, use plural consistently for APIs and remove / before the ? from the WebAuthN API URIs

### DIFF
--- a/astro/src/content/docs/apis/actioning-users.mdx
+++ b/astro/src/content/docs/apis/actioning-users.mdx
@@ -1,5 +1,5 @@
 ---
-title: Actioning Users APIs
+title: Actioning Users
 description: Learn about the APIs for invoking a User Action on a User.
 section: apis
 ---

--- a/astro/src/content/docs/apis/api-keys.mdx
+++ b/astro/src/content/docs/apis/api-keys.mdx
@@ -1,5 +1,5 @@
 ---
-title: API Key APIs
+title: API Keys
 description: Learn about the APIs for creating, retrieving, updating and deleting API Keys.
 section: apis
 ---

--- a/astro/src/content/docs/apis/applications.mdx
+++ b/astro/src/content/docs/apis/applications.mdx
@@ -1,5 +1,5 @@
 ---
-title: Application APIs
+title: Applications
 description: Learn about the APIs for creating, retrieving, updating and deleting Applications.
 section: apis
 ---

--- a/astro/src/content/docs/apis/audit-logs.mdx
+++ b/astro/src/content/docs/apis/audit-logs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Audit Logs APIs
+title: Audit Logs
 description: Learn about the APIs for adding entries to, searching, and exporting the audit log.
 section: apis
 ---

--- a/astro/src/content/docs/apis/connectors/generic.mdx
+++ b/astro/src/content/docs/apis/connectors/generic.mdx
@@ -1,5 +1,5 @@
 ---
-title: Generic Connector APIs
+title: Generic Connector
 description: Learn about the APIs for creating, retrieving, and updating Generic Connectors.
 section: apis
 subcategory: connectors

--- a/astro/src/content/docs/apis/connectors/index.mdx
+++ b/astro/src/content/docs/apis/connectors/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Connector API Overview
+title: Overview
 description: Learn about the APIs for creating, retrieving, updating and deleting identity providers.
 section: apis
 subcategory: connectors

--- a/astro/src/content/docs/apis/connectors/ldap.mdx
+++ b/astro/src/content/docs/apis/connectors/ldap.mdx
@@ -1,5 +1,5 @@
 ---
-title: LDAP Connector APIs
+title: LDAP Connector
 description: Learn about the APIs for creating, retrieving, and updating LDAP Connectors.
 section: apis
 subcategory: connectors

--- a/astro/src/content/docs/apis/consents.mdx
+++ b/astro/src/content/docs/apis/consents.mdx
@@ -1,5 +1,5 @@
 ---
-title: Consent APIs
+title: Consents
 description: Learn about the APIs for creating, retrieving, updating and deleting consents.
 section: apis
 ---

--- a/astro/src/content/docs/apis/custom-forms/form-fields.mdx
+++ b/astro/src/content/docs/apis/custom-forms/form-fields.mdx
@@ -1,5 +1,5 @@
 ---
-title: Form Field APIs
+title: Form Fields
 description: Learn about the APIs for creating, retrieving, updating and deleting form fields.
 section: apis
 subcategory: custom forms

--- a/astro/src/content/docs/apis/custom-forms/forms.mdx
+++ b/astro/src/content/docs/apis/custom-forms/forms.mdx
@@ -1,5 +1,5 @@
 ---
-title: Form APIs
+title: Forms
 description: Learn about the APIs for creating, retrieving, updating and deleting forms.
 section: apis
 subcategory: custom forms

--- a/astro/src/content/docs/apis/emails.mdx
+++ b/astro/src/content/docs/apis/emails.mdx
@@ -1,5 +1,5 @@
 ---
-title: Email APIs
+title: Emails
 description: Learn about the APIs for creating, retrieving, updating and deleting email templates as well as sending emails to users.
 section: apis
 ---

--- a/astro/src/content/docs/apis/entities/entities.mdx
+++ b/astro/src/content/docs/apis/entities/entities.mdx
@@ -1,5 +1,5 @@
 ---
-title: Entity APIs
+title: Entities
 description: Learn about the APIs for creating, retrieving, updating and deleting entities, as well as searching them.
 section: apis
 subcategory: entities

--- a/astro/src/content/docs/apis/entities/entity-types.mdx
+++ b/astro/src/content/docs/apis/entities/entity-types.mdx
@@ -1,5 +1,5 @@
 ---
-title: Entity Types APIs
+title: Entity Types
 description: Learn about the APIs for creating, retrieving, updating and deleting entity types.
 section: apis
 subcategory: entities

--- a/astro/src/content/docs/apis/entities/grants.mdx
+++ b/astro/src/content/docs/apis/entities/grants.mdx
@@ -1,5 +1,5 @@
 ---
-title: Grant APIs
+title: Grants
 description: Learn about the APIs for granting and revoking permissions to entities.
 section: apis
 subcategory: entities

--- a/astro/src/content/docs/apis/entities/index.mdx
+++ b/astro/src/content/docs/apis/entities/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Entity Management API Overview
+title: Overview
 description: Learn about the APIs for creating, retrieving, updating and deleting entities and entity types.
 section: apis
 subcategory: entities
@@ -15,7 +15,7 @@ Entities are arbitrary objects which can be modeled in FusionAuth. Anything whic
 FusionAuth's Entity Management has the following major concepts:
 
 * Entity Types categorize Entities. An Entity Type could be `Device`, `API` or `Company`.
-* Permissions are defined on an Entity Type. These are arbitrary strings which can fit the business domain. A Permission could be `read`, `write`, or `file-lawsuit`. 
+* Permissions are defined on an Entity Type. These are arbitrary strings which can fit the business domain. A Permission could be `read`, `write`, or `file-lawsuit`.
 * Entities are instances of a single type. An Entity could be a `nest device`, an `Email API` or `Raviga`.
 * Entities can have Grants. Grants are relationships between a target Entity and one of two other types: a recipient Entity or a User. Grants can have zero or more Permissions associated with them.
 

--- a/astro/src/content/docs/apis/families.mdx
+++ b/astro/src/content/docs/apis/families.mdx
@@ -1,5 +1,5 @@
 ---
-title: Family APIs
+title: Families
 description: Learn about the APIs for creating, retrieving, updating and deleting families.
 section: apis
 ---

--- a/astro/src/content/docs/apis/groups.mdx
+++ b/astro/src/content/docs/apis/groups.mdx
@@ -1,5 +1,5 @@
 ---
-title: Group APIs
+title: Groups
 description: Learn about the APIs for creating, retrieving, updating and deleting groups.
 section: apis
 ---

--- a/astro/src/content/docs/apis/hosted-backend.mdx
+++ b/astro/src/content/docs/apis/hosted-backend.mdx
@@ -1,5 +1,5 @@
 ---
-title: Hosted Backend APIs
+title: Hosted Backend
 description: Learn about the APIs that you to perform OAuth2 Authorization Code Flow login, logout, and refresh for applications.
 section: apis
 ---

--- a/astro/src/content/docs/apis/identity-providers/links.mdx
+++ b/astro/src/content/docs/apis/identity-providers/links.mdx
@@ -1,5 +1,5 @@
 ---
-title: Link APIs
+title: Links
 description: Learn about the APIs for creating, retrieving, and deleting Identity Provider Links.
 section: apis
 subcategory: identity providers

--- a/astro/src/content/docs/apis/integrations.mdx
+++ b/astro/src/content/docs/apis/integrations.mdx
@@ -1,5 +1,5 @@
 ---
-title: Integration APIs
+title: Integrations
 description: Learn about the APIs for retrieving and updating integrations.
 section: apis
 ---

--- a/astro/src/content/docs/apis/ip-acl.mdx
+++ b/astro/src/content/docs/apis/ip-acl.mdx
@@ -1,5 +1,5 @@
 ---
-title: IP Access Control List APIs
+title: IP Access Control Lists
 description: Learn about the APIs for creating, retrieving, updating and deleting IP Access Control Lists.
 section: apis
 ---

--- a/astro/src/content/docs/apis/jwt.mdx
+++ b/astro/src/content/docs/apis/jwt.mdx
@@ -1,5 +1,5 @@
 ---
-title: JWT & Refresh Token APIs
+title: JWTs & Refresh Tokens
 description: Learn about the APIs that allow you to manage Refresh Tokens, verify Access Tokens and retrieve public keys used for verifying JWT signatures.
 section: apis
 ---

--- a/astro/src/content/docs/apis/keys.mdx
+++ b/astro/src/content/docs/apis/keys.mdx
@@ -1,5 +1,5 @@
 ---
-title: Keys APIs
+title: Keys
 description: Learn about the APIs for generating, importing, retrieving, updating and deleting keys.
 section: apis
 ---

--- a/astro/src/content/docs/apis/lambdas.mdx
+++ b/astro/src/content/docs/apis/lambdas.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lambdas APIs
+title: Lambdas
 description: Learn about the APIs for creating, retrieving, updating and deleting lambdas.
 section: apis
 ---

--- a/astro/src/content/docs/apis/login.mdx
+++ b/astro/src/content/docs/apis/login.mdx
@@ -1,5 +1,5 @@
 ---
-title: Login APIs
+title: Login
 description: Learn about the APIs for authenticating users (logging them in) or tracking an SSO login (login ping) and multi-factor authentication.
 section: apis
 ---

--- a/astro/src/content/docs/apis/message-templates.mdx
+++ b/astro/src/content/docs/apis/message-templates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Message Template APIs
+title: Message Templates
 description: Learn about the APIs for creating, retrieving, updating and deleting message templates.
 section: apis
 ---

--- a/astro/src/content/docs/apis/messengers/generic.mdx
+++ b/astro/src/content/docs/apis/messengers/generic.mdx
@@ -1,5 +1,5 @@
 ---
-title: Generic Messenger APIs
+title: Generic Messenger
 description: Learn about the APIs for creating, retrieving, and updating Generic Messengers.
 section: apis
 subcategory: messengers

--- a/astro/src/content/docs/apis/messengers/index.mdx
+++ b/astro/src/content/docs/apis/messengers/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Messenger API Overview
+title: Overview
 description: Learn about the APIs for creating, retrieving, updating and deleting messengers.
 section: apis
 subcategory: messengers

--- a/astro/src/content/docs/apis/messengers/twilio.mdx
+++ b/astro/src/content/docs/apis/messengers/twilio.mdx
@@ -1,5 +1,5 @@
 ---
-title: Twilio Messenger APIs
+title: Twilio Messenger
 description: Learn about the APIs for creating, retrieving, and updating Twilio Messengers.
 section: apis
 subcategory: messengers

--- a/astro/src/content/docs/apis/passwordless.mdx
+++ b/astro/src/content/docs/apis/passwordless.mdx
@@ -1,5 +1,5 @@
 ---
-title: Passwordless APIs
+title: Passwordless
 description: Learn about the APIs for magic link passwordless authentication.
 section: apis
 ---

--- a/astro/src/content/docs/apis/reactor.mdx
+++ b/astro/src/content/docs/apis/reactor.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reactor APIs
+title: Reactor
 description: Learn about the APIs for activating, deactivating, and retrieving the status of a FusionAuth Reactor license.
 section: apis
 ---

--- a/astro/src/content/docs/apis/registrations.mdx
+++ b/astro/src/content/docs/apis/registrations.mdx
@@ -1,5 +1,5 @@
 ---
-title: User Registration APIs
+title: User Registrations
 description: Learn about the APIs for creating, retrieving, updating and deleting User Registrations.
 section: apis
 ---

--- a/astro/src/content/docs/apis/reports.mdx
+++ b/astro/src/content/docs/apis/reports.mdx
@@ -1,5 +1,5 @@
 ---
-title: Report APIs
+title: Reports
 description: Learn about the APIs for retrieving reports from FusionAuth.
 section: apis
 ---

--- a/astro/src/content/docs/apis/scim/index.mdx
+++ b/astro/src/content/docs/apis/scim/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: SCIM APIs Overview
+title: Overview
 description: Learn about the APIs for provisioning SCIM Resources in FusionAuth using a SCIM Client.
 section: apis
 subcategory: scim

--- a/astro/src/content/docs/apis/system.mdx
+++ b/astro/src/content/docs/apis/system.mdx
@@ -1,5 +1,5 @@
 ---
-title: System APIs
+title: System
 description: Learn about the APIs for retrieving and updating the system configuration.
 section: apis
 ---

--- a/astro/src/content/docs/apis/tenants.mdx
+++ b/astro/src/content/docs/apis/tenants.mdx
@@ -1,5 +1,5 @@
 ---
-title: Tenant APIs
+title: Tenants
 description: Learn about the APIs for creating, retrieving, updating and deleting tenants.
 section: apis
 ---

--- a/astro/src/content/docs/apis/themes.mdx
+++ b/astro/src/content/docs/apis/themes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Theme APIs
+title: Themes
 description: Learn about the APIs for creating, retrieving, updating, and deleting hosted login page themes.
 section: apis
 ---

--- a/astro/src/content/docs/apis/two-factor.mdx
+++ b/astro/src/content/docs/apis/two-factor.mdx
@@ -1,5 +1,5 @@
 ---
-title: Multi-Factor/Two Factor APIs
+title: Multi-Factor
 description: Learn about the APIs for enabling and disabling multi-factor authentication for users.
 section: apis
 ---

--- a/astro/src/content/docs/apis/user-action-reasons.mdx
+++ b/astro/src/content/docs/apis/user-action-reasons.mdx
@@ -1,5 +1,5 @@
 ---
-title: User Action Reason APIs
+title: User Action Reasons
 description: Learn about the APIs for creating, retrieving, updating and deleting user action reasons.
 section: apis
 ---

--- a/astro/src/content/docs/apis/user-actions.mdx
+++ b/astro/src/content/docs/apis/user-actions.mdx
@@ -1,5 +1,5 @@
 ---
-title: User Action APIs
+title: User Actions
 description: Learn about the APIs for creating, retrieving, updating and deleting user actions.
 section: apis
 ---

--- a/astro/src/content/docs/apis/user-comments.mdx
+++ b/astro/src/content/docs/apis/user-comments.mdx
@@ -1,5 +1,5 @@
 ---
-title: User Comment APIs
+title: User Comments
 description: Learn about the APIs for creating and retrieving comments on users.
 section: apis
 ---

--- a/astro/src/content/docs/apis/users.mdx
+++ b/astro/src/content/docs/apis/users.mdx
@@ -1,5 +1,5 @@
 ---
-title: User APIs
+title: Users
 description: Learn about the APIs for creating, retrieving, updating, deleting, importing, searching for and verifying users.
 section: apis
 ---

--- a/astro/src/content/docs/apis/webauthn.mdx
+++ b/astro/src/content/docs/apis/webauthn.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebAuthn APIs
+title: WebAuthn
 description: Learn about the APIs for starting and completing WebAuthn ceremonies and retrieving, importing and deleting WebAuthn passkeys.
 section: apis
 ---
@@ -58,7 +58,7 @@ This API is used to retrieve information about a single WebAuthn passkey or all 
   </APIField>
 </APIBlock>
 
-<API method="GET" uri="/api/webauthn/?userId={userId}" authentication={["api-key"]} title="Retrieve all Passkeys belonging to a User"/>
+<API method="GET" uri="/api/webauthn?userId={userId}" authentication={["api-key"]} title="Retrieve all Passkeys belonging to a User"/>
 
 <XFusionauthTenantIdHeaderScopedOperation />
 
@@ -98,7 +98,7 @@ This API is used to delete a single WebAuthn passkey or all of a user's register
   </APIField>
 </APIBlock>
 
-<API method="DELETE" uri="/api/webauthn/?userId={userId}" authentication={["api-key"]} title="Delete all Passkeys belonging to a User"/>
+<API method="DELETE" uri="/api/webauthn?userId={userId}" authentication={["api-key"]} title="Delete all Passkeys belonging to a User"/>
 
 <XFusionauthTenantIdHeaderScopedOperation />
 

--- a/astro/src/content/docs/apis/webhooks.mdx
+++ b/astro/src/content/docs/apis/webhooks.mdx
@@ -1,5 +1,5 @@
 ---
-title: Webhook APIs
+title: Webhooks
 description: Learn about the APIs for creating, retrieving, updating and deleting Webhooks.
 section: apis
 ---


### PR DESCRIPTION
### Summary 
Remove API suffix, use plural consistently for APIs and remove / before the ? from the WebAuthN API URIs

Reference for naming
- https://auth0.com/docs/api/management/v2/introduction