### PR TITLE
Add more user and registration response verificationIds

### DIFF
--- a/astro/src/components/JSON.astro
+++ b/astro/src/components/JSON.astro
@@ -21,7 +21,7 @@ const parsedTitle = title ? parseInline(title) : '';
 const code = JSON.stringify(json.data, null, 2);
 ---
 {/* title is optional, do not render an empty em tag */}
-{title && <em set:html={parsedTitle}/>}
+{title && <p class="mb-0"><em set:html={parsedTitle}/></p>}
 <div class="mb-14 prose-pre:mt-1">
   <Code lang="json" {code}></Code>
 </div>

--- a/astro/src/components/api/API.astro
+++ b/astro/src/components/api/API.astro
@@ -93,8 +93,10 @@ const authenticationTypes = {
         parts.map(part =>
           <span class:list={[ part.type === 'segment' ? 'text-blue-300 font-semibold' : 'font-normal', 'break-words leading-5 tracking-normal']}>{ part.value }</span>
         )
-      }<!-- Remove line return between these two spans.
-       -->{ parameters && <span class="text-blue-300 break-words leading-5 tracking-normal">{ parameters }</span> }
+
+      }<!-- Note: This comment is removing white space between these two expressions to remove white space between the spans.
+                  If any white space exists, it will render as a space on the page.
+      -->{ parameters && <span class="text-blue-300 break-words leading-5 tracking-normal">{ parameters }</span> }
     </span>
   </div>
 </div>

--- a/astro/src/components/api/API.astro
+++ b/astro/src/components/api/API.astro
@@ -93,8 +93,8 @@ const authenticationTypes = {
         parts.map(part =>
           <span class:list={[ part.type === 'segment' ? 'text-blue-300 font-semibold' : 'font-normal', 'break-words leading-5 tracking-normal']}>{ part.value }</span>
         )
-      }
-      { parameters && <span class="text-blue-300 break-words leading-5 tracking-normal">{ parameters }</span> }
+      }<!-- Remove line return between these two spans.
+       -->{ parameters && <span class="text-blue-300 break-words leading-5 tracking-normal">{ parameters }</span> }
     </span>
   </div>
 </div>

--- a/astro/src/content/docs/apis/_user-email-verification-ids-response.mdx
+++ b/astro/src/content/docs/apis/_user-email-verification-ids-response.mdx
@@ -1,0 +1,20 @@
+import APIField from 'src/components/api/APIField.astro';
+import InlineField from 'src/components/InlineField.astro';
+
+<APIField name="emailVerificationId" type="String" since="1.27.0">
+  An email verification Id. When present, this will represent the user's current email verification Id.
+
+  When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the <InlineField>emailVerificationOneTimeCode</InlineField> is the second part. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's email address.
+
+  When <code>ClickableLink</code> is the verification strategy, this is the value that will have been emailed to the user in order to complete verification. If you have not configured SMTP, you may optionally use this value to use an out of band transport such as your own email service.
+
+  Prior to version <code>1.49.0</code>, this value was only returned when using <code>FormField</code> verification strategy. Beginning in <code>1.49.0</code> the value is always returned when available.
+</APIField>
+
+<APIField name="emailVerificationOneTimeCode" type="String" since="1.49.0">
+  An email one time code that will be paired with the <InlineField>emailVerificationId</InlineField>.
+
+  When <code>FormField</code> is the verification strategy, this is the value that will have been emailed to the user in order to complete verification. If you have not configured SMTP, you may optionally use this value to use an out of band transport such as your own email service.
+
+  This value will only be present when using the <code>FormField</code> verification strategy. When present, this is the value the user will need to enter to complete email verification.
+</APIField>

--- a/astro/src/content/docs/apis/_user-email-verification-ids-response.mdx
+++ b/astro/src/content/docs/apis/_user-email-verification-ids-response.mdx
@@ -4,17 +4,17 @@ import InlineField from 'src/components/InlineField.astro';
 <APIField name="emailVerificationId" type="String" since="1.27.0">
   An email verification Id. When present, this will represent the user's current email verification Id.
 
-  When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the <InlineField>emailVerificationOneTimeCode</InlineField> is the second part. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's email address.
+  When using `FormField` verification strategy, this is the first part of the pair of verification Ids, and the <InlineField>emailVerificationOneTimeCode</InlineField> is the second part. When `ClickableLink` is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's email address.
 
-  When <code>ClickableLink</code> is the verification strategy, this is the value that will have been emailed to the user in order to complete verification. If you have not configured SMTP, you may optionally use this value to use an out of band transport such as your own email service.
+  When `ClickableLink` is the verification strategy, this is the value that will have been emailed to the user in order to complete verification. If you have not configured SMTP, you may optionally use this value to use an out of band transport such as your own email service.
 
-  Prior to version <code>1.49.0</code>, this value was only returned when using <code>FormField</code> verification strategy. Beginning in <code>1.49.0</code> the value is always returned when available.
+  Prior to version `1.49.0`, this value was only returned when using `FormField` verification strategy. Beginning in `1.49.0` the value is always returned when available.
 </APIField>
 
 <APIField name="emailVerificationOneTimeCode" type="String" since="1.49.0">
   An email one time code that will be paired with the <InlineField>emailVerificationId</InlineField>.
 
-  When <code>FormField</code> is the verification strategy, this is the value that will have been emailed to the user in order to complete verification. If you have not configured SMTP, you may optionally use this value to use an out of band transport such as your own email service.
+  When `FormField` is the verification strategy, this is the value that will have been emailed to the user in order to complete verification. If you have not configured SMTP, you may optionally use this value to use an out of band transport such as your own email service.
 
-  This value will only be present when using the <code>FormField</code> verification strategy. When present, this is the value the user will need to enter to complete email verification.
+  This value will only be present when using the `FormField` verification strategy. When present, this is the value the user will need to enter to complete email verification.
 </APIField>

--- a/astro/src/content/docs/apis/_user-login-response.mdx
+++ b/astro/src/content/docs/apis/_user-login-response.mdx
@@ -1,0 +1,29 @@
+import APIField from 'src/components/api/APIField.astro';
+import InlineField from 'src/components/InlineField.astro';
+
+<APIField name="pendingIdPLinkId" type="String" since="1.28.0" renderif={!!props.idp_response}>
+  The pending identity provider link Id. This value is created when logging in with an identity provider configured with a linking strategy of <code>Create a pending link</code>. It will only be included in the response body when this strategy is configured and a link does not yet exist for the user. It is used in conjunction with the <a href="/docs/apis/identity-providers/links">Link APIs</a> to complete a pending link.
+</APIField>
+
+  <APIField name="refreshToken" type="String">
+  The refresh token that can be used to obtain a new access token once the provided one has expired.
+
+  Because a refresh token is per user and per application, this value will only be returned when an <InlineField>applicationId</InlineField> was provided on the login request and the user is registered to the application.
+
+  You must explicitly allow generation of refresh tokens when using the Login API.
+
+  Configure the <InlineField>application.loginConfiguration.generateRefreshTokens</InlineField> setting via the API or enable the setting by navigating to the <strong>Application -&gt; My Application -&gt; Security</strong> tab.
+</APIField>
+
+<APIField name="refreshTokenId" type="String" since="1.37.0">
+  When the <InlineField>refreshToken</InlineField> is returned in the response, this field will also be returned. This unique Id is the persistent identifier for this refresh token, and will not change even when using one-time use refresh tokens. This value may optionally be used to revoke the token using the <a href="/docs/apis/jwt#revoke-refresh-tokens">Refresh Token API</a>.
+</APIField>
+  <APIField name="state" type="Object" renderif={props.login_response && !props.two_factor_login_response}>
+  If authenticated using a One Time Password and <InlineField>state</InlineField> was provided during the Change Password request this value will be returned exactly as it was provided.
+</APIField>
+  <APIField name="state" type="Object" since="1.26.0" renderif={!!props.two_factor_login_response}>
+  If authenticated using Two Factor and <InlineField>state</InlineField> was provided during the Two Factor Start request this value will be returned exactly as it was provided.
+</APIField>
+  <APIField name="state" type="Object" renderif={!!props.passwordless_login_response}>
+  If state was provided during the passwordless login send request this value will be returned exactly as it was provided.
+</APIField>

--- a/astro/src/content/docs/apis/_user-memberships-response.mdx
+++ b/astro/src/content/docs/apis/_user-memberships-response.mdx
@@ -1,0 +1,17 @@
+import APIField from 'src/components/api/APIField.astro';
+
+<APIField name="user.memberships" type="Array">
+  The list of memberships for the User.
+</APIField>
+  <APIField name="user.memberships[x].data" type="Object">
+  An object that can hold any information about the User for this membership that should be persisted.
+</APIField>
+  <APIField name="user.memberships[x].groupId" type="UUID">
+  The Id of the Group of this membership.
+</APIField>
+  <APIField name="user.memberships[x].id" type="UUID">
+  The unique Id of this membership.
+</APIField>
+  <APIField name="user.memberships[x].insertInstant" type="Long">
+  The <a href="/docs/reference/data-types#instants">instant</a> that the membership was created.
+</APIField>

--- a/astro/src/content/docs/apis/_user-registration-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-response-body.mdx
@@ -63,7 +63,18 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
     This value indicates if this User's registration has been verified.
   </APIField>
   <APIField name="registrationVerificationId" type="String" since="1.27.0">
-    When registration verification is enabled, this value will be returned. This is the value that will have been emailed to the user in order to complete verification.
+    When registration verification is enabled, this value will be returned if the registration has not yet been verified.
+
+    When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the <InlineField>registrationVerificationOneTimeCode</InlineField> is the second part. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the registration.
+
+    When <code>ClickableLink</code> is the verification strategy, this is the value that will have been emailed to the user in order to complete verification. If you have not configured SMTP, you may optionally use this value to use an out of band transport such as your own email service.
+
+    Prior to version <code>1.49.0</code>, this value was only returned when using <code>FormField</code> verification strategy. Beginning in <code>1.49.0</code> the value is always returned when available.
+  </APIField>
+  <APIField name="registrationVerificationOneTimeCode" type="String" since="1.49.2">
+    A registration one time code that will be paired with the <InlineField>registrationVerificationId</InlineField>.
+
+    This value will only be present when when <code>FormField</code> is configured as the verification strategy. When present, this value will have been emailed to the user in order to complete verification. If you have not configured SMTP, you may optionally use this value to use an out of band transport such as your own email service.
   </APIField>
   <APIField name="token" type="String" since="1.16.0" renderif={!!props.registration_create_response}>
     The access token, this string is an encoded JSON Web Token (JWT).

--- a/astro/src/content/docs/apis/_user-registration-verification-ids-response.mdx
+++ b/astro/src/content/docs/apis/_user-registration-verification-ids-response.mdx
@@ -1,0 +1,20 @@
+import APIField from 'src/components/api/APIField.astro';
+import InlineField from 'src/components/InlineField.astro';
+
+<APIField name="registrationVerificationIds" type="Map<UUID, List<String>" since="1.27.0">
+  A map of registration verification Id keyed by the `application`. When present, this will represent the user's current registration verification Ids.
+
+  When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the one time code in the <InlineField>registrationVerificationOneTimeCodes</InlineField> map is the second part. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's registration.
+
+  When <code>ClickableLink</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
+
+  Prior to version <code>1.49.0</code>, this value was only returned when using <code>FormField</code> verification strategy. Beginning in <code>1.49.0</code> the value is always returned when available.
+</APIField>
+
+<APIField name="registrationVerificationOneTimeCodes" type="Map<UUID, List<String>" since="1.49.2">
+  A registration one time code that will be paired with the verification Id in the <InlineField>registrationVerificationIds</InlineField> map.
+
+  When <code>FormField</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
+
+  This value will only be present when using the <code>FormField</code> verification strategy. When present, this is the value the user will need to enter to complete registration verification.
+</APIField>

--- a/astro/src/content/docs/apis/_user-registration-verification-ids-response.mdx
+++ b/astro/src/content/docs/apis/_user-registration-verification-ids-response.mdx
@@ -1,20 +1,20 @@
 import APIField from 'src/components/api/APIField.astro';
 import InlineField from 'src/components/InlineField.astro';
 
-<APIField name="registrationVerificationIds" type="Map<UUID, List<String>" since="1.27.0">
+<APIField name="registrationVerificationIds" type="Map<UUID, List<String>>" since="1.27.0">
   A map of registration verification Id keyed by the `application`. When present, this will represent the user's current registration verification Ids.
 
-  When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the one time code in the <InlineField>registrationVerificationOneTimeCodes</InlineField> map is the second part. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's registration.
+  When using `FormField` verification strategy, this is the first part of the pair of verification Ids, and the one time code in the <InlineField>registrationVerificationOneTimeCodes</InlineField> map is the second part. When `ClickableLink` is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's registration.
 
-  When <code>ClickableLink</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
+  When `ClickableLink` is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
 
-  Prior to version <code>1.49.0</code>, this value was only returned when using <code>FormField</code> verification strategy. Beginning in <code>1.49.0</code> the value is always returned when available.
+  Prior to version `1.49.0`, this value was only returned when using `FormField` verification strategy. Beginning in `1.49.0` the value is always returned when available.
 </APIField>
 
-<APIField name="registrationVerificationOneTimeCodes" type="Map<UUID, List<String>" since="1.49.2">
+<APIField name="registrationVerificationOneTimeCodes" type="Map<UUID, List<String>>" since="1.49.2">
   A registration one time code that will be paired with the verification Id in the <InlineField>registrationVerificationIds</InlineField> map.
 
-  When <code>FormField</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
+  When `FormField` is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
 
-  This value will only be present when using the <code>FormField</code> verification strategy. When present, this is the value the user will need to enter to complete registration verification.
+  This value will only be present when using the `FormField` verification strategy. When present, this is the value the user will need to enter to complete registration verification.
 </APIField>

--- a/astro/src/content/docs/apis/_user-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-response-body.mdx
@@ -5,38 +5,18 @@ import JSON from 'src/components/JSON.astro';
 import ModerationStatusResponse from 'src/content/docs/apis/_moderation_status_response.mdx';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
 import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-field-response.mdx';
+import EmailVerificationIdsFieldsResponse from 'src/content/docs/apis/_user-email-verification-ids-response.mdx';
+import RegistrationVerificationIdsFieldsResponse from 'src/content/docs/apis/_user-registration-verification-ids-response.mdx';
+import UserMembershipFieldsResponse from 'src/content/docs/apis/_user-memberships-response.mdx';
+import UserTokenFieldsResponse from 'src/content/docs/apis/_user-token-response.mdx';
+import UserLoginFieldsResponse from 'src/content/docs/apis/_user-login-response.mdx';
 
 #### Response Body
 
 <APIBlock>
-  { (props.login_response || props.passwordless_login_response) && <>
-
-  <APIField name="pendingIdPLinkId" type="String" since="1.28.0" renderif={!!props.idp_response}>
-    The pending identity provider link Id. This value is created when logging in with an identity provider configured with a linking strategy of <code>Create a pending link</code>. It will only be included in the response body when this strategy is configured and a link does not yet exist for the user. It is used in conjunction with the <a href="/docs/apis/identity-providers/links">Link APIs</a> to complete a pending link.
-  </APIField>
-
-  <APIField name="refreshToken" type="String">
-    The refresh token that can be used to obtain a new access token once the provided one has expired.
-
-    Because a refresh token is per user and per application, this value will only be returned when an <InlineField>applicationId</InlineField> was provided on the login request and the user is registered to the application.
-
-    You must explicitly allow generation of refresh tokens when using the Login API. Configure the <InlineField>application.loginConfiguration.generateRefreshTokens</InlineField> setting via the API or enable the setting by navigating to the <strong>Application -&gt; My Application -&gt; Security</strong> tab.
-  </APIField>
-
-  <APIField name="refreshTokenId" type="String" since="1.37.0">
-    When the <InlineField>refreshToken</InlineField> is returned in the response, this field will also be returned. This unique Id is the persistent identifier for this refresh token, and will not change even when using one-time use refresh tokens. This value may optionally be used to revoke the token using the <a href="/docs/apis/jwt#revoke-refresh-tokens">Refresh Token API</a>.
-  </APIField>
-  <APIField name="state" type="Object" renderif={props.login_response && !props.two_factor_login_response}>
-    If authenticated using a One Time Password and <InlineField>state</InlineField> was provided during the Change Password request this value will be returned exactly as it was provided.
-  </APIField>
-  <APIField name="state" type="Object" since="1.26.0" renderif={!!props.two_factor_login_response}>
-    If authenticated using Two Factor and <InlineField>state</InlineField> was provided during the Two Factor Start request this value will be returned exactly as it was provided.
-  </APIField>
-  <APIField name="state" type="Object" renderif={!!props.passwordless_login_response}>
-    If state was provided during the passwordless login send request this value will be returned exactly as it was provided.
-  </APIField>
-
-  </> }
+  { (props.login_response || props.passwordless_login_response) &&
+    <UserLoginFieldsResponse/>
+  }
 
   <APIField name="trustToken" type="String" since="1.33.0" renderif={!!props.two_factor_login_response}>
     A trust token that may be used to complete another API request that requires trust. For example, if you receive an error from an API indicating trust is required - indicated by this error code `[TrustTokenRequired]`, this value can be used to satisfy the trust requirement.
@@ -46,38 +26,17 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
     subsequent login requests to bypass the Two Factor challenge.
   </APIField>
 
-  { (props.create_user || props.login_response || props.passwordless_login_response || props.idp_response) && <>
+  { (props.create_user || props.login_response || props.passwordless_login_response || props.idp_response) &&
+    <UserTokenFieldsResponse/>
+  }
 
-  <APIField name="token" type="String" since="1.16.0">
-    The access token, this string is an encoded JSON Web Token (JWT).
-  </APIField>
-  <APIField name="tokenExpirationInstant" type="Long" since="1.33.0">
-    The <a href="/docs/reference/data-types#instants">instant</a> the <InlineField>token</InlineField> will expire. If the response does not contain a <InlineField>token</InlineField>, this field will also be omitted from the response.
-  </APIField>
+  { (props.create_user || props.update_user || props.retrieve_user) &&
+    <EmailVerificationIdsFieldsResponse />
+  }
 
-  </>}
-
-  { (props.create_user || props.update_user || props.retrieve_user) && <>
-
-    <APIField name="emailVerificationId" type="String" since="1.27.0">
-      An email verification Id. When present, this will represent the user's current email verification Id.
-
-      When using <code>FormField</code> verification strategy, this is the first part of the pair of verification Ids, and the <InlineField>emailVerificationOneTimeCode</InlineField> is the second part. When <code>ClickableLink</code> is the verification strategy, this value is sensitive in that this value by itself can be used to verify the user's email address.
-
-      When <code>ClickableLink</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
-
-      Prior to version <code>1.49.0</code>, this value was only returned when using <code>FormField</code> verification strategy. Beginning in <code>1.49.0</code> the value is always returned when available.
-    </APIField>
-
-    <APIField name="emailVerificationOneTimeCode" type="String" since="1.49.0">
-      An email one time code that will be paired with the <InlineField>emailVerificationId</InlineField>.
-
-      When <code>FormField</code> is the verification strategy, you may optionally use this value to use an out of band transport such as your own email service.
-
-      This value will only be present when using the <code>FormField</code> verification strategy. When present, this is the value the user will need to enter to complete email verification.
-    </APIField>
-
-  </>}
+  { props.retrieve_user &&
+    <RegistrationVerificationIdsFieldsResponse />
+  }
 
   <APIField name="user.active" type="Boolean">
     True if the User is active. False if the User has been deactivated. Deactivated Users will not be able to login.
@@ -88,11 +47,9 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
   <APIField name="user.breachedPasswordLastCheckedInstant" type="Long">
     The [instant](/docs/reference/data-types#instants) this user's password was last checked to determine if it is compromised.
   </APIField>
-  { (!props.connector_response) && <>
   <APIField name="user.connectorId" type="UUID" since="1.18.0">
     The unique Id of the [Connector](/docs/lifecycle/migrate-users/connectors/) associated with the System of Record being used to authenticate the user.
   </APIField>
-  </>}
   <APIField name="user.cleanSpeakId" type="UUID">
     This Id is used by FusionAuth when the User's username is sent to CleanSpeak to be moderated (filtered and potentially sent to the approval queue). It is the **content Id** of the username inside CleanSpeak.
   </APIField>
@@ -136,25 +93,9 @@ import UserDataEmailFieldResponse from 'src/content/docs/apis/_user-data-email-f
     The [instant](/docs/reference/data-types#instants) when the User was last updated.
   </APIField>
 
-  {!props.create_user && <>
-
-  <APIField name="user.memberships" type="Array">
-    The list of memberships for the User.
-  </APIField>
-  <APIField name="user.memberships[x].data" type="Object">
-    An object that can hold any information about the User for this membership that should be persisted.
-  </APIField>
-  <APIField name="user.memberships[x].groupId" type="UUID">
-    The Id of the Group of this membership.
-  </APIField>
-  <APIField name="user.memberships[x].id" type="UUID">
-    The unique Id of this membership.
-  </APIField>
-  <APIField name="user.memberships[x].insertInstant" type="Long">
-    The <a href="/docs/reference/data-types#instants">instant</a> that the membership was created.
-  </APIField>
-
-  </>}
+  {!props.create_user &&
+    <UserMembershipFieldsResponse />
+  }
 
   <APIField name="user.middleName" type="String">
     The User's middle name.

--- a/astro/src/content/docs/apis/_user-token-response.mdx
+++ b/astro/src/content/docs/apis/_user-token-response.mdx
@@ -1,0 +1,9 @@
+import APIField from 'src/components/api/APIField.astro';
+import InlineField from 'src/components/InlineField.astro';
+
+<APIField name="token" type="String" since="1.16.0">
+  The access token, this string is an encoded JSON Web Token (JWT).
+</APIField>
+  <APIField name="tokenExpirationInstant" type="Long" since="1.33.0">
+  The <a href="/docs/reference/data-types#instants">instant</a> the <InlineField>token</InlineField> will expire. If the response does not contain a <InlineField>token</InlineField>, this field will also be omitted from the response.
+</APIField>

--- a/astro/src/content/docs/lifecycle/migrate-users/connectors/generic-connector.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/connectors/generic-connector.mdx
@@ -63,7 +63,7 @@ The security settings may be used to require authentication in order to make the
     The password to be used for HTTP Basic Authentication.
   </APIField>
   <APIField name="Certificate" optional>
-    The SSL certificate to be used when connecting to the POST endpoint. 
+    The SSL certificate to be used when connecting to the POST endpoint.
 
     If you need to add a certificate for use with this connector, navigate to <strong>Settings -> Key Master</strong> and import a certificate. The certificate will then be shown as an option in this form control.
   </APIField>
@@ -121,7 +121,7 @@ If the user cannot be authenticated, then you should return a `404`.
 
 <StandardPostResponseCodes never_search_error missing_message="To prevent enumeration attacks, a 404 is returned for any non 200 status code returned from your connector." omit_internal_error omit_missing_header omit_error_malformed />
 
-<UserResponseBody connector_response />
+<UserResponseBody />
 
 <JSON title="Example Successful Response JSON" src="users/login-migrated-response.json" />
 
@@ -156,7 +156,7 @@ For <InlineField>Connect timeout</InlineField>, if the timeout expires before th
 For <InlineField>Read timeout</InlineField>, if the timeout expires before there is data available to be read, the login fails.
 The default values for these timeouts are typically adequate, but you may want to tune them if there is resource contention on your server.
 
-However, neither timeout prevents the HTTP request from taking as long as it needs to in order to respond once the API endpoint has begun to write bytes to the output stream. 
+However, neither timeout prevents the HTTP request from taking as long as it needs to in order to respond once the API endpoint has begun to write bytes to the output stream.
 If a Connector is not correctly terminating the HTTP response or taking an excessive time to process the login request, then this can cause issues under load.
 
 You can avoid issues by having your API endpoint write login data and completely close the connection as quickly as possible.

--- a/astro/src/css/style.css
+++ b/astro/src/css/style.css
@@ -20,3 +20,18 @@ lite-youtube {
     color: theme('textColor.green.600');
   }
 }
+
+/*
+Handle spacing between the title and the code block for markdown code blocks
+ex:
+```json title="stuff"
+{"things": "stuff"}
+```
+*/
+p[data-title] {
+  margin-bottom: 0;
+}
+
+p[data-title] + div pre {
+  margin-top: .25rem;
+}


### PR DESCRIPTION
### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2681

### Summary
1. Add new fields to the User and Registration API responses. 
2. Fix formatting by removing inlined code and moving them to includes. 

We probably have this error all over the place, so I opened an issue so that we can get all of this fixed. 
- https://github.com/FusionAuth/fusionauth-issues/issues/2699
