### PR TITLE
Remove duplicate name parameter from Form API request body

### DIFF
--- a/astro/src/content/docs/apis/custom-forms/_form-request-body.mdx
+++ b/astro/src/content/docs/apis/custom-forms/_form-request-body.mdx
@@ -12,9 +12,6 @@ import JSON from 'src/components/JSON.astro';
   <APIField name="form.name" type="String" required>
     The unique name of the Form.
   </APIField>
-  <APIField name="form.name" type="String" required>
-    The unique name of the Form.
-  </APIField>
   <APIField name="form.steps" type="Array<Object>" required>
     An ordered list of objects containing one or more Form Fields. A Form must have at least one step defined.
 


### PR DESCRIPTION
The Custom Forms API was displaying the `name` parameter twice. Made updates to the page to remove the duplicate parameter. 