### PR TITLE
Write SDK maintenance policy

### DIFF
--- a/astro/src/content/docs/sdks/_upgrade-policy.mdx
+++ b/astro/src/content/docs/sdks/_upgrade-policy.mdx
@@ -2,4 +2,4 @@ Besides the releases made to keep track of the FusionAuth API as mentioned above
 
 These releases may also update dependencies, language engines, and operating systems, as we'll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
 
-This means that after a language, framework or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also by deprecated by us, and will eventually be updated to use a newer version.
+This means that after a language, framework, or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also by deprecated by us, and will eventually be updated to use a newer version.

--- a/astro/src/content/docs/sdks/_upgrade-policy.mdx
+++ b/astro/src/content/docs/sdks/_upgrade-policy.mdx
@@ -2,4 +2,4 @@ Besides the releases made to keep track of the FusionAuth API as mentioned above
 
 These releases may also update dependencies, language engines, and operating systems, as we'll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
 
-This means that after a language, framework, or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also by deprecated by us, and will eventually be updated to use a newer version.
+This means that after a language, framework, or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also be deprecated by us, and will eventually be updated to use a newer version.

--- a/astro/src/content/docs/sdks/_upgrade-policy.mdx
+++ b/astro/src/content/docs/sdks/_upgrade-policy.mdx
@@ -1,0 +1,5 @@
+Besides the releases made to keep track of the FusionAuth API as mentioned above, SDKs and Client Libraries may periodically receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+
+These releases may also update dependencies, language engines, and operating systems, as we'll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
+
+This means that after a language, framework or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also by deprecated by us, and will eventually be updated to use a newer version.

--- a/astro/src/content/docs/sdks/angular-sdk.mdx
+++ b/astro/src/content/docs/sdks/angular-sdk.mdx
@@ -7,6 +7,7 @@ disableTOC: true
 ---
 import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import RemoteContent from 'src/components/RemoteContent.astro';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-angular-sdk/main/README.md"
                tags="forDocSite" />
@@ -19,3 +20,7 @@ import RemoteContent from 'src/components/RemoteContent.astro';
 ## Source Code
 
 The source code is available here: https://github.com/FusionAuth/fusionauth-angular-sdk/
+
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/dart.mdx
+++ b/astro/src/content/docs/sdks/dart.mdx
@@ -5,6 +5,7 @@ navcategory: developer
 section: sdks
 ---
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 ## Dart Client Library
 
@@ -12,3 +13,7 @@ The dart client is being deprecated and the best path forward is to build the cl
 
 ### Example Apps
 <ExampleApps language="dart" />
+
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/go.mdx
+++ b/astro/src/content/docs/sdks/go.mdx
@@ -6,6 +6,7 @@ section: sdks
 ---
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
 import HowToUseClientLibraries from 'src/content/docs/sdks/_how-to-use-client-libraries.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 import StaticPatchNote from 'src/content/docs/sdks/_static-patch-note.mdx';
 
 ## Go Client Library
@@ -94,3 +95,7 @@ To run:
 
 ### Example apps
 <ExampleApps language="go" />
+
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/index.mdx
+++ b/astro/src/content/docs/sdks/index.mdx
@@ -72,9 +72,8 @@ These client libraries still work and are built for every release, but are depre
 
 ## Maintenance Policy
 
-Besides the releases made to keep track of the FusionAuth API as mentioned above, SDKs and Client Libraries may periodically receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+As Client Libraries and SDKs use other packages and language runtimes to actually run the code, they have a strong coupling on the release process of these external tools.
 
-These releases may also update dependencies, language engines, and operating systems, as we'll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
+Our Client Libraries and SDKs will be updated to newer versions of those libraries and language runtimes every 6 months, which will be the only one actively maintained. The previous version will enter a **deprecated state** and only receive critical bug fixes and security issues for the next cycle of 6 months, and we'll sunset any version older than that.
 
-This means that after a language, framework or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also by deprecated by us, and will eventually be updated to use a newer version.
-
+If we decide to deprecate an entire Client Library and/or SDK, it will also only receive critical bug fixes and security issues for 6 months, until it finally reaches end-of-support, with no releases and updates anymore. Users may still use deprecated libraries at their own discretion via public package managers and/or GitHub repositories, which may be archived.

--- a/astro/src/content/docs/sdks/index.mdx
+++ b/astro/src/content/docs/sdks/index.mdx
@@ -72,8 +72,9 @@ These client libraries still work and are built for every release, but are depre
 
 ## Maintenance Policy
 
-As Client Libraries and SDKs use other packages and language runtimes to actually run the code, they have a strong coupling on the release process of these external tools.
+Besides the releases made to keep track of the FusionAuth API as mentioned above, SDKs and Client Libraries may periodically receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
 
-Our Client Libraries and SDKs will be updated to newer versions of those libraries and language runtimes every 6 months, which will be the only one actively maintained. The previous version will enter a **deprecated state** and only receive critical bug fixes and security issues for the next cycle of 6 months, and we'll sunset any version older than that.
+These releases may also update dependencies, language engines, and operating systems, as we'll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
 
-If we decide to deprecate an entire Client Library and/or SDK, it will also only receive critical bug fixes and security issues for 6 months, until it finally reaches end-of-support, with no releases and updates anymore. Users may still use deprecated libraries at their own discretion via public package managers and/or GitHub repositories, which may be archived.
+This means that after a language, framework or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also by deprecated by us, and will eventually be updated to use a newer version.
+

--- a/astro/src/content/docs/sdks/index.mdx
+++ b/astro/src/content/docs/sdks/index.mdx
@@ -5,6 +5,7 @@ navcategory: developer
 section: sdks
 ---
 import HowToUseClientLibraries from 'src/content/docs/sdks/_how-to-use-client-libraries.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 import Versioning from 'src/content/docs/operate/deploy/_client-library-versioning.mdx'
 
 ## Overview
@@ -70,11 +71,6 @@ These client libraries still work and are built for every release, but are depre
 
 <Versioning/>
 
-## Maintenance Policy
+## Upgrade Policy
 
-Besides the releases made to keep track of the FusionAuth API as mentioned above, SDKs and Client Libraries may periodically receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
-
-These releases may also update dependencies, language engines, and operating systems, as we'll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
-
-This means that after a language, framework or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also by deprecated by us, and will eventually be updated to use a newer version.
-
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/index.mdx
+++ b/astro/src/content/docs/sdks/index.mdx
@@ -69,3 +69,12 @@ These client libraries still work and are built for every release, but are depre
 ## Versioning
 
 <Versioning/>
+
+## Maintenance Policy
+
+Besides the releases made to keep track of the FusionAuth API as mentioned above, SDKs and Client Libraries may periodically receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+
+These releases may also update dependencies, language engines, and operating systems, as we'll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
+
+This means that after a language, framework or operating system is deprecated by their own maintainer, our SDKs and Client Libraries that depend on it will also by deprecated by us, and will eventually be updated to use a newer version.
+

--- a/astro/src/content/docs/sdks/java.mdx
+++ b/astro/src/content/docs/sdks/java.mdx
@@ -6,6 +6,7 @@ section: sdks
 ---
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
 import HowToUseClientLibraries from 'src/content/docs/sdks/_how-to-use-client-libraries.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 import StaticPatchNote from 'src/content/docs/sdks/_static-patch-note.mdx';
 
 ## Java Client Library
@@ -119,3 +120,6 @@ As you can see, using the lambda delegate requires less code to handle the succe
 ### Example Apps
 <ExampleApps language="java" />
 
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/javascript.mdx
+++ b/astro/src/content/docs/sdks/javascript.mdx
@@ -7,6 +7,7 @@ section: sdks
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
 import Aside from 'src/components/Aside.astro';
 import PublicClientNote from 'src/content/docs/sdks/_public-client-note.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 <Aside type="note">
 The following client library is now deprecated in favor of the [typescript](/docs/sdks/typescript) client, as it can do everything this project can but with better type support and examples.
@@ -55,3 +56,8 @@ Here is an example of using the `retrieveUserByEmail` method to retrieve a User 
 
 ### Example Apps
 <ExampleApps language="javascript" />
+
+## Upgrade Policy
+
+<SdkUpgradePolicy/>
+

--- a/astro/src/content/docs/sdks/netcore.mdx
+++ b/astro/src/content/docs/sdks/netcore.mdx
@@ -6,6 +6,7 @@ section: sdks
 ---
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
 import HowToUseClientLibraries from 'src/content/docs/sdks/_how-to-use-client-libraries.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 import StaticPatchNote from 'src/content/docs/sdks/_static-patch-note.mdx';
 import InlineUIElement from 'src/components/InlineUIElement.astro';
 
@@ -130,3 +131,6 @@ You will need to restart Visual Studio for the changes to take effect.
 ### Example Apps
 <ExampleApps language="netcore" />
 
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/node.mdx
+++ b/astro/src/content/docs/sdks/node.mdx
@@ -6,6 +6,7 @@ section: sdks
 ---
 import Aside from 'src/components/Aside.astro';
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 <Aside type="note">
 The following client library is now deprecated in favor of the [typescript](/docs/sdks/typescript) client, as it can do everything this project can but with better type support and examples.
@@ -52,3 +53,6 @@ function handleResponse (clientResponse) {
 ### Example Apps
 <ExampleApps language="javascript" />
 
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/php.mdx
+++ b/astro/src/content/docs/sdks/php.mdx
@@ -6,6 +6,7 @@ section: sdks
 ---
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
 import HowToUseClientLibraries from 'src/content/docs/sdks/_how-to-use-client-libraries.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 ## PHP Client Library
 
@@ -76,3 +77,7 @@ Here are other PHP libraries that may be useful. Some are community supported; p
 * [WordPress OpenID Connect Plugin](https://github.com/FusionAuth/wordpress-openid-connect)
 * https://github.com/jerryhopper/oauth2-fusionauth[FusionAuth Provider for the PHP League's OAuth 2.0 Client]
 * [FusionAuth Provider for Laravel Socialite](https://github.com/SocialiteProviders/FusionAuth)
+
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/python.mdx
+++ b/astro/src/content/docs/sdks/python.mdx
@@ -6,6 +6,7 @@ section: sdks
 ---
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
 import HowToUseClientLibraries from 'src/content/docs/sdks/_how-to-use-client-libraries.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 ## Python Client Library
 
@@ -68,3 +69,6 @@ else:
 ### Example Apps
 <ExampleApps language="python" />
 
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/react-sdk.mdx
+++ b/astro/src/content/docs/sdks/react-sdk.mdx
@@ -7,6 +7,7 @@ disableTOC: true
 ---
 import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import RemoteContent from 'src/components/RemoteContent.astro';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-react-sdk/main/README.md"
                tags="forDocSite" />
@@ -18,3 +19,8 @@ import RemoteContent from 'src/components/RemoteContent.astro';
 ## Source Code
 
 The source code is available here: https://github.com/FusionAuth/fusionauth-react-sdk/
+
+## Upgrade Policy
+
+<SdkUpgradePolicy/>
+

--- a/astro/src/content/docs/sdks/ruby.mdx
+++ b/astro/src/content/docs/sdks/ruby.mdx
@@ -6,6 +6,7 @@ section: sdks
 ---
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
 import HowToUseClientLibraries from 'src/content/docs/sdks/_how-to-use-client-libraries.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 ## Ruby Client Library
 
@@ -82,3 +83,6 @@ end
 ### Example Apps
 <ExampleApps language="ruby" />
 
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/typescript.mdx
+++ b/astro/src/content/docs/sdks/typescript.mdx
@@ -8,6 +8,7 @@ import Aside from 'src/components/Aside.astro';
 import ExampleApps from 'src/content/docs/sdks/examples/_example-footer.astro';
 import HowToUseClientLibraries from 'src/content/docs/sdks/_how-to-use-client-libraries.mdx';
 import PublicClientNote from 'src/content/docs/sdks/_public-client-note.mdx';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 ## Typescript Client Library
 
@@ -105,3 +106,6 @@ You can also find this example's [source code](https://github.com/FusionAuth/fus
 ### Example Apps
 <ExampleApps language="javascript" />
 
+## Upgrade Policy
+
+<SdkUpgradePolicy/>

--- a/astro/src/content/docs/sdks/vue-sdk.mdx
+++ b/astro/src/content/docs/sdks/vue-sdk.mdx
@@ -7,6 +7,7 @@ disableTOC: true
 ---
 import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warning.md';
 import RemoteContent from 'src/components/RemoteContent.astro';
+import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-vue-sdk/main/README.md"
                tags="forDocSite" />
@@ -18,3 +19,8 @@ import RemoteContent from 'src/components/RemoteContent.astro';
 ## Source Code
 
 The source code is available here: https://github.com/FusionAuth/fusionauth-vue-sdk/
+
+## Upgrade Policy
+
+<SdkUpgradePolicy/>
+


### PR DESCRIPTION
The idea behind this is to have a maintenance/deprecation policy on the SDKs / client libraries.

I've read a lot of them (e.g. [AWS'](https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html) and [Azure's](https://azure.github.io/azure-sdk/policies_support.html)), but they are too complex for us, as they have a whole lifecycle that spans over a year, so I tried to make things simpler.

This branch contains 2 commits for two alternatives:

1. 3da532757c9201b7d79029b8ecb0347d79539dce has a simpler approach:
  ![Alternative 1 - Without timeframe](https://github.com/FusionAuth/fusionauth-site/assets/1877191/85ed9937-7b62-4351-8fe2-e08c45baff84)
2. The latest (63ee130c5357025c8ab4bed171a9444bbc2a6e98) has a time commitment of 6 months (that we can discuss):
  ![Alternative 2 - With timeframe](https://github.com/FusionAuth/fusionauth-site/assets/1877191/0014c153-d99a-4436-82bc-50a107caae6c)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206600371228594