### PR TITLE
AWS CloudFront redirect to URL example.

### DIFF
--- a/astro/src/content/json/exampleapps.json
+++ b/astro/src/content/json/exampleapps.json
@@ -568,5 +568,11 @@
     "name": "Github Actions",
     "description": "This sample application demonstrates how to use a GitHub Action to run Playwright tests against a simple Node.js Express.js application that logs in with FusionAuth.",
     "language": "javascript"
+  },
+  {
+    "url": "https://github.com/FusionAuth/fusionauth-example-cloudfront-redirect",
+    "name": "AWS CloudFront redirect to URL",
+    "description": "This example documents how to use a AWS CloudFront Function to redirect to country-specific URLs, such as a FusionAuth instance.",
+    "language": "javascript"
   }
 ]


### PR DESCRIPTION
This example documents how to use a AWS CloudFront Function to redirect to country-specific URLs, such as a FusionAuth instance.