### PR TITLE
Fixing the example app check workflow

### DIFF
--- a/.github/scripts/count-repos.sh
+++ b/.github/scripts/count-repos.sh
@@ -10,8 +10,8 @@ fi
 #fusionauth-containers, fusionauth-theme-helper, etc
 EXTRA_IN_JSON_NOT_NAMED_CORRECTLY=4 
 
-# fusionauth-example-template
-EXTRA_IN_GH_NOT_DISPLAYABLE=1 
+# fusionauth-example-template and (temporarily) fusionauth-example-vue-sdk
+EXTRA_IN_GH_NOT_DISPLAYABLE=2
 
 cat astro/src/content/json/exampleapps.json|jq '.[]|.url' |sed 's/"//g'|sed 's!https://github.com/!!i' > json.list
 COUNT_IN_JSON=`wc -l json.list |sed 's/^ *//' |sed 's/ .*//'`


### PR DESCRIPTION
This is a temporary fix to the [`example_app_check` workflow](https://github.com/FusionAuth/fusionauth-site/actions/workflows/exampleappscheck.yml) failing due to `fusionauth-example-vue-sdk`