### PR TITLE
user_support_manager capabilities update

### DIFF
--- a/astro/src/content/docs/get-started/core-concepts/roles.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/roles.mdx
@@ -131,6 +131,7 @@ _FusionAuth application roles_
 
 The `user_support_manager` role is a role tuned for tier 1 technical support personnel and has a mix of capabilities. A user with such a role can:
 
+_FusionAuth user_support_manager_
 
 | Domain       | Ability                                                                                                                                                                         |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/astro/src/content/docs/get-started/core-concepts/roles.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/roles.mdx
@@ -131,7 +131,6 @@ _FusionAuth application roles_
 
 The `user_support_manager` role is a role tuned for tier 1 technical support personnel and has a mix of capabilities. A user with such a role can:
 
-_FusionAuth user_support_manager_
 
 | Domain       | Ability                                                                                                                                                                         |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -149,7 +148,6 @@ _FusionAuth user_support_manager_
 | user         | Edit a user, except for any identity information that could be used to authenticate. For example, the email and username cannot be modified.                                    |
 | user         | Lock a user account.                                                                                                                                                            |
 | user         | Unlock a user account.                                                                                                                                                          |
-| user         | Modify 2FA settings if available.                                                                                                                                               |
 | user         | Action a user.                                                                                                                                                                  |
 | user         | Add a comment to a user.                                                                                                                                                        |
 | user         | Verify a user's email address.                                                                                                                                                  |

--- a/astro/src/content/docs/get-started/core-concepts/roles.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/roles.mdx
@@ -149,6 +149,7 @@ _FusionAuth user_support_manager_
 | user         | Edit a user, except for any identity information that could be used to authenticate. For example, the email and username cannot be modified.                                    |
 | user         | Lock a user account.                                                                                                                                                            |
 | user         | Unlock a user account.                                                                                                                                                          |
+| user         | View 2FA settings if available.                                                                                                                                                 |
 | user         | Action a user.                                                                                                                                                                  |
 | user         | Add a comment to a user.                                                                                                                                                        |
 | user         | Verify a user's email address.                                                                                                                                                  |


### PR DESCRIPTION
A user with the user_support_manager role cannot update another user's 2FA settings. 