### PR TITLE
RemoteContent is picking up the next to last line incorrectly.

### DIFF
--- a/astro/src/components/RemoteContent.astro
+++ b/astro/src/components/RemoteContent.astro
@@ -51,12 +51,15 @@ function selectTagged(content: string, tags: string): string {
   const lines = content.split("\n");
 
   const startLine = lines.findIndex((line) => line.includes(`tag::${tags}`));
-  const endLine = lines.findIndex((line) => line.includes(`end::${tags}`));
+  const endLine = lines.findIndex((line) => line.includes(`end::${tags}`))
 
   // remove trailing multi-line HTML comment
   if (startLine < lines.length - 1) {
     lines[startLine + 1] = lines[startLine + 1].replace('-->', '');
   }
+
+  // remove preceding multi-line HTML comment
+  lines[endLine-1] = lines[endLine-1].replace('<!--', '');
 
   return lines.slice(startLine + 1, endLine).join("\n").replace(/\s+$/g, '');
 }


### PR DESCRIPTION
We should remove any comments on the next to last line, otherwise it will comment out anything below the remote content call incorrectly.

See https://fusionauth.io/docs/sdks/react-sdk

It should include a "Source Code" section per https://github.com/FusionAuth/fusionauth-site/blob/master/astro/src/content/docs/sdks/react-sdk.mdx

But it doesn't.