### PR TITLE
Update remote content urls to point to SDK monorepo instead of old SDK repos

### DIFF
--- a/DocsDevREADME.md
+++ b/DocsDevREADME.md
@@ -124,7 +124,7 @@ You can find help for {props.topic} at [help](/help)
   - you may need to coerce a prop into a boolean to use as a conditional for an expression. Such as `{!!props.message && <span>{props.message}</span>}`;
 - JSON files are their own content collection in astro. You can reference these using the [JSON component](astro/src/components/JSON.astro)
 - We have an alias mapped in [tsconfig](astro/tsconfig.json) that allows you to use absolute references from 'src'. Otherwise, imports must use relative paths.
-- If a doc pulls code from an example application, use the [RemoteContent](astro/src/components/RemoteContent.astro). You can also pull sections with tags: `<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-react-sdk/main/README.md" tags="forDocSite" />`
+- If a doc pulls code from an example application, use the [RemoteContent](astro/src/components/RemoteContent.astro). You can also pull sections with tags: `<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-javascript-sdk/main/packages/sdk-react/README.md" tags="forDocSite" />`
 
 ### For API docs
 - We have many APIs which return the same objects either singly (if called with an Id) or in an array (if called without an Id). If you are creating or modifying an API with this, see if you can use the -base pattern that the tenants and applications do to reduce duplicates.

--- a/astro/src/content/docs/_shared/_hosted-backend-warning.md
+++ b/astro/src/content/docs/_shared/_hosted-backend-warning.md
@@ -7,7 +7,7 @@ If possible, have FusionAuth and your application served by the same domain, usi
 If this configuration is not possible, use one of these alternative methods:
 
 * Develop using a local FusionAuth instance, so both your webapp and FusionAuth are running on `localhost`.
-* Do not use the FusionAuth hosted backend, and instead write your own backend with a cross origin cookie policy: [here's an example](https://github.com/FusionAuth/fusionauth-example-react-sdk/tree/main/server).
+* Do not use the FusionAuth hosted backend, and instead write your own backend with a cross origin cookie policy: [here's an example](https://github.com/FusionAuth/fusionauth-javascript-sdk-express/tree/main).
 * Configure a [custom domain name for the FusionAuth Cloud instance](/docs/get-started/run-in-the-cloud/cloud#updating-with-existing-custom-domains) (limited to certain plans).
 
 Modifying FusionAuth CORS configuration options does not fix this issue because the cookies that FusionAuth writes will not be accessible cross domain.

--- a/astro/src/content/docs/sdks/angular-sdk.mdx
+++ b/astro/src/content/docs/sdks/angular-sdk.mdx
@@ -9,7 +9,7 @@ import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warni
 import RemoteContent from 'src/components/RemoteContent.astro';
 import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
-<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-angular-sdk/main/README.md"
+<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-javascript-sdk/main/packages/sdk-angular/README.md"
                tags="forDocSite" />
 
 
@@ -19,7 +19,7 @@ import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 ## Source Code
 
-The source code is available here: https://github.com/FusionAuth/fusionauth-angular-sdk/
+The source code is available here: https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-angular/
 
 ## Upgrade Policy
 

--- a/astro/src/content/docs/sdks/react-sdk.mdx
+++ b/astro/src/content/docs/sdks/react-sdk.mdx
@@ -9,7 +9,7 @@ import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warni
 import RemoteContent from 'src/components/RemoteContent.astro';
 import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
-<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-react-sdk/main/README.md"
+<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-javascript-sdk/main/packages/sdk-react/README.md"
                tags="forDocSite" />
 
 ## Usage With FusionAuth Cloud
@@ -18,7 +18,7 @@ import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 ## Source Code
 
-The source code is available here: https://github.com/FusionAuth/fusionauth-react-sdk/
+The source code is available here: https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-react/
 
 ## Upgrade Policy
 

--- a/astro/src/content/docs/sdks/vue-sdk.mdx
+++ b/astro/src/content/docs/sdks/vue-sdk.mdx
@@ -9,7 +9,7 @@ import HostedBackendWarning from 'src/content/docs/_shared/_hosted-backend-warni
 import RemoteContent from 'src/components/RemoteContent.astro';
 import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
-<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-vue-sdk/main/README.md"
+<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-javascript-sdk/main/packages/sdk-vue/README.md"
                tags="forDocSite" />
 
 ## Usage With FusionAuth Cloud
@@ -18,7 +18,7 @@ import SdkUpgradePolicy from 'src/content/docs/sdks/_upgrade-policy.mdx';
 
 ## Source Code
 
-The source code is available here: https://github.com/FusionAuth/fusionauth-vue-sdk/
+The source code is available here: https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-vue/
 
 ## Upgrade Policy
 


### PR DESCRIPTION
#### Related to [this ticket](https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/26)

Updating remote content pulled from these archived repos:
- [fusionauth-angular-sdk](https://github.com/FusionAuth/fusionauth-angular-sdk)
- [fusionauth-react-sdk](https://github.com/FusionAuth/fusionauth-react-sdk)
- [fusionauth-vue-sdk](https://github.com/FusionAuth/fusionauth-vue-sdk)

It should be pulled from the SDK’s respective package within the SDK monorepo: [fusionauth-javascript-sdk](https://github.com/FusionAuth/fusionauth-javascript-sdk)

Also updating hyperlinks pointing to archived repos—barring those within blog posts.