### PR TITLE
updating doc after renaming fusionauth repo

### DIFF
--- a/astro/src/content/docs/get-started/run-in-the-cloud/github-actions.mdx
+++ b/astro/src/content/docs/get-started/run-in-the-cloud/github-actions.mdx
@@ -4,8 +4,8 @@ description: How to use CI/CD with FusionAuth in GitHub.
 section: get started
 subcategory: run in the cloud
 prerequisites: Docker version 20
-url: https://github.com/FusionAuth/fusionauth-github-actions
-codeRoot: https://raw.githubusercontent.com/FusionAuth/fusionauth-github-actions/main
+url: https://github.com/FusionAuth/fusionauth-example-github-actions
+codeRoot: https://raw.githubusercontent.com/FusionAuth/fusionauth-example-github-actions/main
 ---
 import InlineUIElement from 'src/components/InlineUIElement.astro';
 import Aside from '/src/components/Aside.astro';
@@ -58,7 +58,7 @@ There is a minimal but complete CI/CD example in this <a href={frontmatter.url}>
 
 <OverviewDiagram />
 
-In GitHub, click <InlineUIElement>Fork</InlineUIElement> and add the repository to your GitHub account. Then run `git clone https://github.com/<your_username>/fusionauth-github-actions.git` in a terminal to download it.
+In GitHub, click <InlineUIElement>Fork</InlineUIElement> and add the repository to your GitHub account. Then run `git clone https://github.com/<your_username>/fusionauth-example-github-actions.git` in a terminal to download it.
 
 Below is the repository structure.
 


### PR DESCRIPTION
@tonyblank , please rename the [fusionauth-github-actions](https://github.com/FusionAuth/fusionauth-github-actions) repo to fusionauth-example-github-actions and then approve this request so the docs will be updated to the latest link.