### PR TITLE
add sales videos to docs

### DIFF
--- a/astro/src/content/docs/customize/look-and-feel/index.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/index.mdx
@@ -17,6 +17,9 @@ import ThemeEnvironments from 'src/content/docs/operate/deploy/_theme-environmen
 import ThemeTroubleshooting from 'src/content/docs/customize/look-and-feel/_theme-troubleshooting.mdx';
 import ThemeUpgrade from 'src/content/docs/customize/look-and-feel/_theme-upgrade.mdx';
 import Templates from 'src/content/docs/_shared/_theme_templates.astro';
+import { YouTube } from '@astro-community/astro-embed-youtube';
+
+<YouTube id="AFRBH9r4VhY" />
 
 ## Overview
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/index.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/index.mdx
@@ -10,6 +10,7 @@ topOfNav: true
 import Aside from 'src/components/Aside.astro';
 import InlineField from 'src/components/InlineField.astro';
 import ScrollRef from 'src/components/ScrollRef.astro';
+import { YouTube } from '@astro-community/astro-embed-youtube';
 
 ## Identity Providers
 
@@ -86,6 +87,8 @@ However, you cannot have two different Identity Providers for the same applicati
 Additionally, override settings are not available in the External JWT, SAMLv2, or OpenID Connect Identity Providers. You can create multiple instances of these providers; that is the correct way to have multiple configurations for these providers
 
 ## Hints
+
+<YouTube id="5bYpee0dlAA" />
 
 When you are using the FusionAuth hosted login pages, you can bypass the login page and go directly to a third party Identity Provider based upon the user's email address or an Identity Provider Id.
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/multi-factor-authentication.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/multi-factor-authentication.mdx
@@ -14,6 +14,9 @@ import RecoveryCodesBlurb from 'src/content/docs/lifecycle/authenticate-users/_r
 import Aside from 'src/components/Aside.astro';
 import MfaMigration from 'src/content/docs/lifecycle/authenticate-users/_mfa-migration.mdx';
 import MfaTroubleshooting from 'src/content/docs/lifecycle/authenticate-users/_mfa-troubleshooting.mdx';
+import { YouTube } from '@astro-community/astro-embed-youtube';
+
+<YouTube id="GM2JPTu-EE4" />
 
 ## Overview
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/passwordless/index.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/passwordless/index.mdx
@@ -7,6 +7,9 @@ subcategory: authenticate users
 tertcategory: passwordless
 topOfNav: true
 ---
+import { YouTube } from '@astro-community/astro-embed-youtube';
+
+<YouTube id="PO789dLrX3M" />
 
 ## Overview
 

--- a/astro/src/content/docs/lifecycle/migrate-users/connectors/index.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/connectors/index.mdx
@@ -10,8 +10,11 @@ topOfNav: true
 import Aside from 'src/components/Aside.astro';
 import ConnectorDiagram from 'src/diagrams/docs/lifecycle/migrate-users/connectors/_connector-diagram.astro';
 import PremiumEditionBlurb from 'src/content/docs/_shared/_premium-edition-blurb.astro';
+import { YouTube } from '@astro-community/astro-embed-youtube';
 
 <PremiumEditionBlurb />
+
+<YouTube id="ks-ppMH6WXw" />
 
 ## Overview
 


### PR DESCRIPTION

To make testing easier these are the local links for the pages that have videos added. Still waiting on a couple thumbnail images.

http://localhost:3000/docs/lifecycle/migrate-users/connectors/
http://localhost:3000//docs/lifecycle/authenticate-users/passwordless/
http://localhost:3000//docs/lifecycle/authenticate-users/multi-factor-authentication
http://localhost:3000//docs/lifecycle/authenticate-users/identity-providers/#hints
http://localhost:3000/docs/customize/look-and-feel/