### PR TITLE
add global fix to buttons in articles

### DIFF
--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -79,7 +79,7 @@ const articleStyles = [
   // base
   "pb-24 prose prose-slate dark:prose-invert max-w-none overflow-x-auto w-full",
   // a
-  "dark:prose-a:text-indigo-400 dark:hover:prose-a:text-indigo-400 dark:hover:prose-a:border-b-indigo-400 dark:prose-a:border-b-indigo-400 hover:prose-a:border-b-2 hover:prose-a:border-b-indigo-700 prose-a:border-b prose-a:border-b-indigo-700 prose-a:no-underline prose-a:text-indigo-700",
+  "dark:prose-a:text-indigo-400 dark:hover:prose-a:text-indigo-400 dark:hover:prose-a:border-b-indigo-400 dark:prose-a:border-b-indigo-400 hover:prose-a:border-b-2 hover:prose-a:border-b-indigo-700 [&:not(:has(button))]:prose-a:border-b prose-a:border-b-indigo-700 prose-a:no-underline prose-a:text-indigo-700",
   // code
   "dark:prose-code:bg-slate-700 prose-code:font-bold prose-code:bg-slate-200 prose-code:p-0.5 prose-code:rounded-sm prose-code:break-words prose-code:px-2 prose-code:rounded-md",
   // headings


### PR DESCRIPTION
Buttons with a tag show border bleeding over

![image](https://github.com/FusionAuth/fusionauth-site/assets/139158618/250fb69a-15b1-4521-b9d5-756c5c301862)

Adding `[&:not(:has(button))]`