### PR TITLE
Fix wordpress link and nav issues

### DIFF
--- a/astro/src/content/docs/lifecycle/migrate-users/provider-specific/wordpress.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/provider-specific/wordpress.mdx
@@ -1,5 +1,5 @@
 ---
-title: Migrate From WordPress
+title: Migration From WordPress
 description: How to migrate your users from WordPress to FusionAuth.
 section: lifecycle
 subcategory: migrate users

--- a/astro/src/content/docs/lifecycle/migrate-users/provider-specific/wordpress.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/provider-specific/wordpress.mdx
@@ -397,7 +397,7 @@ In a terminal in the `fusionauth-import-scripts/wordpress/src` directory, run th
 node 4_convertWpUserToFaUser.mjs
 ```
 
-### Save The User Details And Hash To FusionAuth
+### Use The Script
 
 Now you have the users file `faUsers.json` and the {frontmatter.hashTechnology} plugin is installed. To import the users into FusionAuth, you need to run the Node.js import script.
 


### PR DESCRIPTION
There were 2 issues:

* the social login fragment references a particular header anchor, but it wasn't used in the wordpress guide
* the wordpress guide used a different title than others, which caused nav issues