### PR TITLE
Change base field name to remove double-dot on applications response

### DIFF
--- a/astro/src/content/docs/apis/_applications-response-body.mdx
+++ b/astro/src/content/docs/apis/_applications-response-body.mdx
@@ -5,4 +5,4 @@ import ApplicationResponseBodyBase from 'src/content/docs/apis/_application-resp
 {/*  these are all used for the configuration of the emailConfiguration section. Shared between application and tenant. */}
 
 <ApplicationResponseBodyBase application_email_config_override_text="When configured, this value will take precedence over the same configuration from the Tenant when an application context is known."
-                             base_field_name="applications[x]." include_total={false}/>
+                             base_field_name="applications[x]" include_total={false}/>


### PR DESCRIPTION
Noticed an issue with the API `applications` response where it was showing `applications[x]..fieldName`.