### PR TITLE
handle multiple top of nav elements, not just one

### DIFF
--- a/astro/src/tools/docs/getDocNavContext.ts
+++ b/astro/src/tools/docs/getDocNavContext.ts
@@ -56,11 +56,17 @@ const prepContext = (context: DocNavContext, subcategory: string, tertcategory: 
 const recursiveSort = (category: Category) => {
   if (category.entries.length > 0) {
     category.entries.sort((a, b) => a.title.localeCompare(b.title));
-    const top = category.entries.find(entry => entry.topOfNav);
-    if (top) {
-      const idx = category.entries.indexOf(top);
-      category.entries.splice(idx, 1);
-      category.entries.unshift(top);
+    const topOfNavElements = category.entries.filter(entry => entry.topOfNav);
+
+    // sort these in reverse order so we process the Z elements before the A elements, which means A elements come first
+    topOfNavElements.sort((a, b) => b.title.localeCompare(a.title));
+    if (topOfNavElements !== [] ) {
+      topOfNavElements.map((top) => {
+          const idx = category.entries.indexOf(top);
+          category.entries.splice(idx, 1);
+          category.entries.unshift(top);
+        }
+      )
     }
   }
   if (category.subcategories.length > 0) {


### PR DESCRIPTION
This change to the docs supports multiple content items being tagged with `topOfNav`. It then adds them to the top of the nav in alphabetical order, title descending.