### PR TITLE
incorrectly shows a blank space for the identity provider on this api

### DIFF
--- a/astro/src/content/docs/apis/identity-providers/_identity-provider-login-request-body.astro
+++ b/astro/src/content/docs/apis/identity-providers/_identity-provider-login-request-body.astro
@@ -165,7 +165,8 @@ const show_code_and_token_examples = ['Facebook', 'Google'].includes(idp_display
   </APIField>
   <APIField name="identityProviderId" type="UUID" required>
     <p>The unique Id of the identity provider to process this login request.</p>
-    <p>For the {idp_display_name} identity provider, this value will always be <code>{ idpIdMap[idp_display_name] }</code>.</p>
+    { idpIdMap[idp_display_name] ? 
+       <p>For the {idp_display_name} identity provider, this value will always be <code>{ idpIdMap[idp_display_name] }</code>.</p> : ""}
   </APIField>
   <APIField name="ipAddress" type="String" optional>
     The IP address of the end-user that is logging into FusionAuth. If this value is omitted FusionAuth will attempt to obtain the IP address of


### PR DESCRIPTION
updated to not have blank with oidc and other non specific identity providers