### PR TITLE
fixing Safari and other diagram issues

### DIFF
--- a/astro/src/components/mermaid/FlowchartDiagram.astro
+++ b/astro/src/components/mermaid/FlowchartDiagram.astro
@@ -1,6 +1,7 @@
 ---
 import renderDiagram from './render-diagram.js';
 import cache, { generateHash } from './cache.js';
+import 'src/css/diagrams.css';
 
 const props = { ...Astro.props };
 props.code = props.code || '';

--- a/astro/src/css/diagrams.css
+++ b/astro/src/css/diagrams.css
@@ -218,3 +218,7 @@
   stroke: #64748b !important;
   fill: #64748b !important;
 }
+
+foreignObject {
+  overflow: visible;
+}

--- a/astro/src/diagrams/blog/custom-scopes-in-third-party-applications/login-diagram.astro
+++ b/astro/src/diagrams/blog/custom-scopes-in-third-party-applications/login-diagram.astro
@@ -13,4 +13,3 @@ flowchart TD
 `;
 ---
 <Diagram code={diagram} alt={alt}/>
-

--- a/astro/src/diagrams/docs/get-started/core-concepts/_users-tenants-relation.astro
+++ b/astro/src/diagrams/docs/get-started/core-concepts/_users-tenants-relation.astro
@@ -20,8 +20,4 @@ graph BT
 `;
 ---
 <Diagram {code} />
-<style is:global>
-  foreignObject > div {
-    transform: translateY(-4px);
-  }
-</style>
+

--- a/astro/src/diagrams/docs/get-started/run-in-cloud/github-actions/action-workflow.astro
+++ b/astro/src/diagrams/docs/get-started/run-in-cloud/github-actions/action-workflow.astro
@@ -18,8 +18,3 @@ graph TD
 `;
 ---
 <Diagram {code} alt={alt} />
-<style is:global>
-    foreignObject > div {
-        transform: translateY(-4px);
-    }
-</style>

--- a/astro/src/diagrams/docs/get-started/run-in-cloud/github-actions/app-database.astro
+++ b/astro/src/diagrams/docs/get-started/run-in-cloud/github-actions/app-database.astro
@@ -20,8 +20,4 @@ graph LR
 `;
 ---
 <Diagram {code} alt={alt} />
-<style is:global>
-    foreignObject > div {
-        transform: translateY(-4px);
-    }
-</style>
+

--- a/astro/src/diagrams/docs/get-started/run-in-cloud/github-actions/overview.astro
+++ b/astro/src/diagrams/docs/get-started/run-in-cloud/github-actions/overview.astro
@@ -27,8 +27,3 @@ graph LR
 `;
 ---
 <Diagram {code} alt={alt} />
-<style is:global>
-    foreignObject > div {
-        transform: translateY(-4px);
-    }
-</style>

--- a/astro/src/diagrams/docs/operate/deploy/_blue-green-deployment.astro
+++ b/astro/src/diagrams/docs/operate/deploy/_blue-green-deployment.astro
@@ -26,9 +26,5 @@ graph TB
 `;
 ---
 <Diagram {code} />
-<style is:global>
-  foreignObject > div {
-    transform: translateY(-4px);
-  }
-</style>
+
 

--- a/astro/src/diagrams/docs/operate/deploy/_rolling-upgrade.astro
+++ b/astro/src/diagrams/docs/operate/deploy/_rolling-upgrade.astro
@@ -12,9 +12,4 @@ graph TB
 `;
 ---
 <Diagram {code} />
-<style is:global>
-  foreignObject > div {
-    transform: translateY(-4px);
-  }
-</style>
 


### PR DESCRIPTION
I added the change to the diagrams.css and checked several diagrams.  All seem to be OK.  The centering is still off in Safari but it is still better than it was.

these are some examples that I checked:

webauthn-components.astro - http://localhost:3000/articles/authentication/webauthn
login-diagram.astro - http://localhost:3000/blog/custom-scopes-in-third-party-applications
_users-temants-relation.astro - http://localhost:3000/docs/get-started/core-concepts/applications - fixed user diagram in safari by removing translate

