### PR TITLE
Update copy of react-quickstart tutorial in lockstep with React SDK v2

### DIFF
--- a/astro/src/content/quickstarts/quickstart-javascript-react-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-javascript-react-web.mdx
@@ -52,13 +52,13 @@ cd fusionauth-quickstart-javascript-react-web
 
 ### Create a basic React application
 
-Now you are going to create a basic React application using the React CLI. While this section builds a simple React application, you can use the same configuration to integrate your existing React application with FusionAuth.
+Now you are going to create a basic React application using the [Vite](https://vitejs.dev/). While this section builds a simple React application, you can use the same configuration to integrate your existing React application with FusionAuth.
 
 ```shell
-npx create-react-app changebank && cd changebank
+npm create vite@latest changebank -- --template react-ts && cd changebank
 ```
 <Aside type="note">
-    It may ask you to install the `create-react-app` package, just confirm it. Further information can be found on the [Create React App Website](https://create-react-app.dev/docs/getting-started/)
+    The fusionauth server is configured with the valid redirect URI of localhost:3000. Ensure your changebank app runs on this port by adding `server: { port: 3000 }` to your `vite.config.ts`.
 </Aside>
 
 We are going to use the [Hosted Backend](/docs/apis/hosted-backend) feature of FusionAuth, so you don't need to worry about setting up a backend server.
@@ -75,7 +75,7 @@ Install the FusionAuth React SDK, and React Router, which we'll use to manage th
 npm install @fusionauth/react-sdk react-router-dom
 ```
 
-Next, you'll need to configure the SDK with your FusionAuth URL and client Id. You can do this by modifying the configuration object in `src/main.tsx`:
+Next, you'll need to configure the SDK with your FusionAuth URL, client Id, and redirect URI. You can do this by updating `src/main.tsx`:
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-react-web/main/complete-application/src/main.tsx"
             lang="tsx"/>


### PR DESCRIPTION
Redrafting part of copy for quickstart-javascript-react-web tutorial in lockstep with React SDK v2.

This tutorial copy needs these small updates due to [this fusionauth-quickstart-javascript-react-web change](https://github.com/FusionAuth/fusionauth-quickstart-javascript-react-web/pull/20), which broke some links as well.