### PR TITLE
add aside for users[x].registrations[x].roles

### DIFF
--- a/astro/src/content/docs/apis/_import-users-request-body.mdx
+++ b/astro/src/content/docs/apis/_import-users-request-body.mdx
@@ -173,10 +173,7 @@ You must provide either the **email** or the **username** field for each User. T
     An array of locale strings that give, in order, the User's preferred languages for this registration. These are important for email templates and other localizable text. See [Locales](/docs/reference/data-types#locales).
   </APIField>
   <APIField name="users[x].registrations[x].roles" type="Array<String>" optional>
-    The list of roles that the User has for this registration.
-    <Aside type="note">
-      The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
-    </Aside>
+    The list of roles that the User has for this registration. The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
   </APIField>
   <APIField name="users[x].registrations[x].username" type="String" optional>
     The username of the User for this registration only.

--- a/astro/src/content/docs/apis/_import-users-request-body.mdx
+++ b/astro/src/content/docs/apis/_import-users-request-body.mdx
@@ -174,6 +174,9 @@ You must provide either the **email** or the **username** field for each User. T
   </APIField>
   <APIField name="users[x].registrations[x].roles" type="Array<String>" optional>
     The list of roles that the User has for this registration.
+    <Aside type="note">
+      The string is using the role's `Name` not the role's `Id`.
+    </Aside>
   </APIField>
   <APIField name="users[x].registrations[x].username" type="String" optional>
     The username of the User for this registration only.

--- a/astro/src/content/docs/apis/_import-users-request-body.mdx
+++ b/astro/src/content/docs/apis/_import-users-request-body.mdx
@@ -175,7 +175,7 @@ You must provide either the **email** or the **username** field for each User. T
   <APIField name="users[x].registrations[x].roles" type="Array<String>" optional>
     The list of roles that the User has for this registration.
     <Aside type="note">
-      The string is using the role's `Name` not the role's `Id`.
+      The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
     </Aside>
   </APIField>
   <APIField name="users[x].registrations[x].username" type="String" optional>

--- a/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
@@ -5,6 +5,7 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
 import UserSendSetPasswordEmail from 'src/content/docs/apis/_user-send-set-password-email.mdx';
 import UserDataEmailFieldRequest from 'src/content/docs/apis/_user-data-email-field-request.mdx';
 import JSON from 'src/components/JSON.astro';
+import Aside from 'src/components/Aside.astro';
 
 This request requires that you specify both the User object and the User Registration object in the request body. The fields for each are listed below.
 
@@ -37,7 +38,10 @@ This request requires that you specify both the User object and the User Registr
     The Id of this registration. If this is not specified, FusionAuth will create a random UUID for you.
   </APIField>
   <APIField name="registration.roles" type="Array<String>" optional>
-    The list of roles that the User has for this Application.
+    The list of roles that the User has for this registration.
+    <Aside type="note">
+      The string is using the role's `Name` not the role's `Id`.
+    </Aside>
   </APIField>
   <APIField name="registration.timezone" type="String" optional>
     The User's preferred timezone for this Application registration. The format is not enforced, however it is recommended to use a timezone in the TZ format such as

--- a/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
@@ -5,7 +5,6 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
 import UserSendSetPasswordEmail from 'src/content/docs/apis/_user-send-set-password-email.mdx';
 import UserDataEmailFieldRequest from 'src/content/docs/apis/_user-data-email-field-request.mdx';
 import JSON from 'src/components/JSON.astro';
-import Aside from 'src/components/Aside.astro';
 
 This request requires that you specify both the User object and the User Registration object in the request body. The fields for each are listed below.
 
@@ -38,10 +37,7 @@ This request requires that you specify both the User object and the User Registr
     The Id of this registration. If this is not specified, FusionAuth will create a random UUID for you.
   </APIField>
   <APIField name="registration.roles" type="Array<String>" optional>
-    The list of roles that the User has for this registration.
-    <Aside type="note">
-      The string is using the role's `Name` not the role's `Id`.
-    </Aside>
+    The list of roles that the User has for this registration. The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
   </APIField>
   <APIField name="registration.timezone" type="String" optional>
     The User's preferred timezone for this Application registration. The format is not enforced, however it is recommended to use a timezone in the TZ format such as

--- a/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
@@ -5,7 +5,6 @@ import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_r
 import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-field-response.mdx';
 import JSON from 'src/components/JSON.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
-import Aside from 'src/components/Aside.astro';
 
 #### Response Body
 
@@ -41,10 +40,7 @@ import Aside from 'src/components/Aside.astro';
     An array of locale strings that give, in order, the User's preferred languages for this registration. These are important for email templates and other localizable text. See [Locales](/docs/reference/data-types#locales).
   </APIField>
   <APIField name="registration.roles" type="Array<String>">
-    The list of roles that the User has for this registration.
-    <Aside type="note">
-      The string is using the role's `Name` not the role's `Id`.
-    </Aside>
+    The list of roles that the User has for this registration. The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
   </APIField>
   <APIField name="registration.timezone" type="String">
     The User's preferred timezone. The string will be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
@@ -5,6 +5,7 @@ import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_r
 import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-field-response.mdx';
 import JSON from 'src/components/JSON.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
+import Aside from 'src/components/Aside.astro';
 
 #### Response Body
 
@@ -41,6 +42,9 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   </APIField>
   <APIField name="registration.roles" type="Array<String>">
     The list of roles that the User has for this registration.
+    <Aside type="note">
+      The string is using the role's `Name` not the role's `Id`.
+    </Aside>
   </APIField>
   <APIField name="registration.timezone" type="String">
     The User's preferred timezone. The string will be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_user-registration-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-request-body.mdx
@@ -2,7 +2,6 @@ import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
-import Aside from 'src/components/Aside.astro';
 
 #### Request Body
 
@@ -30,10 +29,7 @@ import Aside from 'src/components/Aside.astro';
     The Id of this registration. If not specified a secure random UUID will be generated.
   </APIField>
   <APIField name="registration.roles" type="Array<String>" optional>
-    The list of roles that the User has for this registration.
-    <Aside type="note">
-      The string is using the role's `Name` not the role's `Id`.
-    </Aside>
+    The list of roles that the User has for this registration. The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
   </APIField>
   <APIField name="registration.timezone" type="String" optional>
     The User's preferred timezone for this Application registration. The string must be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_user-registration-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-request-body.mdx
@@ -2,6 +2,7 @@ import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
+import Aside from 'src/components/Aside.astro';
 
 #### Request Body
 
@@ -29,7 +30,10 @@ import JSON from 'src/components/JSON.astro';
     The Id of this registration. If not specified a secure random UUID will be generated.
   </APIField>
   <APIField name="registration.roles" type="Array<String>" optional>
-    The list of roles that the User has for this Application.
+    The list of roles that the User has for this registration.
+    <Aside type="note">
+      The string is using the role's `Name` not the role's `Id`.
+    </Aside>
   </APIField>
   <APIField name="registration.timezone" type="String" optional>
     The User's preferred timezone for this Application registration. The string must be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_user-registration-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-response-body.mdx
@@ -4,7 +4,6 @@ import InlineField from 'src/components/InlineField.astro';
 import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_response.mdx';
 import JSON from 'src/components/JSON.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
-import Aside from 'src/components/Aside.astro';
 
 #### Response Body
 
@@ -40,10 +39,7 @@ import Aside from 'src/components/Aside.astro';
     An array of locale strings that give, in order, the User's preferred languages for this registration. These are important for email templates and other localizable text. See [Locales](/docs/reference/data-types#locales).
   </APIField>
   <APIField name="registration.roles" type="Array<String>">
-    The list of roles that the User has for this registration.
-    <Aside type="note">
-      The string is using the role's `Name` not the role's `Id`.
-    </Aside>
+    The list of roles that the User has for this registration. The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
   </APIField>
   <APIField name="registration.timezone" type="String">
     The User's preferred timezone for this registration. The string will be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_user-registration-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-response-body.mdx
@@ -4,6 +4,7 @@ import InlineField from 'src/components/InlineField.astro';
 import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_response.mdx';
 import JSON from 'src/components/JSON.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
+import Aside from 'src/components/Aside.astro';
 
 #### Response Body
 
@@ -40,6 +41,9 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   </APIField>
   <APIField name="registration.roles" type="Array<String>">
     The list of roles that the User has for this registration.
+    <Aside type="note">
+      The string is using the role's `Name` not the role's `Id`.
+    </Aside>
   </APIField>
   <APIField name="registration.timezone" type="String">
     The User's preferred timezone for this registration. The string will be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_user-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-response-body.mdx
@@ -5,7 +5,6 @@ import JSON from 'src/components/JSON.astro';
 import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_response.mdx';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
 import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-field-response.mdx';
-import Aside from 'src/components/Aside.astro';
 
 #### Response Body
 
@@ -181,10 +180,7 @@ import Aside from 'src/components/Aside.astro';
     An array of locale strings that give, in order, the User's preferred languages for this registration. These are important for email templates and other localizable text.
   </APIField>
   <APIField name="user.registrations[x].roles" type="Array<String>">
-    The list of roles that the User has for this registration.
-    <Aside type="note">
-      The string is using the role's `Name` not the role's `Id`.
-    </Aside>
+    The list of roles that the User has for this registration. The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
   </APIField>
   <APIField name="user.registrations[x].timezone" type="String">
     The User's preferred timezone for this registration. The string will be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_user-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-response-body.mdx
@@ -5,6 +5,7 @@ import JSON from 'src/components/JSON.astro';
 import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_response.mdx';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
 import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-field-response.mdx';
+import Aside from 'src/components/Aside.astro';
 
 #### Response Body
 
@@ -181,6 +182,9 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
   </APIField>
   <APIField name="user.registrations[x].roles" type="Array<String>">
     The list of roles that the User has for this registration.
+    <Aside type="note">
+      The string is using the role's `Name` not the role's `Id`.
+    </Aside>
   </APIField>
   <APIField name="user.registrations[x].timezone" type="String">
     The User's preferred timezone for this registration. The string will be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_users-response-body.mdx
+++ b/astro/src/content/docs/apis/_users-response-body.mdx
@@ -4,7 +4,6 @@ import InlineField from 'src/components/InlineField.astro';
 import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_response.mdx';
 import JSON from 'src/components/JSON.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
-import Aside from 'src/components/Aside.astro';
 
 #### Response Body
 
@@ -142,10 +141,7 @@ import Aside from 'src/components/Aside.astro';
     An array of locale strings that give, in order, the User's preferred languages for this registration. These are important for email templates and other localizable text. See [Locales](/docs/reference/data-types#locales).
   </APIField>
   <APIField name="users[x].registrations[x].roles" type="Array<String>">
-    The list of roles that the User has for this registration.
-    <Aside type="note">
-      The string is using the role's `Name` not the role's `Id`.
-    </Aside>
+    The list of roles that the User has for this registration. The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
   </APIField>
   <APIField name="users[x].registrations[x].timezone" type="String">
     The User's preferred timezone for this registration. The string will be in an [IANA](https://www.iana.org/time-zones) time zone format.

--- a/astro/src/content/docs/apis/_users-response-body.mdx
+++ b/astro/src/content/docs/apis/_users-response-body.mdx
@@ -4,6 +4,7 @@ import InlineField from 'src/components/InlineField.astro';
 import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_response.mdx';
 import JSON from 'src/components/JSON.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
+import Aside from 'src/components/Aside.astro';
 
 #### Response Body
 
@@ -142,6 +143,9 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   </APIField>
   <APIField name="users[x].registrations[x].roles" type="Array<String>">
     The list of roles that the User has for this registration.
+    <Aside type="note">
+      The string is using the role's `Name` not the role's `Id`.
+    </Aside>
   </APIField>
   <APIField name="users[x].registrations[x].timezone" type="String">
     The User's preferred timezone for this registration. The string will be in an [IANA](https://www.iana.org/time-zones) time zone format.


### PR DESCRIPTION
Making more clear that the roles should be using `Name` not `Id`

from https://fusionauth.io/community/forum/topic/2630/why-does-import-user-with-registration-fail

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206729123648418