### PR TITLE
adjust regex for rss to include single or double quotes

### DIFF
--- a/astro/src/tools/docs/getReleaseNoteRssItems.ts
+++ b/astro/src/tools/docs/getReleaseNoteRssItems.ts
@@ -6,7 +6,7 @@ export const getReleaseNoteRssItems = async () => {
   const releaseLines = releaseNotes.body.split("\n");
   const archiveLines = archive.body.split("\n");
   const lines = [...releaseLines, ...archiveLines];
-  const items = lines.map(line => line.match(/ReleaseNoteHeading version="([^"]*)" releaseDate="([^"]*)"/))
+  const items = lines.map(line => line.match(/ReleaseNoteHeading version=['"]([^('|")]*)['"] releaseDate=['"]([^('|")]*)['"]/))
       .filter(line => !!line)
       .map(match => ({version: match[1], date: match[2]}))
       .map(version => ({


### PR DESCRIPTION
Adjusted regex to pick up single or double quotes in the ReleaseNoteHeading

https://inversoft.slack.com/archives/C02H35R1Q6N/p1709842867204509

<img width="825" alt="image" src="https://github.com/FusionAuth/fusionauth-site/assets/139158618/cc52ef52-abcd-4703-8eea-a5d1e4bbf17b">
