### PR TITLE
added a section to support first time setup wizard

### DIFF
--- a/astro/src/content/quickstarts/quickstart-python-flask-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-python-flask-web.mdx
@@ -45,9 +45,18 @@ git clone https://github.com/FusionAuth/fusionauth-quickstart-python-flask-web.g
 cd fusionauth-quickstart-python-flask-web
 ```
 
-### Run FusionAuth via Docker
+### Run FusionAuth
 
+#### Run FusionAuth via Docker
 <DockerSpinup kickstartUri={frontmatter.codeRoot + "/kickstart/kickstart.json"} />
+
+#### Run FusionAuth Another Way
+If you plan on running FusionAuth another way, check out our [downloads page](/download). When you start FusionAuth for the first time, go through the First Time Setup wizard - you'll see it at the top of the main Dashboard page. At the end of First Time Setup, you'll find the information you need for the quickstart configuration on the Summary page at the end of the wizard. You'll need to:
+1. Take those values and use them in the `.env` config file
+2. Update your application in FusionAuth
+    1. Go to the Applications area in FusionAuth and edit your application
+    2. On the OAuth tab, set the `Authorized Redirect URLs` to `http://localhost:5000/callback`
+    3. Click Save
 
 ### Create your Flask Application
 

--- a/astro/src/content/quickstarts/quickstart-python-flask-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-python-flask-web.mdx
@@ -19,6 +19,7 @@ import LoginArchitectureWeb from '/src/components/quickstarts/LoginArchitectureW
 import NextSteps from '/src/components/quickstarts/NextSteps.astro';
 import {RemoteCode} from '@fusionauth/astro-components';
 import QuickstartTshirtCTA from '/src/components/quickstarts/QuickstartTshirtCTA.astro'
+import RunFusionAuthAnotherWay from 'src/content/quickstarts/_run-fusionauth-other.mdx';
 
 <Intro technology={`${frontmatter.language} and ${frontmatter.technology}`}
        repositoryUrl="https://github.com/FusionAuth/fusionauth-quickstart-python-flask-web"/>
@@ -51,12 +52,7 @@ cd fusionauth-quickstart-python-flask-web
 <DockerSpinup kickstartUri={frontmatter.codeRoot + "/kickstart/kickstart.json"} />
 
 #### Run FusionAuth Another Way
-If you plan on running FusionAuth another way, check out our [downloads page](/download). When you start FusionAuth for the first time, go through the First Time Setup wizard - you'll see it at the top of the main Dashboard page. At the end of First Time Setup, you'll find the information you need for the quickstart configuration on the Summary page at the end of the wizard. You'll need to:
-1. Take those values and use them in the `.env` config file
-2. Update your application in FusionAuth
-    1. Go to the Applications area in FusionAuth and edit your application
-    2. On the OAuth tab, set the `Authorized Redirect URLs` to `http://localhost:5000/callback`
-    3. Click Save
+<RunFusionAuthAnotherWay />
 
 ### Create your Flask Application
 


### PR DESCRIPTION
To support users coming in from first time setup wizards, I broke the Run FusionAuth into 2 subsections, one for docker and one for "other", and then added some first time setup info