### PR TITLE
update pagefind and tune the query a bit

### DIFF
--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -22,7 +22,7 @@
 				"astro-index-pages": "src/integrations/astro-index-pages",
 				"marked": "^7.0.1",
 				"mermaid": "^9.1.6",
-				"pagefind": "^1.0.4",
+				"pagefind": "^1.1.0",
 				"puppeteer": "^18.0.2",
 				"semver": "^7.5.4",
 				"tailwindcss": "^3.2.7"
@@ -1849,9 +1849,9 @@
 			}
 		},
 		"node_modules/@pagefind/darwin-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.0.4.tgz",
-			"integrity": "sha512-2OcthvceX2xhm5XbgOmW+lT45oLuHqCmvFeFtxh1gsuP5cO8vcD8ZH8Laj4pXQFCcK6eAdSShx+Ztx/LsQWZFQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.1.0.tgz",
+			"integrity": "sha512-SLsXNLtSilGZjvqis8sX42fBWsWAVkcDh1oerxwqbac84HbiwxpxOC2jm8hRwcR0Z55HPZPWO77XeRix/8GwTg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1861,9 +1861,9 @@
 			]
 		},
 		"node_modules/@pagefind/darwin-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.0.4.tgz",
-			"integrity": "sha512-xkdvp0D9Ld/ZKsjo/y1bgfhTEU72ITimd2PMMQtts7jf6JPIOJbsiErCvm37m/qMFuPGEq/8d+fZ4pydOj08HQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.1.0.tgz",
+			"integrity": "sha512-QjQSE/L5oS1C8N8GdljGaWtjCBMgMtfrPAoiCmINTu9Y9dp0ggAyXvF8K7Qg3VyIMYJ6v8vg2PN7Z3b+AaAqUA==",
 			"cpu": [
 				"x64"
 			],
@@ -1873,9 +1873,9 @@
 			]
 		},
 		"node_modules/@pagefind/linux-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.0.4.tgz",
-			"integrity": "sha512-jGBrcCzIrMnNxLKVtogaQyajVfTAXM59KlBEwg6vTn8NW4fQ6nuFbbhlG4dTIsaamjEM5e8ZBEAKZfTB/qd9xw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.1.0.tgz",
+			"integrity": "sha512-8zjYCa2BtNEL7KnXtysPtBELCyv5DSQ4yHeK/nsEq6w4ToAMTBl0K06khqxdSGgjMSwwrxvLzq3so0LC5Q14dA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1885,9 +1885,9 @@
 			]
 		},
 		"node_modules/@pagefind/linux-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.0.4.tgz",
-			"integrity": "sha512-LIn/QcvcEtLEBqKe5vpSbSC2O3fvqbRCWOTIklslqSORisCsvzsWbP6j+LYxE9q0oWIfkdMoWV1vrE/oCKRxHg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.1.0.tgz",
+			"integrity": "sha512-4lsg6VB7A6PWTwaP8oSmXV4O9H0IHX7AlwTDcfyT+YJo/sPXOVjqycD5cdBgqNLfUk8B9bkWcTDCRmJbHrKeCw==",
 			"cpu": [
 				"x64"
 			],
@@ -1897,9 +1897,9 @@
 			]
 		},
 		"node_modules/@pagefind/windows-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.0.4.tgz",
-			"integrity": "sha512-QlBCVeZfj9fc9sbUgdOz76ZDbeK4xZihOBAFqGuRJeChfM8pnVeH9iqSnXgO3+m9oITugTf7PicyRUFAG76xeQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.1.0.tgz",
+			"integrity": "sha512-OboCM76BcMKT9IoSfZuFhiqMRgTde8x4qDDvKulFmycgiJrlL5WnIqBHJLQxZq+o2KyZpoHF97iwsGAm8c32sQ==",
 			"cpu": [
 				"x64"
 			],
@@ -7117,18 +7117,18 @@
 			}
 		},
 		"node_modules/pagefind": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.0.4.tgz",
-			"integrity": "sha512-oRIizYe+zSI2Jw4zcMU0ebDZm27751hRFiSOBLwc1OIYMrsZKk+3m8p9EVaOmc6zZdtqwwdilNUNxXvBeHcP9w==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.1.0.tgz",
+			"integrity": "sha512-1nmj0/vfYcMxNEQj0YDRp6bTVv9hI7HLdPhK/vBBYlrnwjATndQvHyicj5Y7pUHrpCFZpFnLVQXIF829tpFmaw==",
 			"bin": {
 				"pagefind": "lib/runner/bin.cjs"
 			},
 			"optionalDependencies": {
-				"@pagefind/darwin-arm64": "1.0.4",
-				"@pagefind/darwin-x64": "1.0.4",
-				"@pagefind/linux-arm64": "1.0.4",
-				"@pagefind/linux-x64": "1.0.4",
-				"@pagefind/windows-x64": "1.0.4"
+				"@pagefind/darwin-arm64": "1.1.0",
+				"@pagefind/darwin-x64": "1.1.0",
+				"@pagefind/linux-arm64": "1.1.0",
+				"@pagefind/linux-x64": "1.1.0",
+				"@pagefind/windows-x64": "1.1.0"
 			}
 		},
 		"node_modules/param-case": {
@@ -11207,33 +11207,33 @@
 			}
 		},
 		"@pagefind/darwin-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.0.4.tgz",
-			"integrity": "sha512-2OcthvceX2xhm5XbgOmW+lT45oLuHqCmvFeFtxh1gsuP5cO8vcD8ZH8Laj4pXQFCcK6eAdSShx+Ztx/LsQWZFQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.1.0.tgz",
+			"integrity": "sha512-SLsXNLtSilGZjvqis8sX42fBWsWAVkcDh1oerxwqbac84HbiwxpxOC2jm8hRwcR0Z55HPZPWO77XeRix/8GwTg==",
 			"optional": true
 		},
 		"@pagefind/darwin-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.0.4.tgz",
-			"integrity": "sha512-xkdvp0D9Ld/ZKsjo/y1bgfhTEU72ITimd2PMMQtts7jf6JPIOJbsiErCvm37m/qMFuPGEq/8d+fZ4pydOj08HQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.1.0.tgz",
+			"integrity": "sha512-QjQSE/L5oS1C8N8GdljGaWtjCBMgMtfrPAoiCmINTu9Y9dp0ggAyXvF8K7Qg3VyIMYJ6v8vg2PN7Z3b+AaAqUA==",
 			"optional": true
 		},
 		"@pagefind/linux-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.0.4.tgz",
-			"integrity": "sha512-jGBrcCzIrMnNxLKVtogaQyajVfTAXM59KlBEwg6vTn8NW4fQ6nuFbbhlG4dTIsaamjEM5e8ZBEAKZfTB/qd9xw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.1.0.tgz",
+			"integrity": "sha512-8zjYCa2BtNEL7KnXtysPtBELCyv5DSQ4yHeK/nsEq6w4ToAMTBl0K06khqxdSGgjMSwwrxvLzq3so0LC5Q14dA==",
 			"optional": true
 		},
 		"@pagefind/linux-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.0.4.tgz",
-			"integrity": "sha512-LIn/QcvcEtLEBqKe5vpSbSC2O3fvqbRCWOTIklslqSORisCsvzsWbP6j+LYxE9q0oWIfkdMoWV1vrE/oCKRxHg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.1.0.tgz",
+			"integrity": "sha512-4lsg6VB7A6PWTwaP8oSmXV4O9H0IHX7AlwTDcfyT+YJo/sPXOVjqycD5cdBgqNLfUk8B9bkWcTDCRmJbHrKeCw==",
 			"optional": true
 		},
 		"@pagefind/windows-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.0.4.tgz",
-			"integrity": "sha512-QlBCVeZfj9fc9sbUgdOz76ZDbeK4xZihOBAFqGuRJeChfM8pnVeH9iqSnXgO3+m9oITugTf7PicyRUFAG76xeQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.1.0.tgz",
+			"integrity": "sha512-OboCM76BcMKT9IoSfZuFhiqMRgTde8x4qDDvKulFmycgiJrlL5WnIqBHJLQxZq+o2KyZpoHF97iwsGAm8c32sQ==",
 			"optional": true
 		},
 		"@pkgjs/parseargs": {
@@ -14877,15 +14877,15 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"pagefind": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.0.4.tgz",
-			"integrity": "sha512-oRIizYe+zSI2Jw4zcMU0ebDZm27751hRFiSOBLwc1OIYMrsZKk+3m8p9EVaOmc6zZdtqwwdilNUNxXvBeHcP9w==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.1.0.tgz",
+			"integrity": "sha512-1nmj0/vfYcMxNEQj0YDRp6bTVv9hI7HLdPhK/vBBYlrnwjATndQvHyicj5Y7pUHrpCFZpFnLVQXIF829tpFmaw==",
 			"requires": {
-				"@pagefind/darwin-arm64": "1.0.4",
-				"@pagefind/darwin-x64": "1.0.4",
-				"@pagefind/linux-arm64": "1.0.4",
-				"@pagefind/linux-x64": "1.0.4",
-				"@pagefind/windows-x64": "1.0.4"
+				"@pagefind/darwin-arm64": "1.1.0",
+				"@pagefind/darwin-x64": "1.1.0",
+				"@pagefind/linux-arm64": "1.1.0",
+				"@pagefind/linux-x64": "1.1.0",
+				"@pagefind/windows-x64": "1.1.0"
 			}
 		},
 		"param-case": {

--- a/astro/package.json
+++ b/astro/package.json
@@ -26,7 +26,7 @@
 		"astro-index-pages": "src/integrations/astro-index-pages",
 		"marked": "^7.0.1",
 		"mermaid": "^9.1.6",
-		"pagefind": "^1.0.4",
+		"pagefind": "^1.1.0",
 		"puppeteer": "^18.0.2",
 		"semver": "^7.5.4",
 		"tailwindcss": "^3.2.7"

--- a/astro/public/js/Search-0.2.2.js
+++ b/astro/public/js/Search-0.2.2.js
@@ -183,6 +183,16 @@ class Search {
 
     if (!this.#pagefind) {
       this.#pagefind = await import("/pagefind/pagefind.js");
+      // some tuning of the search ranking
+      // https://pagefind.app/docs/ranking/
+      await this.#pagefind.options({
+        ranking: {
+          termFrequency: 0.1,
+          termSimilarity: 0.2,
+          pageLength: 0,
+          termSaturation: 1.8,
+        }
+      })
       // prime the filters
       await this.#pagefind.filters();
     }

--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -32,7 +32,7 @@ const isProd = import.meta.env.PROD as boolean;
   <link rel="stylesheet" href="/css/sharp-thin.min.css"/>
   <link rel="stylesheet" href="/css/solid.min.css"/>
   <script src="/js/CopyToClipboard-0.2.2.js" type="text/javascript"></script>
-  <script src="/js/Search-0.2.1.js" type="text/javascript"></script>
+  <script src="/js/Search-0.2.2.js" type="text/javascript"></script>
   <script src="/js/ScrollSpy-0.1.0.js" type="text/javascript"></script>
   { hasDark && <script src="/js/ThemeSelector-0.1.0.js" type="text/javascript"></script> }
   <script src="/js/Visibility-0.1.2.js" type="text/javascript"></script>


### PR DESCRIPTION
Based on their [Changelog](https://github.com/CloudCannon/pagefind/blob/main/CHANGELOG.md) pagefind has updating their algorithm to provide better results.

They have also provided some new [tuning parameters](https://pagefind.app/docs/ranking/) to adjust how results come back. Our content tends to be long and repeats the same words over and over and it sounds like we were getting penalized fo that. Now that should be less of an issue and in my local testing seems a lot better.

If you would like to try this run the `npm run start` command to do a full local build and try out the search after it indexes everything.