### PR TITLE
Only show trust token when doing two factor login response

### DIFF
--- a/astro/src/content/docs/apis/_user-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-response-body.mdx
@@ -38,7 +38,7 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
 
   </> }
 
-  <APIField name="trustToken" type="String" since="1.33.0" renderif={!!!props.two_factor_login_response}>
+  <APIField name="trustToken" type="String" since="1.33.0" renderif={!!props.two_factor_login_response}>
     A trust token that may be used to complete another API request that requires trust. For example, if you receive an error from an API indicating trust is required - indicated by this error code `[TrustTokenRequired]`, this value can be used to satisfy the trust requirement.
   </APIField>
   <APIField name="twoFactorTrustId" type="String" renderif={!!props.two_factor_login_response}>


### PR DESCRIPTION
This addresses https://github.com/FusionAuth/fusionauth-issues/issues/2562

Looks like an extra `!` got put in there.

I examined the [UserResponse object](https://github.com/FusionAuth/fusionauth-java-client/blob/master/src/main/java/io/fusionauth/domain/api/UserResponse.java) and there's not any way for a `trustToken` to be delivered as part of a user CRUD operation.