### PR TITLE
Parsing headers from Identity Providers pages to create TOCs

### DIFF
--- a/astro/src/content/config.js
+++ b/astro/src/content/config.js
@@ -59,6 +59,7 @@ const docsCollection = defineCollection({
     nestedHeadings: z.boolean().optional(),
     disableTOC: z.boolean().default(false),
     topOfNav: z.boolean().default(false),
+    idpDisplayName: z.string().optional(),
   }),
 });
 

--- a/astro/src/content/docs/apis/identity-providers/epicgames.mdx
+++ b/astro/src/content/docs/apis/identity-providers/epicgames.mdx
@@ -3,6 +3,7 @@ title: Epic Games
 description: Learn about the APIs for creating, retrieving, updating and disabling the Epic Games identity provider.
 section: apis
 subcategory: identity providers
+idpDisplayName: Epic Games
 ---
 import PremiumEditionBlurb from 'src/content/docs/_shared/_premium-edition-blurb.astro';
 import Aside from 'src/components/Aside.astro';
@@ -21,6 +22,6 @@ The Epic Games identity provider type will use the Epic Games OAuth login API. I
 
 This identity provider will call Epic Games' API to load the Epic Games user's `displayName` and use that as `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider.  However, Epic Games does not allow access to user emails, so neither email linking strategy can be used and user’s will not be able to login or be created.
 
-<TokenStorageNote idp_long_lived_token_type="refresh" idp_refresh_additional_info_url="https://dev.epicgames.com/docs/web-api-ref/authentication" idp_display_name="Epic Games" token_name="refresh_token" return_text="the Epic Games login " hide_token_map_deprecation="true" />
+<TokenStorageNote idp_long_lived_token_type="refresh" idp_refresh_additional_info_url="https://dev.epicgames.com/docs/web-api-ref/authentication" idp_display_name={frontmatter.idpDisplayName} token_name="refresh_token" return_text="the Epic Games login " hide_token_map_deprecation="true" />
 
-<OAuthIdpOperations idp_long_lived_token_type="refresh" idp_refresh_additional_info_url="https://dev.epicgames.com/docs/web-api-ref/authentication" idp_display_name="Epic Games" idp_id="1b932b19-61a8-47c7-9e81-27dbf9011dad" idp_linking_strategy="CreatePendingLink" idp_lowercase="epicgames" idp_since={12800} idp_token_or_code="token or code" idp_type="EpicGames" />
+<OAuthIdpOperations idp_long_lived_token_type="refresh" idp_refresh_additional_info_url="https://dev.epicgames.com/docs/web-api-ref/authentication" idp_display_name={frontmatter.idpDisplayName} idp_id="1b932b19-61a8-47c7-9e81-27dbf9011dad" idp_linking_strategy="CreatePendingLink" idp_lowercase="epicgames" idp_since={12800} idp_token_or_code="token or code" idp_type="EpicGames" />

--- a/astro/src/content/docs/apis/identity-providers/google.mdx
+++ b/astro/src/content/docs/apis/identity-providers/google.mdx
@@ -3,12 +3,11 @@ title: Google
 description: Learn about the APIs for creating, retrieving, updating and disabling the Google identity provider.
 section: apis
 subcategory: identity providers
+idpDisplayName: Google
 ---
 import Aside from 'src/components/Aside.astro';
 import TokenStorageNote from 'src/content/docs/apis/identity-providers/_token-storage-note.mdx';
 import OauthIdpOperations from 'src/content/docs/apis/identity-providers/_oauth-idp-operations.mdx';
-
-export const idp_display_name = 'Google';
 
 ## Overview
 
@@ -20,8 +19,8 @@ The Google identity provider type will use the Google OAuth v2.0 login API. It w
 
 This identity provider will call Google’s API to load the user's `email` and `preferred_username` and use those as `email` and `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider. Additional claims returned by Google can be used to reconcile the user to FusionAuth by using a Google Reconcile Lambda.
 
-<TokenStorageNote idp_long_lived_token_type="id_token" idp_display_name="Google" idp_linking_strategy="LinkByEmail" token_name="id_token" return_text="Google API" />
+<TokenStorageNote idp_long_lived_token_type="id_token" idp_display_name={frontmatter.idpDisplayName} idp_linking_strategy="LinkByEmail" token_name="id_token" return_text="Google API" />
 
 Please note if an `idp_hint` is appended to the OAuth Authorize endpoint, then the login method interaction will be `redirect`, even if popup interaction is explicitly configured.
 
-<OauthIdpOperations idp_id="82339786-3dff-42a6-aac6-1f1ceecb6c46" idp_display_name={idp_display_name} idp_login_method idp_lowercase="google" idp_since="10100" idp_token_or_code="token or code" idp_type="Google" />
+<OauthIdpOperations idp_id="82339786-3dff-42a6-aac6-1f1ceecb6c46" idp_display_name={frontmatter.idpDisplayName} idp_login_method idp_lowercase="google" idp_since="10100" idp_token_or_code="token or code" idp_type="Google" />

--- a/astro/src/content/docs/apis/identity-providers/nintendo.mdx
+++ b/astro/src/content/docs/apis/identity-providers/nintendo.mdx
@@ -3,6 +3,7 @@ title: Nintendo
 description: Learn about the APIs for creating, retrieving, updating and deleting the Nintendo identity provider.
 section: apis
 subcategory: identity providers
+idpDisplayName: Nintendo
 ---
 import PremiumEditionBlurb from 'src/content/docs/_shared/_premium-edition-blurb.astro';
 import Aside from 'src/components/Aside.astro';
@@ -21,10 +22,11 @@ The Nintendo identity provider type will use the Nintendo OAuth login API. It wi
 
 If the linking strategy depends on a username or email address, FusionAuth will leverage the `/users/me` API that is part of the Nintendo specification. The email address and username returned in the response will be used to create or lookup the existing User. Additional claims from the response can be used to reconcile the User in FusionAuth by using an Nintendo Reconcile Lambda. Unless you assign a reconcile lambda to this provider or configure the IdP options to use different claims, the `email` and `preferred_username` will be used from the available claims returned by the Nintendo identity provider.
 
-<TokenStorageNote idp_long_lived_token_type="access_token" idp_display_name="Nintendo" token_name="access_token" return_text="Nintendo API" hide_token_map_deprecation="true" />
+<TokenStorageNote idp_long_lived_token_type="access_token" idp_display_name={frontmatter.idpDisplayName} token_name="access_token" return_text="Nintendo API" hide_token_map_deprecation="true" />
 
 <OauthIdpOperations idp_long_lived_token_type="access_token"
-                    idp_display_name="Nintendo" idp_id="b0ac2e16-d4af-483e-98c8-7f6693610665"
+                    idp_display_name={frontmatter.idpDisplayName}
+                    idp_id="b0ac2e16-d4af-483e-98c8-7f6693610665"
                     idp_linking_strategy="CreatePendingLink"
                     idp_lowercase="nintendo"
                     idp_since="13600"

--- a/astro/src/content/docs/apis/identity-providers/sonypsn.mdx
+++ b/astro/src/content/docs/apis/identity-providers/sonypsn.mdx
@@ -3,6 +3,7 @@ title: Sony PlayStation Network
 description: Learn about the APIs for creating, retrieving, updating and disabling the Sony PlayStation Network identity provider.
 section: apis
 subcategory: identity providers
+idpDisplayName: Sony PlayStation Network
 ---
 import PremiumEditionBlurb from 'src/content/docs/_shared/_premium-edition-blurb.astro';
 import Aside from 'src/components/Aside.astro';
@@ -22,13 +23,13 @@ The Sony PlayStation Network identity provider type will use the Sony OAuth v2.0
 This identity provider will call Sony’s API to load the user's `email` and `online_id` and use those as `email` and `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider. Additional claims returned by Sony PlayStation Network can be used to reconcile the user to FusionAuth by using a Sony PlayStation Network Reconcile Lambda.
 
 <TokenStorageNote idp_long_lived_token_type="access_token"
-                  idp_display_name="Sony PlayStation Network "
+                  idp_display_name={frontmatter.idpDisplayName}
                   token_name="access_token"
                   return_text="Sony PlayStation Network API"
                   hide_token_map_deprecation="true" />
 
 <OauthIdpOperations idp_long_lived_token_type="access_token"
-                    idp_display_name="Sony PlayStation Network "
+                    idp_display_name={frontmatter.idpDisplayName}
                     idp_id="7764b5c7-165b-4e7e-94aa-02ebe2a0a5fb"
                     idp_linking_strategy="CreatePendingLink"
                     idp_lowercase="sonypsn"

--- a/astro/src/content/docs/apis/identity-providers/steam.mdx
+++ b/astro/src/content/docs/apis/identity-providers/steam.mdx
@@ -3,6 +3,7 @@ title: Steam
 description: Learn about the APIs for creating, retrieving, updating and disabling the Steam identity provider.
 section: apis
 subcategory: identity providers
+idpDisplayName: Steam
 ---
 import PremiumEditionBlurb from 'src/content/docs/_shared/_premium-edition-blurb.astro';
 import Aside from 'src/components/Aside.astro';
@@ -22,13 +23,13 @@ The Steam identity provider type will use the Steam OAuth login API. It will als
 This identity provider will call Steam's API to load the Steam user's `personaname` and use that as `username` to lookup or create a user in FusionAuth depending on the linking strategy configured for this identity provider.  However, Steam does not allow access to user emails, so neither email linking strategy can be used and user’s will not be able to login or be created.
 
 <TokenStorageNote idp_long_lived_token_type="token"
-                  idp_display_name="Steam"
+                  idp_display_name={frontmatter.idpDisplayName}
                   token_name="token"
                   return_text="Steam login"
                   hide_token_map_deprecation="true" />
 
 <OauthIdpOperations idp_long_lived_token_type="token"
-                    idp_display_name="Steam"
+                    idp_display_name={frontmatter.idpDisplayName}
                     idp_id="e4f39345-7833-4b1d-b331-ca03bdc2c4be"
                     idp_linking_strategy="CreatePendingLink"
                     idp_lowercase="steam"

--- a/astro/src/content/docs/apis/identity-providers/twitch.mdx
+++ b/astro/src/content/docs/apis/identity-providers/twitch.mdx
@@ -3,6 +3,7 @@ title: Twitch
 description: Learn about the APIs for creating, retrieving, updating and disabling the Twitch identity provider.
 section: apis
 subcategory: identity providers
+idpDisplayName: Twitch
 ---
 import PremiumEditionBlurb from 'src/content/docs/_shared/_premium-edition-blurb.astro';
 import Aside from 'src/components/Aside.astro';
@@ -25,9 +26,9 @@ FusionAuth will also store the Twitch `refresh_token` returned from the Twitch A
 
 <TokenStorageNote idp_long_lived_token_type="refresh"
                   idp_refresh_additional_info_url="https://dev.twitch.tv/docs/authentication/refresh-tokens/"
-                  idp_display_name="Twitch"
+                  idp_display_name={frontmatter.idpDisplayName}
                   token_name="refresh_token"
                   return_text="Twitch API"
                   hide_token_map_deprecation="true" />
 
-<OauthIdpOperations idp_long_lived_token_type="refresh" idp_refresh_additional_info_url="https://dev.twitch.tv/docs/authentication/refresh-tokens/" idp_display_name="Twitch" idp_id="bf4cf83f-e824-42d7-b4a3-5b10847a66b2" idp_linking_strategy="CreatePendingLink" idp_lowercase="twitch" idp_since="12800" idp_token_or_code="token or code" idp_type="Twitch" />
+<OauthIdpOperations idp_long_lived_token_type="refresh" idp_refresh_additional_info_url="https://dev.twitch.tv/docs/authentication/refresh-tokens/" idp_display_name={frontmatter.idpDisplayName} idp_id="bf4cf83f-e824-42d7-b4a3-5b10847a66b2" idp_linking_strategy="CreatePendingLink" idp_lowercase="twitch" idp_since="12800" idp_token_or_code="token or code" idp_type="Twitch" />

--- a/astro/src/content/docs/apis/identity-providers/xbox.mdx
+++ b/astro/src/content/docs/apis/identity-providers/xbox.mdx
@@ -3,6 +3,7 @@ title: Xbox
 description: Learn about the APIs for creating, retrieving, updating and disabling the Xbox identity provider.
 section: apis
 subcategory: identity providers
+idpDisplayName: Xbox
 ---
 import PremiumEditionBlurb from 'src/content/docs/_shared/_premium-edition-blurb.astro';
 import Aside from 'src/components/Aside.astro';
@@ -23,14 +24,14 @@ This identity provider will call Xbox’s API to load the user's `email` and `gt
 
 <TokenStorageNote idp_long_lived_token_type="refresh"
                   idp_refresh_additional_info_url="https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/live/features/s2s-auth-calls/service-authentication/live-service-authentication-nav"
-                  idp_display_name="Xbox"
+                  idp_display_name={frontmatter.idpDisplayName}
                   token_name="refresh_token"
                   return_text="Xbox API"
                   hide_token_map_deprecation={true} />
 
 <OauthIdpOperations idp_long_lived_token_type="refresh"
                     idp_refresh_additional_info_url="https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/live/features/s2s-auth-calls/service-authentication/live-service-authentication-nav"
-                    idp_display_name="Xbox"
+                    idp_display_name={frontmatter.idpDisplayName}
                     idp_id="af53ab21-34c3-468a-8ba2-ecb3905f67f2"
                     idp_linking_strategy="CreatePendingLink"
                     idp_lowercase="xbox"

--- a/astro/src/pages/docs/[...slug].astro
+++ b/astro/src/pages/docs/[...slug].astro
@@ -12,8 +12,23 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const navContext = await getDocNavContext(entry.data.section);
-let { Content, headings = [] } = await entry.render();
-if (headings.length === 0 && entry.data.nestedHeadings && !entry.data.disableTOC) {
+let { Content, headings, remarkPluginFrontmatter = [] } = await entry.render();
+if ((entry.data.section === 'apis') &&
+  (entry.data.subcategory === 'identity providers') &&
+  (headings.length === 1) &&
+  ('idpDisplayName' in remarkPluginFrontmatter)) {
+  const globs = await Astro.glob('../../content/docs/apis/identity-providers/_oauth-idp-operations.mdx');
+  if (globs[0]) {
+    const fileHeadings = globs[0].getHeadings();
+    if (fileHeadings) {
+      for (const h of fileHeadings) {
+        h.text = h.text.replace('props.idp_display_name', remarkPluginFrontmatter.idpDisplayName);
+        // We have a bug that we aren't replacing propsidp_display_name in the slug
+      }
+      headings = fileHeadings;
+    }
+  }
+} else if (headings.length === 0 && entry.data.nestedHeadings && !entry.data.disableTOC) {
   const globs = await Astro.glob('../../content/docs/**/**.mdx');
   const myglob = globs.find(glob => glob.url.endsWith(entry.id));
   if (myglob && myglob.headings) {


### PR DESCRIPTION
My approach to display TOCs on Identity Provider pages is to manually parse headers from `_oauth-idp-operations.mdx` when building the docs layout.

This only works if the frontmatter has `section` = `apis`, `subcategory` = `identity providers` and an `idpDisplayName` property (which will be used to replace the `{props.idp_display_name}` in the headers).

Closes fusionauth/fusionauth-issues#2554 