### PR TITLE
the trust policy settings apply for application mfa when enabled or required

### DIFF
--- a/astro/src/content/docs/apis/_application-request-body.mdx
+++ b/astro/src/content/docs/apis/_application-request-body.mdx
@@ -50,7 +50,7 @@ import AdvancedEditionBlurbApi from 'src/content/docs/_shared/_advanced-edition-
 
     When this value is not defined, the value defined by <InlineField>tenant.externalIdentifierConfiguration.twoFactorTrustIdTimeToLiveInSeconds</InlineField> is utilized. When this value is defined it will override the tenant configured value.
 
-    This configuration is only utilized when <InlineField>application.multiFactorConfiguration.loginPolicy</InlineField> is enabled.
+    This configuration is only utilized when <InlineField>application.multiFactorConfiguration.loginPolicy</InlineField> is `Enabled` or `Required`.
   </APIField>
   <APIField name="application.formConfiguration.selfServiceFormConfiguration.requireCurrentPasswordOnPasswordChange" type="Boolean" optional since="1.45.0">
     When enabled a user will be required to provide their current password when changing their password on a self-service account form.
@@ -174,7 +174,7 @@ import AdvancedEditionBlurbApi from 'src/content/docs/_shared/_advanced-edition-
     The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.
   </APIField>
   <APIField name="application.multiFactorConfiguration.trustPolicy" type="String" optional since="1.37.0">
-    When <InlineField>application.multiFactorConfiguration.loginPolicy</InlineField> is set to `Enabled`, this trust policy is utilized when determining if a user must complete a two-factor challenge during login.
+    When <InlineField>application.multiFactorConfiguration.loginPolicy</InlineField> is set to `Enabled` or `Required`, this trust policy is utilized when determining if a user must complete a two-factor challenge during login.
 
     For example, a normal two-factor login flow will result in a trust Id being returned if you set <InlineField>trustComputer</InlineField> equal to `true` when completing a Two Factor Login. The returned Trust identifier can be used on subsequent Login requests to keep from being required to complete a Two-Factor login. This configuration determines if that trust value can be utilized for another application.
 

--- a/astro/src/content/docs/get-started/core-concepts/applications.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/applications.mdx
@@ -269,7 +269,7 @@ The multi-factor configuration allows you to provide Application specific multi-
     * Required. A challenge will be required during login. &nbsp; <AvailableSince since="1.42.0" />
   </APIField>
   <APIField name="Trust policy" optional>
-    When <InlineField>On login policy</InlineField> is set to `Enabled`,  the following field will be displayed. This value will control how the two-factor trust value is utilized.
+    When <InlineField>On login policy</InlineField> is set to `Enabled` or `Required`, the following field will be displayed. This value will control how the two-factor trust value is utilized.
 
     Supported values include:
 


### PR DESCRIPTION
Update the api and app doc to correctly state when the policy applies