### PR TITLE
Re-enable regular cache invalidation

### DIFF
--- a/.github/workflows/invalidate.yml
+++ b/.github/workflows/invalidate.yml
@@ -3,8 +3,8 @@ name: invalidate_cache
 # Controls when the action will run. 
 on:
   # run once a weekday at ~8am/8pm MT 
-  # schedule:
-  #   - cron: '31 1,13 * * *'
+  schedule:
+    - cron: '31 1,13 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/invalidate.yml
+++ b/.github/workflows/invalidate.yml
@@ -1,8 +1,8 @@
 name: invalidate_cache
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
-  # run once a weekday at ~8am/8pm MT 
+  # run once a weekday at ~8am/8pm MT
   schedule:
     - cron: '31 1,13 * * *'
   # Allows you to run this workflow manually from the Actions tab
@@ -28,7 +28,7 @@ jobs:
       - name: Set prod env vars based on branch
         if: startsWith(github.ref, 'refs/heads/master')
         run: |
-          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> ${GITHUB_ENV} 
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> ${GITHUB_ENV}
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> ${GITHUB_ENV}
         shell: bash
 
@@ -36,6 +36,5 @@ jobs:
       - name: Invalidate cache
         run: |
           CLOUDFRONT_DISTRIBUTION_ID=$(grep cloudfront_distribution_id s3_website.yml|awk -F: '{print $2}' |sed 's/ //g')
-          aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*" 
+          aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"
         shell: bash
-


### PR DESCRIPTION
For some reason we turned this off in October, but this is useful for pulling changes from our webflow site without requiring any human interaction.