### PR TITLE
Reverting changes in the `count-repos.sh` script

### DIFF
--- a/.github/scripts/count-repos.sh
+++ b/.github/scripts/count-repos.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+SHOW_DIFF=0
+if [ "$1x" == "-vx" ]; then
+  SHOW_DIFF=1
+fi
+
 # count the repos we have in our example apps page and the number we have in our organization and make sure they match
 
 #fusionauth-containers, fusionauth-theme-helper, etc
@@ -17,8 +22,10 @@ COUNT_EXAMPLE_REPOS=`wc -l ex.list |sed 's/^ *//' |sed 's/ .*//'`
 gh repo list fusionauth --no-archived --visibility public -L 300 |grep fusionauth-quickstart | sed 's/\t.*//g'> qs.list
 COUNT_QUICKSTART_REPOS=`wc -l qs.list |sed 's/^ *//' |sed 's/ .*//'`
 
-sort json.list > json.sorted
-sort ex.list qs.list > gh.sorted
-diff json.sorted gh.sorted
+if [ $SHOW_DIFF -eq 1 ]; then
+  sort json.list > json.sorted
+  sort ex.list qs.list > gh.sorted
+  diff json.sorted gh.sorted
+fi
 
 echo "$COUNT_QUICKSTART_REPOS + $COUNT_EXAMPLE_REPOS - $EXTRA_IN_GH_NOT_DISPLAYABLE - $COUNT_IN_JSON + $EXTRA_IN_JSON_NOT_NAMED_CORRECTLY"|bc


### PR DESCRIPTION
37134839f0886693a96014ca98787f1968ef2a72 has removed a flag for verbose output in the [`count-repos.sh`](https://github.com/FusionAuth/fusionauth-site/blob/master/.github/scripts/count-repos.sh) script, which is causing it to display the `diff` and making the action fail, so I've reverted this change.