### PR TITLE
Improving cookie/Authorization instructions in the Laravel API quickstart 

### DIFF
--- a/astro/src/content/quickstarts/quickstart-php-laravel-api.mdx
+++ b/astro/src/content/quickstarts/quickstart-php-laravel-api.mdx
@@ -84,7 +84,7 @@ We are going to be building an API backend for a banking application called Chan
 - `make-change`: This endpoint will allow you to call GET with a `total` amount and receive a response indicating how many nickels and pennies are needed to make change. Valid roles are `customer` and `teller`.
 - `panic`: Tellers may call this endpoint to call the police in case of an incident. The only valid role is `teller`.
 
-Both endpoints will be protected such that a valid JSON web token (JWT) will be required in the `app.at` cookie in order to be accessed. Additionally, the JWT must have a `roles` claim containing the appropriate role to use the endpoint.
+Both endpoints will be protected such that a valid JSON web token (JWT) will be required in an `app.at` cookie or the `Authorization` header in order to be accessed. Additionally, the JWT must have a `roles` claim containing the appropriate role to use the endpoint.
 
 <Aside type="note">
   If you simply want to run the application, there is a completed version in the `complete-application` directory. You can install [PHP](https://www.php.net) and [Composer](https://getcomposer.org/) and use the following commands to get it up and running if you do not want to create your own.
@@ -291,11 +291,15 @@ Copy the `token` from the response, which should look like this:
 
 ### Make the Request
 
-Make a request to `/api/make-change` with a query parameter `total=5.12` and passing the `token` in an `app.at` cookie.
+Make a request to `/api/make-change` with a query parameter `total=5.12` and pass the `token` in an `app.at` cookie (or as a `Bearer` token in the `Authorization` header).
 
 ```shell
 curl --cookie 'app.at=YOUR_TOKEN' 'http://localhost/api/make-change?total=5.12'
 ```
+
+<Aside type="note">
+  You can replace `--cookie 'app.at=<your_token>'` with `--header 'Authorization: Bearer <your_token>'` if you wish to use the `Authorization` header instead of the `app.at` cookie.
+</Aside>
 
 The response should look similar to below, however it has been formatted here for readability:
 
@@ -454,3 +458,4 @@ cd complete-application
 composer install
 ./vendor/bin/sail up -d
 ```
+


### PR DESCRIPTION
Making it clearer that Laravel accepts tokens via cookies and the Authorization header

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206289570611239