### PR TITLE
Doc changes for new confirmation required themed page

### DIFF
--- a/astro/src/content/docs/_shared/_theme_template_variables.astro
+++ b/astro/src/content/docs/_shared/_theme_template_variables.astro
@@ -14,7 +14,7 @@ const makeId = (name) => { return name.toLowerCase().replaceAll(' ', '-') };
 {templates.filter((t) => t.onlyAPI === undefined).map((t) =>
 <APIBlock>
   <h3 id={makeId(t.displayName)}>{t.displayName}</h3>
-  {t.version && <Aside type="version">Available since {t.version}.</Aside>}
+  {t.version && <Aside type="version">Available since {t.version}</Aside>}
   {t.path && <API method="" uri={t.path}/>}
   <h4>Variables</h4>
   {!t.variables && <p>No template specific variables.</p>}

--- a/astro/src/content/docs/_shared/_theme_templates.astro
+++ b/astro/src/content/docs/_shared/_theme_templates.astro
@@ -1,13 +1,14 @@
 ---
 import templates from 'src/content/json/themes/templates.json';
 import APIField from 'src/components/api/APIField.astro';
+import URI from 'src/components/URI.astro';
 import { marked } from 'marked';
 
-templates.sort((a, b) => { return a.fieldName.toUpperCase().localeCompare(b.fieldName.toUpperCase())}); 
+templates.sort((a, b) => { return a.fieldName.toUpperCase().localeCompare(b.fieldName.toUpperCase())});
 ---
-{templates.filter((t) => t.onlyAPI === undefined).map((t) => 
+{templates.filter((t) => t.onlyAPI === undefined).map((t) =>
   <APIField name={t.displayName} since={t.version} required>
     <span set:html={t.description ? marked.parse(t.description) : ''}></span>
-    {t.path}
+    <URI>{t.path}</URI>
   </APIFIeld>
 )}

--- a/astro/src/content/docs/apis/_theme-template-fields.astro
+++ b/astro/src/content/docs/apis/_theme-template-fields.astro
@@ -9,12 +9,12 @@ templates.sort((a, b) => { return a.fieldName.toUpperCase().localeCompare(b.fiel
 ---
 {templates.map((tmpl) =>
   <APIField name={((singleRequest || singleResponse) ? 'theme' : 'themes[x]') + '.templates.' + tmpl.fieldName } type="String" since={tmpl.version} optional={singleResponse}>
-    {tmpl.rawDescription ? 
+    {tmpl.rawDescription ?
       <p>
       {tmpl.rawDescription}
       </p> :
       <p>
-        A <a href="https://freemarker.apache.org">FreeMarker</a> template that is rendered when the user requests the {tmpl.path} path. <span set:html={marked.parse(tmpl.description)}></span>
+        A <a href="https://freemarker.apache.org">FreeMarker</a> template that is rendered when the user requests the <code>{tmpl.path}</code> path. <span set:html={marked.parse(tmpl.description)}></span>
       </p>
     }
 </APIFIeld>

--- a/astro/src/content/docs/apis/_user-registration-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-response-body.mdx
@@ -62,8 +62,14 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   <APIField name="registration.verified" type="Boolean">
     This value indicates if this User's registration has been verified.
   </APIField>
+  <APIField name="registrationVerificationId" type="String" since="1.27.0">
+    When registration verification is enabled, this value will be returned. This is the value that will have been emailed to the user in order to complete verification.
+  </APIField>
   <APIField name="token" type="String" since="1.16.0" renderif={!!props.registration_create_response}>
     The access token, this string is an encoded JSON Web Token (JWT).
+  </APIField>
+  <APIField name="tokenExpirationInstant" type="Long" since="1.33.0" renderif={!!props.registration_create_response}>
+    The <a href="/docs/reference/data-types#instants">instant</a> the <InlineField>token</InlineField> will expire. If the response does not contain a <InlineField>token</InlineField>, this field will also be omitted from the response.
   </APIField>
 </APIBlock>
 

--- a/astro/src/content/docs/apis/_user-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-response-body.mdx
@@ -57,6 +57,32 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
 
   </>}
 
+  { (props.create_user || props.update_user || props.retrieve_user) && <>
+
+    <APIField name="emailVerificationId" type="String" since="1.27.0">
+      An email verification Id. When present, this will represent the user's current email verification Id.
+
+      When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the <InlineField>emailVerificationOneTimeCode</InlineField> is the second component. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's email address.
+
+      When <code>ClickableLink</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
+
+      Prior to version <code>1.49.0</code>, this value was only returned when using <code>FormField</code> verification strategy. Beginning in <code>1.49.0</code> the value is always returned when available.
+    </APIField>
+
+    <APIField name="emailVerificationOneTimeCode" type="String" since="1.49.0">
+      An email one time code that will be paired with the <InlineField>emailVerificationOId</InlineField>.
+
+      When <code>FormField</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
+
+      This value will only be present when using the <code>FormField</code> verification strategy. When present, this is the value the user will need to enter to complete email verification.
+    </APIField>
+
+    <APIField name="registrationVerificationIds" type="Map<String, UUID>" since="1.27.0">
+      One or more registration verification Ids, keyed by the the <code>applicationId</code>. When present, these will represent any current registration verification Ids that are are valid for this user.
+    </APIField>
+
+  </>}
+
   <APIField name="user.active" type="Boolean">
     True if the User is active. False if the User has been deactivated. Deactivated Users will not be able to login.
   </APIField>

--- a/astro/src/content/docs/apis/_user-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-response-body.mdx
@@ -62,7 +62,7 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
     <APIField name="emailVerificationId" type="String" since="1.27.0">
       An email verification Id. When present, this will represent the user's current email verification Id.
 
-      When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the <InlineField>emailVerificationOneTimeCode</InlineField> is the second component. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's email address.
+      When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the <InlineField>emailVerificationOneTimeCode</InlineField> is the second part. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's email address.
 
       When <code>ClickableLink</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
 

--- a/astro/src/content/docs/apis/_user-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-response-body.mdx
@@ -70,15 +70,11 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
     </APIField>
 
     <APIField name="emailVerificationOneTimeCode" type="String" since="1.49.0">
-      An email one time code that will be paired with the <InlineField>emailVerificationOId</InlineField>.
+      An email one time code that will be paired with the <InlineField>emailVerificationId</InlineField>.
 
       When <code>FormField</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
 
       This value will only be present when using the <code>FormField</code> verification strategy. When present, this is the value the user will need to enter to complete email verification.
-    </APIField>
-
-    <APIField name="registrationVerificationIds" type="Map<String, UUID>" since="1.27.0">
-      One or more registration verification Ids, keyed by the the <code>applicationId</code>. When present, these will represent any current registration verification Ids that are are valid for this user.
     </APIField>
 
   </>}

--- a/astro/src/content/docs/apis/users.mdx
+++ b/astro/src/content/docs/apis/users.mdx
@@ -186,7 +186,7 @@ The response for this API contains the User that was updated. The password hash 
 
 <StandardPutResponseCodes webhook_event />
 
-<UserResponseBody />
+<UserResponseBody update_user />
 
 
 ## Delete a User

--- a/astro/src/content/docs/get-started/core-concepts/roles.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/roles.mdx
@@ -4,6 +4,7 @@ description: An overview of FusionAuth Roles.
 section: get started
 subcategory: core concepts
 ---
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import RoleAttributes from 'src/content/docs/get-started/core-concepts/_role_attributes.mdx';
 import Aside from 'src/components/Aside.astro';
 import Diagram from 'src/diagrams/docs/get-started/core-concepts/_users-tenants-relation.astro';
@@ -89,30 +90,30 @@ _FusionAuth application roles_
 | Name                       | Id                                     | Description                                                                        |
 |----------------------------|----------------------------------------|------------------------------------------------------------------------------------|
 | `admin`                    | `631ecd9d-8d40-4c13-8277-80cedb8236e2` | Can manage everything, including creating new users with administrator privileges. |
-| `acl_manager`              | `631ecd9d-8d40-4c13-8277-80cedb823712` | Can add and edit IP access control lists. Available since 1.30.0.                  |
-| `acl_deleter`              | `631ecd9d-8d40-4c13-8277-80cedb823711` | Can delete IP access control lists. Available since 1.30.0.                        |
+| `acl_manager`              | `631ecd9d-8d40-4c13-8277-80cedb823712` | Can add and edit IP access control lists. <AvailableSince since="1.30.0"/>         |
+| `acl_deleter`              | `631ecd9d-8d40-4c13-8277-80cedb823711` | Can delete IP access control lists. <AvailableSince since="1.30.0"/>               |
 | `api_key_manager`          | `631ecd9d-8d40-4c13-8277-80cedb8236e3` | Can add and edit API keys.                                                         |
 | `application_deleter`      | `631ecd9d-8d40-4c13-8277-80cedb8236e4` | Can delete applications.                                                           |
 | `application_manager`      | `631ecd9d-8d40-4c13-8277-80cedb8236e5` | Can add and edit applications.                                                     |
 | `audit_log_viewer`         | `631ecd9d-8d40-4c13-8277-80cedb8236e6` | Can view audit logs.                                                               |
-| `connector_deleter`        | `631ecd9d-8d40-4c13-8277-80cedb823700` | Can delete Connectors. Available since 1.18.0.                                     |
-| `connector_manager`        | `631ecd9d-8d40-4c13-8277-80cedb823701` | Can add and edit Connectors. Available since 1.18.0.                               |
+| `connector_deleter`        | `631ecd9d-8d40-4c13-8277-80cedb823700` | Can delete Connectors. <AvailableSince since="1.18.0"/>                            |
+| `connector_manager`        | `631ecd9d-8d40-4c13-8277-80cedb823701` | Can add and edit Connectors. <AvailableSince since="1.18.0"/>                      |
 | `consent_deleter`          | `631ecd9d-8d40-4c13-8277-80cedb8236fc` | Can delete consents.                                                               |
 | `consent_manager`          | `631ecd9d-8d40-4c13-8277-80cedb8236fd` | Can add and edit consents.                                                         |
 | `email_template_manager`   | `631ecd9d-8d40-4c13-8277-80cedb8236e7` | Can add and edit email templates.                                                  |
-| `entity_manager`           | `631ecd9d-8d40-4c13-8277-80cedb823706` | Can add and edit entities. Available since 1.26.0.                                 |
+| `entity_manager`           | `631ecd9d-8d40-4c13-8277-80cedb823706` | Can add and edit entities. <AvailableSince since="1.26.0"/>                        |
 | `event_log_viewer`         | `631ecd9d-8d40-4c13-8277-80cedb8236fa` | Can view the event log.                                                            |
-| `form_deleter`             | `631ecd9d-8d40-4c13-8277-80cedb823702` | Can delete forms and form fields. Available since 1.18.0.                          |
-| `form_manager`             | `631ecd9d-8d40-4c13-8277-80cedb823703` | Can add and edit forms and form fields. Available since 1.18.0.                    |
+| `form_deleter`             | `631ecd9d-8d40-4c13-8277-80cedb823702` | Can delete forms and form fields. <AvailableSince since="1.18.0"/>                 |
+| `form_manager`             | `631ecd9d-8d40-4c13-8277-80cedb823703` | Can add and edit forms and form fields. <AvailableSince since="1.18.0"/>           |
 | `group_deleter`            | `631ecd9d-8d40-4c13-8277-80cedb8236f6` | Can delete groups.                                                                 |
 | `group_manager`            | `631ecd9d-8d40-4c13-8277-80cedb8236f5` | Can add and edit groups.                                                           |
 | `key_manager`              | `631ecd9d-8d40-4c13-8277-80cedb8236fb` | Can add and edit keys.                                                             |
 | `lambda_manager`           | `631ecd9d-8d40-4c13-8277-80cedb8236f9` | Can add and edit lambdas.                                                          |
-| `message_template_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823709` | Can delete message templates. Available since 1.26.0.                              |
-| `message_template_manager` | `631ecd9d-8d40-4c13-8277-80cedb823710` | Can add and edit message templates. Available since 1.26.0.                        |
-| `messenger_deleter`        | `631ecd9d-8d40-4c13-8277-80cedb823707` | Can delete messengers. Available since 1.26.0.                                     |
-| `messenger_manager`        | `631ecd9d-8d40-4c13-8277-80cedb823708` | Can add and edit messengers. Available since 1.26.0.                               |
-| `reactor_manager`          | `631ecd9d-8d40-4c13-8277-80cedb8236ff` | Can add and edit reactor settings. Available since 1.15.0.                         |
+| `message_template_deleter` | `631ecd9d-8d40-4c13-8277-80cedb823709` | Can delete message templates. <AvailableSince since="1.26.0"/>                     |
+| `message_template_manager` | `631ecd9d-8d40-4c13-8277-80cedb823710` | Can add and edit message templates. <AvailableSince since="1.26.0"/>               |
+| `messenger_deleter`        | `631ecd9d-8d40-4c13-8277-80cedb823707` | Can delete messengers. <AvailableSince since="1.26.0"/>                            |
+| `messenger_manager`        | `631ecd9d-8d40-4c13-8277-80cedb823708` | Can add and edit messengers. <AvailableSince since="1.26.0"/>                      |
+| `reactor_manager`          | `631ecd9d-8d40-4c13-8277-80cedb8236ff` | Can add and edit reactor settings. <AvailableSince since="1.15.0"/>                |
 | `report_viewer`            | `631ecd9d-8d40-4c13-8277-80cedb8236e8` | Can view reports.                                                                  |
 | `system_manager`           | `631ecd9d-8d40-4c13-8277-80cedb8236e9` | Can add and edit system configuration.                                             |
 | `tenant_deleter`           | `631ecd9d-8d40-4c13-8277-80cedb8236f8` | Can delete tenants.                                                                |
@@ -121,9 +122,9 @@ _FusionAuth application roles_
 | `user_action_deleter`      | `631ecd9d-8d40-4c13-8277-80cedb8236f0` | Can delete user actions.                                                           |
 | `user_action_manager`      | `631ecd9d-8d40-4c13-8277-80cedb8236f1` | Can add and edit user actions.                                                     |
 | `user_deleter`             | `631ecd9d-8d40-4c13-8277-80cedb8236f2` | Can delete users.                                                                  |
-| `user_manager`             | `631ecd9d-8d40-4c13-8277-80cedb8236f3` | Can add and edit users.                                                            |
-| `user_support_manager`     | `631ecd9d-8d40-4c13-8277-80cedb823704` | Allows for a limited scope of user management. See below. Available since 1.23.0.  |
-| `user_support_viewer`      | `631ecd9d-8d40-4c13-8277-80cedb823705` | Can view user information. Available since 1.23.0.                                 |
+| `user_manager`             | `631ecd9d-8d40-4c13-8277-80cedb8236f3` | Can add and edit users.<br/><br/>Please note that because this role can fully managee users, it is similar to `admin`. The `user_support_manager` is recommended in most cases.|
+| `user_support_manager`     | `631ecd9d-8d40-4c13-8277-80cedb823704` | Allows for a limited scope of user management. See below. <AvailableSince since="1.23.0"/>  |
+| `user_support_viewer`      | `631ecd9d-8d40-4c13-8277-80cedb823705` | Can view user information. <AvailableSince since="1.23.0"/>                        |
 | `webhook_manager`          | `631ecd9d-8d40-4c13-8277-80cedb8236f4` | Can add or edit webhooks.                                                          |
 
 ## Special Role - user_support_manager

--- a/astro/src/content/docs/get-started/core-concepts/roles.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/roles.mdx
@@ -122,7 +122,7 @@ _FusionAuth application roles_
 | `user_action_deleter`      | `631ecd9d-8d40-4c13-8277-80cedb8236f0` | Can delete user actions.                                                           |
 | `user_action_manager`      | `631ecd9d-8d40-4c13-8277-80cedb8236f1` | Can add and edit user actions.                                                     |
 | `user_deleter`             | `631ecd9d-8d40-4c13-8277-80cedb8236f2` | Can delete users.                                                                  |
-| `user_manager`             | `631ecd9d-8d40-4c13-8277-80cedb8236f3` | Can add and edit users.<br/><br/>Please note that because this role can fully managee users, it is similar to `admin`. The `user_support_manager` is recommended in most cases.|
+| `user_manager`             | `631ecd9d-8d40-4c13-8277-80cedb8236f3` | Can add and edit users.<br/><br/>Please note that because this role can fully manage users, it is similar to `admin`. The `user_support_manager` is recommended in most cases.|
 | `user_support_manager`     | `631ecd9d-8d40-4c13-8277-80cedb823704` | Allows for a limited scope of user management. See below. <AvailableSince since="1.23.0"/>  |
 | `user_support_viewer`      | `631ecd9d-8d40-4c13-8277-80cedb823705` | Can view user information. <AvailableSince since="1.23.0"/>                        |
 | `webhook_manager`          | `631ecd9d-8d40-4c13-8277-80cedb8236f4` | Can add or edit webhooks.                                                          |

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -1004,13 +1004,13 @@ This migration will add an index to the `identity_provider_links` table. It is n
   * Resolved in version `1.40.2` via [GitHub Issue #1905](https://github.com/FusionAuth/fusionauth-issues/issues/1905)
 * A theme issue may exist on a form action and may cause breaking changes when upgrading to this version.
   * If you are upgrading, please verify your theme files accurately create a form action.  The following themes should be updated as follows:
-  ** OAuth authorize -> `action="/oauth2/authorize"`
-  ** Child registration not allowed -> `action="/oauth2/child-registration-not-allowed"`
-  ** OAuth passwordless -> `action="/oauth2/passwordless"`
-  ** OAuth register -> `action="/oauth2/register"`
-  ** OAuth two factor -> `action="/oauth2/two-factor"`
-  ** Change password form -> `action="/password/change"`
-  ** Forgot password -> `action="/password/forgot"`
+   * OAuth authorize -> `action="/oauth2/authorize"`
+   * Child registration not allowed -> `action="/oauth2/child-registration-not-allowed"`
+   * OAuth passwordless -> `action="/oauth2/passwordless"`
+   * OAuth register -> `action="/oauth2/register"`
+   * OAuth two factor -> `action="/oauth2/two-factor"`
+   * Change password form -> `action="/password/change"`
+   * Forgot password -> `action="/password/forgot"`
 
 ### Security
 

--- a/astro/src/content/json/themes/templates.json
+++ b/astro/src/content/json/themes/templates.json
@@ -187,6 +187,25 @@
     ]
   },
   {
+    "displayName": "Confirmation required",
+    "fieldName": "confirmationRequired",
+    "description": "This page is displayed when a user attempts to complete an email based workflow that did not begin in the same browser. For example, if the user starts a forgot password workflow, and then opens the link in a separate browser the user will be shown this panel.",
+    "path": "/confirmation-required",
+    "version": "1.49.0",
+    "variables": [
+      {
+        "name": "confirmationRequiredReason",
+        "type": "String",
+        "description": "The reason the user is being prompted for confirmation."
+      },
+      {
+        "name": "confirmationRequiredActionURI",
+        "type": "String",
+        "description": "The URI to return to once confirmation has been provided."
+      }
+    ]
+  },
+  {
     "displayName": "Email verification complete",
     "fieldName": "emailComplete",
     "description": "This page is used after a user has verified their email address by clicking the URL in the email. After FusionAuth has updated their user object to indicate that their email was verified, the browser is redirected to this page.",
@@ -201,12 +220,7 @@
       {
         "name": "email",
         "type": "String",
-        "description": "The email address that was passed as a URL parameter. This is the email address that is requesting that the verification email be re-sent to."
-      },
-      {
-        "name": "emailSent",
-        "type": "Boolean",
-        "description": "A boolean that indicates if the verification email was re-sent or not."
+        "description": "The email address that requested to receive a new email verification request."
       }
     ]
   },
@@ -1176,7 +1190,15 @@
     "displayName": "Forgot password sent",
     "fieldName": "passwordSent",
     "description": "This page is used when a user has submitted the forgot password form with their email. FusionAuth does not indicate back to the user if their email address was valid in order to prevent malicious activity that could reveal valid email addresses. Therefore, this page should indicate to the user that if their email was valid, they will receive an email shortly with a link to reset their password.",
-    "path": "/password/sent"
+    "path": "/password/sent",
+    "variables": [
+      {
+        "name": "email",
+        "type": "String",
+        "description": "The email address that requested to receive a change password request.",
+        "since": "1.48.0"
+      }
+    ]
   },
   {
     "displayName": "Unauthorized",
@@ -1217,12 +1239,7 @@
       {
         "name": "email",
         "type": "String",
-        "description": "The email address that was passed as a URL parameter. This is the email address that is requesting that the verification email be re-sent to."
-      },
-      {
-        "name": "emailSent",
-        "type": "Boolean",
-        "description": "A boolean that indicates if the verification email was re-sent or not."
+        "description": "The email address that requested to receive a new registration verification request."
       }
     ]
   },


### PR DESCRIPTION
### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2443

### Summary of changes 
1. Add new confirmationRequired themed page
2. Updated User response API to add missing fields. 
3. Use URI object in themed templates.
4. Fix formatting on release notes for 1.37.0
5. Message about `user_manager`.
6. Document `email` variable on `/password/sent`. 

Notes for reviewers. We have a lot of bugs in our docs. It is super important that each time you are in an API doc, or any doc - that you review it for completeness and accuracy. 