### PR TITLE
fix red arrows on diagrams

### DIFF
--- a/astro/src/css/diagrams.css
+++ b/astro/src/css/diagrams.css
@@ -15,8 +15,8 @@
 }
 
 .mermaid-diagram .marker {
-  fill: red !important;
-  stroke: red !important;
+  fill: black !important;
+  stroke: black !important;
 }
 
 .mermaid-diagram .marker.cross {


### PR DESCRIPTION
Had red arrows before:

<img width="484" alt="Screenshot 2024-03-19 at 11 19 18 AM" src="https://github.com/FusionAuth/fusionauth-site/assets/91825/0d05dcef-58eb-4d7c-9f37-3e60a14ee9a8">
