### PR TITLE
Advanced threat detection can be enabled when a license is created.

### DIFF
--- a/astro/src/content/docs/operate/secure-and-monitor/advanced-threat-detection.mdx
+++ b/astro/src/content/docs/operate/secure-and-monitor/advanced-threat-detection.mdx
@@ -23,9 +23,7 @@ Flagging and responding to suspicious behavior is a part of any cybersecurity pr
 Advanced Threat Detection, a feature that brings best-practice functionality to help you deal with bizarre, possibly malicious behavior around logins, registrations, user creation, and user updates.
 
 <Aside type="note">
-Turning this feature on requires a support ticket, as it is being rolled out on an account by account basis.
-
-To enable Advanced Threat Detection, submit a [support ticket through your account portal](https://account.fusionauth.io/account/support) and request it be turned on.
+Advanced Threat Detection can be enabled when the user creates a license.
 
 This feature also requires increased RAM on the servers running the FusionAuth application, as documented in the [System Requirements](/docs/get-started/download-and-install/system-requirements#compute-ram).
 </Aside>

--- a/astro/src/content/docs/operate/secure-and-monitor/advanced-threat-detection.mdx
+++ b/astro/src/content/docs/operate/secure-and-monitor/advanced-threat-detection.mdx
@@ -23,7 +23,7 @@ Flagging and responding to suspicious behavior is a part of any cybersecurity pr
 Advanced Threat Detection, a feature that brings best-practice functionality to help you deal with bizarre, possibly malicious behavior around logins, registrations, user creation, and user updates.
 
 <Aside type="note">
-Advanced Threat Detection can be enabled when the user creates a license.
+Advanced Threat Detection can be enabled when the user creates a license or updates an existing license.
 
 This feature also requires increased RAM on the servers running the FusionAuth application, as documented in the [System Requirements](/docs/get-started/download-and-install/system-requirements#compute-ram).
 </Aside>


### PR DESCRIPTION
refers to [https://github.com/FusionAuth/fusionauth-site/issues/2584](https://github.com/FusionAuth/fusionauth-site/issues/2584)

### screenshot
<img width="1490" alt="atd-enabled" src="https://github.com/FusionAuth/fusionauth-site/assets/2787768/f5fa06fc-e239-496c-aef5-a7486d0dd71d">

