### PR TITLE
fix(kickstart): all examples should be using generateRefreshTokens

### DIFF
--- a/astro/src/content/json/applications/oauth-configuration/response.json
+++ b/astro/src/content/json/applications/oauth-configuration/response.json
@@ -16,7 +16,7 @@
       "authorization_code",
       "refresh_token"
     ],
-    "generateRefreshToken": true,
+    "generateRefreshTokens": true,
     "logoutBehavior": "AllApplications",
     "logoutURL": "http://www.example.com/logout",
     "proofKeyForCodeExchangePolicy": "NotRequired",

--- a/astro/src/content/json/applications/post-request.json
+++ b/astro/src/content/json/applications/post-request.json
@@ -79,7 +79,7 @@
         "authorization_code",
         "refresh_token"
       ],
-      "generateRefreshToken": true,
+      "generateRefreshTokens": true,
       "logoutBehavior": "AllApplications",
       "logoutURL": "http://www.example.com/logout",
       "proofKeyForCodeExchangePolicy": "NotRequired"

--- a/astro/src/content/json/applications/response.json
+++ b/astro/src/content/json/applications/response.json
@@ -85,7 +85,7 @@
         "authorization_code",
         "refresh_token"
       ],
-      "generateRefreshToken": true,
+      "generateRefreshTokens": true,
       "logoutBehavior": "AllApplications",
       "logoutURL": "http://www.example.com/logout",
       "proofKeyForCodeExchangePolicy": "NotRequired",

--- a/astro/src/content/json/applications/responses.json
+++ b/astro/src/content/json/applications/responses.json
@@ -86,7 +86,7 @@
           "authorization_code",
           "refresh_token"
         ],
-        "generateRefreshToken": true,
+        "generateRefreshTokens": true,
         "logoutBehavior": "AllApplications",
         "logoutURL": "http://www.example.com/logout",
         "proofKeyForCodeExchangePolicy": "NotRequired",

--- a/astro/src/content/json/applications/search-response.json
+++ b/astro/src/content/json/applications/search-response.json
@@ -84,7 +84,7 @@
           "authorization_code",
           "refresh_token"
         ],
-        "generateRefreshToken": true,
+        "generateRefreshTokens": true,
         "logoutBehavior": "AllApplications",
         "logoutURL": "http://www.example.com/logout",
         "proofKeyForCodeExchangePolicy" : "NotRequired",


### PR DESCRIPTION
The example code does not follow the specification https://fusionauth.io/docs/apis/applications:
`application.oauthConfiguration.generateRefreshTokens` - Boolean - Available since 1.3.0
Determines if the OAuth 2.0 Token endpoint will generate a refresh token when the offline_access scope is requested.

Interestingly enough when using `generateRefreshToken` it does not fail but just ignores the value with FusionAuth version 1.49.2.