### PR TITLE
Add 403 warning to pages with the SPA documentation

### DIFF
--- a/astro/src/content/docs/_shared/_hosted-backend-warning.md
+++ b/astro/src/content/docs/_shared/_hosted-backend-warning.md
@@ -1,12 +1,13 @@
-When developing against a FusionAuth Cloud instance using an apex domain of `fusionauth.io` address, unless your application shares the same domain of `fusionauth.io` attempts to use these endpoints will fail with a `403` status code. 
+When developing against a FusionAuth Cloud instance with a hostname ending in `fusionauth.io`, unless your application shares the same domain of `fusionauth.io` attempts to use these endpoints will fail with a `403` status code. 
 
-These endpoints will not work correctly for cross origin requests. Cross origin requests occur when the application making the request to FusionAuth is using a separate domain. For example, if your application URL is `app.acme.com` and the FusionAuth URL is `acme.fusionauth.io` requests from your application to FusionAuth will be considered cross origin.
+These endpoints do not work correctly for cross origin requests. Cross origin requests occur when the application making the request to FusionAuth is using a separate domain. For example, if your application URL is `app.acme.com` and the FusionAuth URL is `acme.fusionauth.io` requests from your application to FusionAuth will be considered cross origin.
 
-If at all possible you should plan to access FusionAuth and your application in the same domain. If this is not possible, you may use one of these alternative methods:
+If possible, have FusionAuth and your application served by the same domain, using a [proxy if needed](/docs/operate/deploy/proxy-setup). For example, serve your app from `app.acme.com` and FusionAuth from `auth.acme.com`.
+
+If this configuration is not possible, use one of these alternative methods:
 
 * Develop using a local FusionAuth instance, so both your webapp and FusionAuth are running on `localhost`.
-* Use a proxy to rewrite the requests to utilize the same domain. 
 * Do not use the the FusionAuth hosted backend, and instead write your own backend with a cross origin cookie policy: [here's an example](https://github.com/FusionAuth/fusionauth-example-react-sdk/tree/main/server).
 * Configure a [custom domain name for the FusionAuth Cloud instance](/docs/get-started/run-in-the-cloud/cloud#updating-with-existing-custom-domains) (limited to certain plans).
 
-Modifying FusionAuth CORS configuration options will not fix this issue because the cookies that FusionAuth writes will not be accessible cross domain.
+Modifying FusionAuth CORS configuration options does not fix this issue because the cookies that FusionAuth writes will not be accessible cross domain.

--- a/astro/src/content/docs/sdks/angular-sdk.mdx
+++ b/astro/src/content/docs/sdks/angular-sdk.mdx
@@ -5,10 +5,16 @@ navcategory: developer
 section: sdks
 disableTOC: true
 ---
+import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import RemoteContent from 'src/components/RemoteContent.astro';
 
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-angular-sdk/main/README.md"
                tags="forDocSite" />
+
+
+## Usage With FusionAuth Cloud
+
+<HostedBackendWarning />
 
 ## Source Code
 

--- a/astro/src/content/docs/sdks/react-sdk.mdx
+++ b/astro/src/content/docs/sdks/react-sdk.mdx
@@ -5,12 +5,16 @@ navcategory: developer
 section: sdks
 disableTOC: true
 ---
+import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import RemoteContent from 'src/components/RemoteContent.astro';
 
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-react-sdk/main/README.md"
                tags="forDocSite" />
 
+## Usage With FusionAuth Cloud
+
+<HostedBackendWarning />
+
 ## Source Code
 
 The source code is available here: https://github.com/FusionAuth/fusionauth-react-sdk/
-

--- a/astro/src/content/docs/sdks/vue-sdk.mdx
+++ b/astro/src/content/docs/sdks/vue-sdk.mdx
@@ -5,10 +5,15 @@ navcategory: developer
 section: sdks
 disableTOC: true
 ---
+import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import RemoteContent from 'src/components/RemoteContent.astro';
 
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-vue-sdk/main/README.md"
                tags="forDocSite" />
+
+## Usage With FusionAuth Cloud
+
+<HostedBackendWarning />
 
 ## Source Code
 

--- a/astro/src/content/quickstarts/quickstart-javascript-angular-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-javascript-angular-web.mdx
@@ -14,6 +14,7 @@ cta: EmailListCTA
 ---
 import Aside from '/src/components/Aside.astro';
 import DockerSpinup from '/src/components/quickstarts/DockerSpinup.astro';
+import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import Intro from '/src/components/quickstarts/Intro.astro';
 import LoginArchitectureSdk from '/src/components/quickstarts/LoginArchitectureSdk.astro';
 import NextSteps from '/src/components/quickstarts/NextSteps.astro';
@@ -62,6 +63,12 @@ You'll be prompted to answer a few questions about your application. You can cho
 #### Create the Application
 
 We are going to use the [Hosted Backend](/docs/apis/hosted-backend) feature of FusionAuth, so you don't need to worry about setting up a backend server.
+
+<Aside type="caution">
+While this example uses localhost for your application and FusionAuth, there are complications if you plan to deploy using FusionAuth Cloud.
+
+  <HostedBackendWarning />
+</Aside>
 
 First, install the FusionAuth Angular SDK:
 

--- a/astro/src/content/quickstarts/quickstart-javascript-react-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-javascript-react-web.mdx
@@ -14,6 +14,7 @@ cta: EmailListCTA
 ---
 import Aside from '/src/components/Aside.astro';
 import DockerSpinup from '/src/components/quickstarts/DockerSpinup.astro';
+import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import Intro from '/src/components/quickstarts/Intro.astro';
 import LoginArchitectureSdk from '/src/components/quickstarts/LoginArchitectureSdk.astro';
 import NextSteps from '/src/components/quickstarts/NextSteps.astro';
@@ -61,6 +62,12 @@ npx create-react-app changebank && cd changebank
 </Aside>
 
 We are going to use the [Hosted Backend](/docs/apis/hosted-backend) feature of FusionAuth, so you don't need to worry about setting up a backend server.
+
+<Aside type="caution">
+While this example uses localhost for your application and FusionAuth, there are complications if you plan to deploy using FusionAuth Cloud.
+
+  <HostedBackendWarning />
+</Aside>
 
 Install the FusionAuth React SDK, and React Router, which we'll use to manage the routes in our application:
 

--- a/astro/src/content/quickstarts/quickstart-javascript-vue-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-javascript-vue-web.mdx
@@ -14,6 +14,7 @@ cta: EmailListCTA
 ---
 import Aside from '/src/components/Aside.astro';
 import DockerSpinup from '/src/components/quickstarts/DockerSpinup.astro';
+import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import Intro from '/src/components/quickstarts/Intro.astro';
 import LoginArchitectureSdk from '/src/components/quickstarts/LoginArchitectureSdk.astro';
 import NextSteps from '/src/components/quickstarts/NextSteps.astro';
@@ -58,6 +59,12 @@ npm create vue@latest -- changebank --typescript --router
 ```
 
 We are going to use the [Hosted Backend](/docs/apis/hosted-backend) feature of FusionAuth, so you don't need to worry about setting up a backend server.
+
+<Aside type="caution">
+While this example uses localhost for your application and FusionAuth, there are complications if you plan to deploy using FusionAuth Cloud.
+
+  <HostedBackendWarning />
+</Aside>
 
 First, install the FusionAuth Vue SDK:
 


### PR DESCRIPTION
We want to make it super clear to customers using the hosted backend that they'll get a 403 if the domain of their app differs from the domain FusionAuth is running in (most typically because of them using a FusionAuth cloud instance). 

Internal: https://app.asana.com/0/1204713564015993/1206380173727211/f