### PR TITLE
Document that FusionAuth admin app can set the app MFA policy regardl…

### DIFF
--- a/astro/src/content/docs/apis/_application-request-body.mdx
+++ b/astro/src/content/docs/apis/_application-request-body.mdx
@@ -157,7 +157,7 @@ import AdvancedEditionBlurbApi from 'src/content/docs/_shared/_advanced-edition-
   <APIField name="application.multiFactorConfiguration.email.templateId" type="UUID" optional since="1.26.0">
     The Id of the email template that is used when notifying a user to complete a multi-factor authentication request.
   </APIField>
-  <APIField name="application.multiFactorConfiguration.loginPolicy" type="String" optional since="1.37.0">
+    <APIField name="application.multiFactorConfiguration.loginPolicy" type="String" optional since="1.37.0">
     When enabled and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When disabled, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login. When required, the user will be required to complete a two-factor challenge during login.
 
     When configured, this value overrides the value configured by the <InlineField>tenant.multiFactorConfiguration.loginPolicy</InlineField>.
@@ -167,6 +167,8 @@ import AdvancedEditionBlurbApi from 'src/content/docs/_shared/_advanced-edition-
     * `Enabled` - Require a two-factor challenge during login when an eligible method is available.
     * `Disabled` - Do not require a two-factor challenge during login.
     * `Required` - Require a two-factor challenge during login. A user will be required to configure 2FA if no eligible methods are available. <span class="text-green-600">Available since 1.42.0</span>
+
+    While this configuration requires a license, in version `1.49.0` or later it may be enabled for the FusionAuth admin application regardless of the license state.
   </APIField>
   <APIField name="application.multiFactorConfiguration.sms.templateId" type="UUID" optional since="1.26.0">
     The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.


### PR DESCRIPTION
### Summary 
Document that FusionAuth admin app can set the app MFA policy regardless of license state.

### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2571