### PR TITLE
Adding License Key Instructions to Common Config

### DIFF
--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -29,7 +29,7 @@ Production keys must be used for any FusionAuth instance that customers will be 
 Non-production keys may be used for any other instances such as your developers' laptops, QA, or UAT. 
 
 * Log in to the administrative user interface.
-* Navigate to <strong>Plan</strong> and copy the appropriate key.
+* Navigate to  <Breadcrumb>Plan</Breadcrumb> and copy the appropriate key.
 * Access the FusionAuth instance and navigate to the <Breadcrumb>Reactor</Breadcrumb>.
 * Paste that key into the License Key field and Activate it.
 

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -1,3 +1,4 @@
+import Breadcrumb from 'src/components/Breadcrumb.astro';
 import InlineField from 'src/components/InlineField.astro';
 
 These configuration steps are common to almost all FusionAuth installations. Take these steps to avoid being inadvertently locked out of your FusionAuth server.

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -29,7 +29,7 @@ Production keys must be used for any FusionAuth instance that customers will be 
 Non-production keys may be used for any other instances such as your developer's laptops, QA, or UAT. 
 
 * Log in to the administrative user interface.
-* Navigate to <strong>Plan</strong> and copy the appropiate key
+* Navigate to <strong>Plan</strong> and copy the appropriate key.
 * Access the FusionAuth instance and navigate to the <strong>Reactor</strong> 
 * Paste that key into the License Key field and Activate it
 

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -19,6 +19,18 @@ Create a second user with the admin role. This user can provide access should yo
 * Add a user with a known, valid email address and secure password within your organization.
 * Register that user with the FusionAuth application and the `admin` role.
 
+## Activate License Key
+
+Activating the license key will allow access to all of the features inside FusionAuth. The key is found in your account portal and is activated in the <strong>Reactor</strong> tab. Production keys must be used for any FusionAuth instance that customers will be logging into, that is how we track MAUs. Non-Production may be used for any other instances such as Dev,QA, or Sandbox. 
+
+* Log in to the administrative user interface.
+* Navigate to <strong>Plan</strong> and copy the appropiate key
+* Access the FusionAuth instance and navigate to the <strong>Reactor</strong> 
+* Paste that key into the License Key field and Activate it
+
+[Full instructions on how to activate your license ](/docs/get-started/core-concepts/licensing)
+
+
 ## Set Up an API Key
 
 Create an API key you can use to manage FusionAuth in an emergency. If you lose access to the administrative user interface, you can use this API key to retain access to your FusionAuth instance by adding a new `admin` user.

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -26,7 +26,7 @@ Activating the license key will allow access to all of the paid features inside 
 
 Production keys must be used for any FusionAuth instance that customers will be logging into, that is how we track MAUs. 
 
-Non-production keys may be used for any other instances such as your developer's laptops, QA, or UAT. 
+Non-production keys may be used for any other instances such as your developers' laptops, QA, or UAT. 
 
 * Log in to the administrative user interface.
 * Navigate to <strong>Plan</strong> and copy the appropriate key.

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -21,7 +21,11 @@ Create a second user with the admin role. This user can provide access should yo
 
 ## Activate License Key
 
-Activating the license key will allow access to all of the features inside FusionAuth. The key is found in your account portal and is activated in the <strong>Reactor</strong> tab. Production keys must be used for any FusionAuth instance that customers will be logging into, that is how we track MAUs. Non-Production may be used for any other instances such as Dev,QA, or Sandbox. 
+Activating the license key will allow access to all of the paid features inside FusionAuth. The key is found in your [account portal](https://account.fusionauth.io/account/plan/) and is activated in the <Breadcrumb>Reactor</Breadcrumb> tab. 
+
+Production keys must be used for any FusionAuth instance that customers will be logging into, that is how we track MAUs. 
+
+Non-production keys may be used for any other instances such as your developer's laptops, QA, or UAT. 
 
 * Log in to the administrative user interface.
 * Navigate to <strong>Plan</strong> and copy the appropiate key

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -33,7 +33,7 @@ Non-production keys may be used for any other instances such as your developer's
 * Access the FusionAuth instance and navigate to the <Breadcrumb>Reactor</Breadcrumb>.
 * Paste that key into the License Key field and Activate it.
 
-[Full instructions on how to activate your license ](/docs/get-started/core-concepts/licensing)
+[Full instructions on how to activate your license](/docs/get-started/core-concepts/licensing).
 
 ## Set Up an API Key
 

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -35,7 +35,6 @@ Non-production keys may be used for any other instances such as your developer's
 
 [Full instructions on how to activate your license ](/docs/get-started/core-concepts/licensing)
 
-
 ## Set Up an API Key
 
 Create an API key you can use to manage FusionAuth in an emergency. If you lose access to the administrative user interface, you can use this API key to retain access to your FusionAuth instance by adding a new `admin` user.

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -31,7 +31,7 @@ Non-production keys may be used for any other instances such as your developer's
 * Log in to the administrative user interface.
 * Navigate to <strong>Plan</strong> and copy the appropriate key.
 * Access the FusionAuth instance and navigate to the <Breadcrumb>Reactor</Breadcrumb>.
-* Paste that key into the License Key field and Activate it
+* Paste that key into the License Key field and Activate it.
 
 [Full instructions on how to activate your license ](/docs/get-started/core-concepts/licensing)
 

--- a/astro/src/content/docs/_shared/_common-configuration.mdx
+++ b/astro/src/content/docs/_shared/_common-configuration.mdx
@@ -30,7 +30,7 @@ Non-production keys may be used for any other instances such as your developer's
 
 * Log in to the administrative user interface.
 * Navigate to <strong>Plan</strong> and copy the appropriate key.
-* Access the FusionAuth instance and navigate to the <strong>Reactor</strong> 
+* Access the FusionAuth instance and navigate to the <Breadcrumb>Reactor</Breadcrumb>.
 * Paste that key into the License Key field and Activate it
 
 [Full instructions on how to activate your license ](/docs/get-started/core-concepts/licensing)


### PR DESCRIPTION
Adding a section into common config doc to activate the license key per action item from a Q1 Support meeting. 