### PR TITLE
Remove archived example repos from exampleapps json

### DIFF
--- a/astro/src/content/json/exampleapps.json
+++ b/astro/src/content/json/exampleapps.json
@@ -84,18 +84,6 @@
     "language": "javascript"
   },
   {
-    "url": "https://github.com/FusionAuth/fusionauth-example-react-sdk",
-    "name": "React with an Express backend",
-    "description": "The Authorization Code grant using the React framework with the FusionAuth React SDK and an Express backend",
-    "language": "react"
-  },
-  {
-    "url": "https://github.com/FusionAuth/fusionauth-example-angular-sdk",
-    "name": "Angular with an Express backend",
-    "description": "The Authorization Code grant using the Angular framework with the FusionAuth Angular SDK and an Express backend",
-    "language": "angular"
-  },
-  {
     "url": "https://github.com/FusionAuth/fusionauth-example-device-grant",
     "name": "Device grant",
     "description": "An example of the Device Authorization grant",


### PR DESCRIPTION
Removing references to the following repos that are being archived as we consolidate SDK example apps with express backends:
- [Angular with an Express Backend](https://github.com/FusionAuth/fusionauth-example-angular-sdk)
- [React with an Express Backend](https://github.com/FusionAuth/fusionauth-example-react-sdk)
- [Vue](https://github.com/FusionAuth/fusionauth-example-vue-sdk) -- this repo was not referenced here, but it will be archived.