### PR TITLE
Update Login Method for Google and Facebook IdP pages

### DIFF
--- a/astro/src/content/docs/apis/identity-providers/_facebook-login-method-parameter.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_facebook-login-method-parameter.mdx
@@ -1,0 +1,10 @@
+import APIField from 'src/components/api/APIField.astro';
+
+<APIField name="identityProvider.loginMethod" type="String" since={props.idp_since < 12800 ? '1.28.0': ''}>
+  The login method to use for this Identity Provider.
+
+  The possible values are:
+
+  * `UsePopup` - When logging in use a popup window and the {props.idp_display_name} JavaScript library.
+  * `UseRedirect` - When logging in use the {props.idp_display_name} OAuth redirect login flow.
+</APIField>

--- a/astro/src/content/docs/apis/identity-providers/_facebook-post-request-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_facebook-post-request-body.mdx
@@ -2,9 +2,9 @@ import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
+import FacebookLoginMethodParameter from 'src/content/docs/apis/identity-providers/_facebook-login-method-parameter.mdx';
 import IdentityProviderDebugRequestParameter from 'src/content/docs/apis/identity-providers/_identity-provider-debug-request-parameter.mdx';
 import IdentityProviderLinkingStrategyRequestParameter from 'src/content/docs/apis/identity-providers/_identity-provider-linking-strategy-request-parameter.mdx';
-import IdentityProviderLoginMethodRequestParameter from 'src/content/docs/apis/identity-providers/_identity-provider-login-method-request-parameter.mdx';
 import IdentityProviderTenantConfiguration from 'src/content/docs/apis/identity-providers/_identity-provider-tenant-configuration.mdx';
 
 #### Request Body
@@ -65,7 +65,8 @@ import IdentityProviderTenantConfiguration from 'src/content/docs/apis/identity-
                                                    idp_display_name={props.idp_display_name}
                                                    idp_since={props.idp_since} />
 
-  <IdentityProviderLoginMethodRequestParameter idp_since={props.idp_since} />
+  <FacebookLoginMethodParameter idp_since={props.idp_since}
+                                idp_display_name={props.idp_display_name} />
 
   <APIField name="identityProvider.permissions" type="String" optional defaults="email">
     The top-level permissions that your application is asking of the user's Facebook account.

--- a/astro/src/content/docs/apis/identity-providers/_facebook-put-request-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_facebook-put-request-body.mdx
@@ -2,9 +2,8 @@ import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
-import IdentityProviderDebugRequestParameter from 'src/content/docs/apis/identity-providers/_identity-provider-debug-request-parameter.mdx';
+import FacebookLoginMethodParameter from 'src/content/docs/apis/identity-providers/_facebook-login-method-parameter.mdx';
 import IdentityProviderLinkingStrategyRequestParameter from 'src/content/docs/apis/identity-providers/_identity-provider-linking-strategy-request-parameter.mdx';
-import IdentityProviderLoginMethodRequestParameter from 'src/content/docs/apis/identity-providers/_identity-provider-login-method-request-parameter.mdx';
 import IdentityProviderTenantConfiguration from 'src/content/docs/apis/identity-providers/_identity-provider-tenant-configuration.mdx';
 
 #### Request Body
@@ -57,7 +56,8 @@ import IdentityProviderTenantConfiguration from 'src/content/docs/apis/identity-
 
   <IdentityProviderLinkingStrategyRequestParameter idp_linking_strategy={props.idp_linking_strategy} idp_display_name={props.idp_display_name} idp_since={props.idp_since} />
 
-  <IdentityProviderLoginMethodRequestParameter idp_since={props.idp_since} />
+  <FacebookLoginMethodParameter idp_since={props.idp_since}
+                                idp_display_name={props.idp_display_name} />
 
   <IdentityProviderTenantConfiguration idp_since={props.idp_since} />
 

--- a/astro/src/content/docs/apis/identity-providers/_facebook-response-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_facebook-response-body.mdx
@@ -2,8 +2,8 @@ import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
+import FacebookLoginMethodParameter from 'src/content/docs/apis/identity-providers/_facebook-login-method-parameter.mdx';
 import IdentityProviderLinkingStrategyResponseParameter from 'src/content/docs/apis/identity-providers/_identity-provider-linking-strategy-response-parameter.mdx';
-import IdentityProviderLoginMethodResponseParameter from 'src/content/docs/apis/identity-providers/_identity-provider-login-method-response-parameter.mdx';
 import IdentityProviderTenantConfiguration from 'src/content/docs/apis/identity-providers/_identity-provider-tenant-configuration.mdx';
 
 #### Response Body
@@ -68,7 +68,8 @@ import IdentityProviderTenantConfiguration from 'src/content/docs/apis/identity-
                                                     idp_since={props.idp_since}
                                                     idp_linking_strategy={props.idp_linking_strategy} />
 
-  <IdentityProviderLoginMethodResponseParameter idp_since={props.idp_since} />
+  <FacebookLoginMethodParameter idp_since={props.idp_since}
+                                idp_display_name={props.idp_display_name} />
 
   <APIField name="identityProvider.name" type="String">
     The name of the provider, this field will always be set to `Facebook`.

--- a/astro/src/content/docs/apis/identity-providers/_identity-provider-login-method-request-parameter.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_identity-provider-login-method-request-parameter.mdx
@@ -10,7 +10,7 @@ import APIField from 'src/components/api/APIField.astro';
    * `UseVendorJavaScript` - When logging in allow the {props.idp_display_name} JavaScript library to determine the login method.
 
   {props.idp_type === 'Google' && <>
-    <span class="text-green-600">Since 1.44.0</span>
-    **If you are using a version of FusionAuth older than 1.44.0**, `UsePopup` won't work. `UseRedirect` will continue to work after this date. Please see https://github.com/FusionAuth/fusionauth-issues/issues/1939[Issue #1939] for more. This [forum post](/community/forum/topic/2329/upcoming-google-identity-provider-changes) has more details on an available workaround and upgrade process.
+    <span class="text-green-600">Since 1.44.0</span> <br/>
+    <strong>If you are using a version of FusionAuth older than 1.44.0</strong>, <code>UsePopup</code> won't work. <code>UseRedirect</code> will continue to work after this date. Please see <a href="https://github.com/FusionAuth/fusionauth-issues/issues/1939">Issue #1939</a> for more. This <a href="/community/forum/topic/2329/upcoming-google-identity-provider-changes">forum post</a> has more details on an available workaround and upgrade process.
   </>}
 </APIField>

--- a/astro/src/content/docs/apis/identity-providers/_oauth-idp-operations.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_oauth-idp-operations.mdx
@@ -26,6 +26,7 @@ The <InlineField>type</InlineField> in the request JSON is used to determine tha
                      idp_type={props.idp_type}
                      idp_display_name={props.idp_display_name}
                      idp_linking_strategy={props.idp_linking_strategy}
+                     idp_login_method={props.idp_login_method}
                      idp_since={props.idp_since}
                      optional_tag={props.optional_tag} />
 
@@ -37,6 +38,7 @@ The <InlineField>type</InlineField> in the request JSON is used to determine tha
                       idp_type={props.idp_type}
                       idp_display_name={props.idp_display_name}
                       idp_linking_strategy={props.idp_linking_strategy}
+                      idp_login_method={props.idp_login_method}
                       idp_since={props.idp_since}
                       idp_id={props.idp_id}
                       optional_tag={props.optional_tag} />
@@ -60,6 +62,7 @@ There is only one {props.idp_display_name} Identity Provider, so this Identity P
                       idp_type={props.idp_type}
                       idp_display_name={props.idp_display_name}
                       idp_linking_strategy={props.idp_linking_strategy}
+                      idp_login_method={props.idp_login_method}
                       idp_since={props.idp_since}
                       idp_id={props.idp_id}
                       optional_tag={props.optional_tag} />

--- a/astro/src/content/docs/apis/identity-providers/_oauth-idp-request-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_oauth-idp-request-body.mdx
@@ -111,7 +111,9 @@ import IdentityProviderLoginMethodRequestParameter from 'src/content/docs/apis/i
 
   <IdentityProviderLinkingStrategyRequestParameter idp_since={props.idp_since} idp_linking_strategy={props.idp_linking_strategy} idp_display_name={props.idp_display_name}/>
 
-  { props.idp_login_method && <IdentityProviderLoginMethodRequestParameter /> }
+  { props.idp_login_method && <IdentityProviderLoginMethodRequestParameter idp_since={props.idp_since}
+                                                                           idp_display_name={props.idp_display_name}
+                                                                           idp_type={props.idp_type} /> }
 
   <APIField name="identityProvider.properties" type="Object" optional since="1.44.0" renderif={props.idp_type === 'Google'}>
     An object to hold configuration parameters for the [Google Identity Services API](https://developers.google.com/identity/gsi/web/reference/html-reference). See the <InlineField>identityProvider.properties.api</InlineField> and <InlineField>identityProvider.properties.button</InlineField> fields for more detail on format and configurable values.

--- a/astro/src/content/docs/apis/identity-providers/_oauth-idp-response-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_oauth-idp-response-body.mdx
@@ -88,10 +88,11 @@ import IdentityProviderTenantConfiguration from 'src/content/docs/apis/identity-
                                                     idp_linking_strategy={props.idp_linking_strategy}
                                                     idp_display_name={props.idp_display_name} />
 
-  { props.idp_login_method && <IdentityProviderLoginMethodResponseParameter /> }
+  { props.idp_login_method && <IdentityProviderLoginMethodResponseParameter idp_since={props.idp_since}
+                                                                            idp_display_name={props.idp_display_name} /> }
 
   <APIField name="identityProvider.name" type="String">
-    The name of the provider, this field will always be set to `{idp_type}`.
+    The name of the provider, this field will always be set to <code>{props.idp_type}</code>.
   </APIField>
 
   <APIField name="identityProvider.properties" type="Object" since="1.44.0" renderif={props.idp_type === 'Google'}>

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/social/facebook.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/social/facebook.mdx
@@ -97,7 +97,6 @@ This will take you to the `Add Facebook` panel, and you'll fill out the `App Id`
     If selected, the redirect URL *must* be set to an absolute URL in the Facebook console for your application. If your hostname is login.piedpiper.com, the redirect URL would be `https://login.piedpiper.com/oauth2/callback/`.
      * `Use popup for login` - if selected, a popup is displayed to the user to login with Facebook. Once authenticated, the window is closed.
     If using `Use Popup for login`, you will need to fill in `App Domain`, `User Data Deletion`, and `Privacy Policy URL` fields in your Facebook App settings.  Additionally, you need to enable `Login with the JavaScript SDK`.
-     * `Use vendor JavaScript` - if selected, behavior will match `Use popup for login`
 
     Please note if an `idp_hint` is appended to the OAuth Authorize endpoint, then the login method interaction will be `redirect`, even if popup interaction is explicitly configured.
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/social/google.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/social/google.mdx
@@ -120,7 +120,7 @@ This will take you to the `Add Google` panel, and you'll fill out the `Client Id
 
     <span class="text-green-500">Since 1.44.0</span>
 
-    **If you are using a version of FusionAuth older than 1.44.0**, `Use popup for login` won't work. `UseRedirect` will continue to work after this date. Please see https://github.com/FusionAuth/fusionauth-issues/issues/1939[Issue #1939] for more. This [forum post](/community/forum/topic/2329/upcoming-google-identity-provider-changes) has more details on an available workaround and upgrade process.
+    **If you are using a version of FusionAuth older than 1.44.0**, `Use popup for login` won't work. `UseRedirect` will continue to work after this date. Please see [Issue #1939](https://github.com/FusionAuth/fusionauth-issues/issues/1939) for more. This [forum post](/community/forum/topic/2329/upcoming-google-identity-provider-changes) has more details on an available workaround and upgrade process.
   </APIField>
   <APIField name="Button text" required>
     The text to be displayed in the button on the login form. This value is defaulted to `Login with Google` but it may be modified to your preference.


### PR DESCRIPTION
### Issue:
- https://github.com/FusionAuth/fusionauth-issues/issues/2351

### Description
Updated the Facebook IdP pages to no longer mention the UseVendorJavaScript login method. Additionally, I noticed that the requests/responses for the loginMethod field for the Google IdP weren't showing properly, so I addressed those here as well. 
 
NOTE: These updates don't need to wait for the next FusionAuth release. 

