### PR TITLE
No base 64 secret in user response

### DIFF
--- a/astro/src/content/docs/apis/_family-pending-response-body.mdx
+++ b/astro/src/content/docs/apis/_family-pending-response-body.mdx
@@ -75,11 +75,6 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   <APIField name="users[x].twoFactor.methods[x].mobilePhone" type="String">
     The value of the mobile phone for this method. Only present if <InlineField>user.twoFactor.methods``[x]``.method</InlineField> is `sms`.
   </APIField>
-  <APIField name="users[x].twoFactor.methods[x].secret" type="String">
-    A base64 encoded secret
-
-    This field is required when <InlineField>method</InlineField> is `authenticator`.
-  </APIField>
   <APIField name="users[x].twoFactor.recoveryCodes" type="Array<String>">
     A list of recovery codes. These may be used in place of a code provided by an MFA factor. They are single use.
 

--- a/astro/src/content/docs/apis/_import-users-request-body.mdx
+++ b/astro/src/content/docs/apis/_import-users-request-body.mdx
@@ -227,7 +227,7 @@ You must provide either the **email** or the **username** field for each User. T
     The value of the mobile phone for this method. Only present if <InlineField>user.twoFactor.methods``[x]``.method</InlineField> is `sms`.
   </APIField>
   <APIField name="users[x].twoFactor.methods[x].secret" type="String" optional>
-    A base64 encoded secret
+    A base64 encoded secret.
 
     This field is required when <InlineField>method</InlineField> is `authenticator`.
   </APIField>

--- a/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
@@ -147,7 +147,7 @@ This request requires that you specify both the User object and the User Registr
     The value of the mobile phone for this method. Only present if <InlineField>user.twoFactor.methods[x].method</InlineField> is `sms`.
   </APIField>
   <APIField name="user.twoFactor.methods[x].secret" type="String" optional>
-    A base64 encoded secret
+    A base64 encoded secret.
 
     This field is required when <InlineField>method</InlineField> is `authenticator`.
   </APIField>

--- a/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
@@ -156,9 +156,6 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   <APIField name="user.twoFactor.methods[x].mobilePhone" type="String">
     The value of the mobile phone for this method. Only present if <InlineField>user.twoFactor.methods[x].method</InlineField> is `sms`.
   </APIField>
-  <APIField name="user.twoFactor.methods[x].secret" type="String">
-    A base64 encoded secret
-  </APIField>
   <APIField name="user.twoFactorDelivery" type="String" deprecated>
     The User's preferred delivery for verification codes during a two factor login request.
 

--- a/astro/src/content/docs/apis/_user-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-request-body.mdx
@@ -197,7 +197,7 @@ You must specify either the **email** or the **username** or both for the User. 
   </APIField>
 
   <APIField name="user.twoFactor.methods[x].secret" type="String" optional>
-    A base64 encoded secret
+    A base64 encoded secret.
 
     This field is required when <InlineField>method</InlineField> is `authenticator`.
   </APIField>

--- a/astro/src/content/docs/apis/_user-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-response-body.mdx
@@ -243,9 +243,6 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
   <APIField name="user.twoFactor.methods[x].mobilePhone" type="String">
     The value of the mobile phone for this method. Only present if <InlineField>user.twoFactor.methods``[x]``.method</InlineField> is `sms`.
   </APIField>
-  <APIField name="user.twoFactor.methods[x].secret" type="String">
-    A base64 encoded secret
-  </APIField>
   <APIField name="user.twoFactorDelivery" type="String" deprecated>
     The User's preferred delivery for verification codes during a two factor login request.
 

--- a/astro/src/content/docs/apis/_users-response-body.mdx
+++ b/astro/src/content/docs/apis/_users-response-body.mdx
@@ -202,11 +202,6 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   <APIField name="users[x].twoFactor.methods[x].mobilePhone" type="String">
     The value of the mobile phone for this method. Only present if <InlineField>user.twoFactor.methods<code></code>[x]<code></code>.method</InlineField> is <code>sms</code>.
   </APIField>
-  <APIField name="users[x].twoFactor.methods[x].secret" type="String">
-    A base64 encoded secret
-
-    This field is required when <InlineField>method</InlineField> is <code>authenticator</code>.
-  </APIField>
   <APIField name="users[x].twoFactorDelivery" type="String" deprecated>
     The User's preferred delivery for verification codes during a two factor login request.
 


### PR DESCRIPTION
I discovered that we were sometimes documenting that we returned the TOTP secret in the response.

I looked at code paths and do not believe this is ever the case.

Also checked the JSON example responses and none show that.