### PR TITLE
Renaming repos from the "Device Limiting" guide

### DIFF
--- a/astro/src/content/docs/extend/examples/device-limiting.mdx
+++ b/astro/src/content/docs/extend/examples/device-limiting.mdx
@@ -4,8 +4,8 @@ description: Learn how to limit the number of devices a user can log in to concu
 navcategory: developer
 section: extend
 subcategory: examples
-codeRootSimple: https://raw.githubusercontent.com/FusionAuth/fusionauth-device-limit-guide-simple/main
-codeRootFriendly: https://raw.githubusercontent.com/FusionAuth/fusionauth-device-limit-guide-friendly/main
+codeRootSimple: https://raw.githubusercontent.com/FusionAuth/fusionauth-example-device-limit-simple/main
+codeRootFriendly: https://raw.githubusercontent.com/FusionAuth/fusionauth-example-device-limit-friendly/main
 ---
 import Aside from 'src/components/Aside.astro';
 import InlineField from 'src/components/InlineField.astro';
@@ -213,6 +213,6 @@ The web page posts the selected token Ids to the backend. You will need a route 
 
 You can download, review, and run full applications for both the simple and user-friendly device-limiting implementations from the FusionAuth GitHub: 
 
- * [Simple implementation using a webhook](https://github.com/FusionAuth/fusionauth-device-limit-guide-simple)
+ * [Simple implementation using a webhook](https://github.com/FusionAuth/fusionauth-example-device-limit-simple)
 
- * [User-friendly implementation](https://github.com/FusionAuth/fusionauth-device-limit-guide-friendly)
+ * [User-friendly implementation](https://github.com/FusionAuth/fusionauth-example-device-limit-friendly)

--- a/astro/src/content/json/exampleapps.json
+++ b/astro/src/content/json/exampleapps.json
@@ -556,5 +556,17 @@
     "name": "PHP Laravel API quickstart",
     "description": "PHP Laravel API quickstart tutorial showing how to integrate FusionAuth with a PHP Laravel API",
     "language": "php"
+  },
+  {
+    "url": "https://github.com/fusionauth/fusionauth-example-device-limit-simple",
+    "name": "Restrict Simultaneous Logins (Simple)",
+    "description": "Demonstrates how to limit the number of devices a user can simultaneously log in from, asking them to sign out from an existing session in order to continue",
+    "language": "javascript"
+  },
+  {
+    "url": "https://github.com/fusionauth/fusionauth-example-device-limit-friendly",
+    "name": "Restrict Simultaneous Logins (User-friendly)",
+    "description": "Demonstrates how to limit the number of devices a user can simultaneously log in from, allowing them to sign out via interface from other sessions",
+    "language": "javascript"
   }
 ]


### PR DESCRIPTION
Adding the "Device Limiting" guide to example apps and pointing to the new repos.

Before merging this, can someone please rename these repos?

- [FusionAuth/fusionauth-device-limit-guide-simple](https://github.com/FusionAuth/fusionauth-device-limit-guide-simple) to `FusionAuth/fusionauth-example-device-limit-simple`
- [FusionAuth/fusionauth-device-limit-guide-friendly](https://github.com/FusionAuth/fusionauth-device-limit-guide-friendly) to `FusionAuth/fusionauth-example-device-limit-friendly`
