### PR TITLE
Update single sign on guide

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
@@ -57,50 +57,27 @@ Above, note that FusionAuth automatically logs the user out of the Hooli applica
 
 ## Prerequisites
 
-To walk through this guide, you will need to have FusionAuth, ngrok and Node installed.
-
-You can [install FusionAuth in any number of ways](/docs/get-started/download-and-install/), but if [you have Docker installed](/docs/get-started/download-and-install/docker), you can get up and running quickly.
-
-[Ngrok](https://ngrok.com/download) is used to proxy local applications.
+To walk through this guide, you will need to have FusionAuth and Node installed. For FusionAuth installation instructions, please visit [the 5 minute setup guide](/docs/quickstarts/5-minute-setup-guide).
 
 ## Set Up The Domains
 
-In order to properly exercise single sign-on, applications need to live on different domains. You'll be starting two different applications on different hosts using ngrok, one on port 3000 and one on port 3001.
+In order to properly exercise single sign-on, applications need to live on different domains, or at least different paths. If you, for instance, set up two Node applications at `localhost:3000` and `localhost:3001`, browser sessions won't be separated and the SSO functionality won't work as intended. Cookies typically don't differ based on ports, so you'll see confusing behavior.
 
-Open up a terminal window and run this command:
+You can, however, easily set up two local domains. Edit your hosts file; on macOS, this file lives at `/etc/hosts`. Look for a line starting with `127.0.0.1`, which is the address of your computer.
 
-```sh
-ngrok http 3000
+Add the following text to that line:
+
+```ini title="Additions to the /etc/hosts file"
+ hooli.local piedpiper.local
 ```
 
-The particular hostnames will be different, but you should see a screen similar to this:
+You want it to look something like this after editing:
 
-```
-Session Status                online
-Account                       dan@example.com (Plan: Free)
-Update                        update available (version 3.12.1, Ctrl-U to update)
-Version                       3.3.1
-Latency                       49ms
-Web Interface                 http://127.0.0.1:4040
-Forwarding                    https://d50a-73-14-173-49.ngrok-free.app -> http://localhost:3000
-
-Connections                   ttl     opn     rt1     rt5     p50     p90
-                              0       0       0.00    0.00    0.00    0.00   
+```ini title="The modified localhost line in /etc/hosts file"
+127.0.0.1       localhost hooli.local piedpiper.local
 ```
 
-Copy the string starting with `https://` in the forwarding line and paste it into a text file. In this case, it would be `https://d50a-73-14-173-49.ngrok-free.app`. You'll need that value later on.
-
-Later, when you have the code running, you can type `https://d50a-73-14-173-49.ngrok-free.app/` into your browser's address bar and the Node application will serve the request.
-
-Do the same for the second application, running on port 3001.
-
-```sh
-ngrok http 3001
-```
-
-Copy the string starting with `https://` in the forwarding line and paste it into a text file. You'll need that value later on as well.
-
-You are not going to use [ngrok to set up FusionAuth to run on a public facing domain](/docs/get-started/download-and-install/development/exposing-instance) because this example works without doing so.
+Later, when you have the code running, you can type `http://piedpiper.local:3000` or `http://hooli.local:3001` into your browser's address bar and the local Node application will serve the request.
 
 ## Configure The Applications In FusionAuth
 
@@ -121,23 +98,22 @@ The <InlineField>Authorized redirect URL</InlineField> lists all the valid redir
 For the Pied Piper application, the configuration values will be:
 
 * <InlineField>Name</InlineField>: Pied Piper
-* <InlineField>Authorized redirect URL</InlineField>: `<the value from ngrok for the first application>/oauth-redirect`. It will look similar to `https://d50a-73-14-173-49.ngrok-free.app/oauth-redirect`
-* <InlineField>Logout URL</InlineField>: `<the value from ngrok for the first application>/endsession`. It will look similar to `https://d50a-73-14-173-49.ngrok-free.app/endsession`
+* <InlineField>Authorized redirect URL</InlineField>: `http://piedpiper.local:3000/oauth-redirect`
+* <InlineField>Logout URL</InlineField>: `http://piedpiper.local:3000/endsession`
 
 For the Hooli application, the values will be:
 
 * <InlineField>Name</InlineField>: Hooli
-* <InlineField>Authorized redirect URL</InlineField>: `<the value from ngrok for the second application>/oauth-redirect`.
-* <InlineField>Logout URL</InlineField>: `<the value from ngrok for the second application>/endsession`
+* <InlineField>Authorized redirect URL</InlineField>: `http://hooli.local:3001/oauth-redirect`
+* <InlineField>Logout URL</InlineField>: `http://hooli.local:3001/endsession`
 
 All of these will be configured on the <Breadcrumb>OAuth</Breadcrumb> tab. 
 
 Here's what the Pied Piper application might look like when properly configured:
 
-TODO screenshot
 <img src="/img/docs/lifecycle/authenticate-users/add-application-docs.png" alt="Example of configured application." width="1200" />
 
-Click "Save" each time.
+Click "Save" for each application.
 
 View each application by clicking the green magnifying glass when looking at the list of applications and note the `Client Id` and `Client Secret` values:
 
@@ -213,7 +189,7 @@ Here's the `.env` file, which should be placed at `.env`:
   lang="properties" 
   title="The .env File" />
 
-The `clientId` and `clientSecret` are the values noted in the administrative user interface when you created the application in FusionAuth and set in the `.env` file. The `fusionAuthURL` value needs to match your FusionAuth location, typically `http://localhost:9011`. If the FusionAuth server is running at a different hostname, update that. You'll need to update the `hostName` value to be your ngrok hostname.
+This contains configuration settings such as the Client Id and Client Secret. Make sure to update it with the correct values you've copied in the [Configure The Applications In FusionAuth](#configure-the-applications-in-fusionauth) section.
 
 Next, build out the `indexRouter` code referenced from the `app.js` file above.
 
@@ -234,7 +210,9 @@ This code handles a number of paths. Let's look at the code in more detail.
   lang="javascript" 
   title="Constants section" />
 
-The top of the `index.js` file has configuration values pulled from the environments and required constants. 
+The top of the `index.js` file has configuration values and some needed constants. 
+
+The `clientId` and `clientSecret` are the values noted in the administrative user interface when you created the application in FusionAuth. The `fusionAuthURL` value needs to match your FusionAuth location, typically `http://localhost:9011`. If the FusionAuth server is running at a different hostname, update that.
 
 The first argument to the FusionAuth client creation is `noapikeyneeded` because the client interactions this application performs do not require an API key. If you extend these applications to update user data or make other privileged API calls, you'll need to change that value to a [real API key](/docs/apis/authentication#managing-api-keys).
 
@@ -244,7 +222,7 @@ The first argument to the FusionAuth client creation is `noapikeyneeded` because
   lang="javascript" 
   title="Home page route" />
 
-In this SSO implementation, users can't view the homepage if they aren't signed in. This is a design choice based on your application. The code checks for the presence of a user in the session and if it isn't present, the user is redirected to the FusionAuth login page. 
+In this SSO implementation, users can't view the homepage if they aren't signed in. This is a design choice you can make. The code checks for the presence of a user in the session and if it isn't present, the user is redirected to the FusionAuth login page. 
 
 <RemoteCode
   url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
@@ -315,7 +293,7 @@ There is some CSS in this application too; the CSS is available in the GitHub re
 
 ### Start It Up
 
-Start the Pied Piper application on port 3000 after you've created the above files.
+Start the Pied Piper application on port 3000 after you've built the above files.
 
 ```shell script title="Starting up the Pied Piper application"
 PORT=3000 npm start
@@ -328,8 +306,8 @@ Next, create the sibling Hooli application.
 In real life, these applications would have different functionality. For this guide, they are going to be similar. The only changes you need to make for the Hooli application are:
 
 * Put the same files in a directory called `hooli`.
-* Update `.env` to use the Hooli values for the title (to 'Hooli'), hostname (the ngrok value for the second application), and the Client Id and Client Secret (from the admin UI application screen).
-* Change the layout so that the menu links to the Pied Piper application.
+* Change `index.js` constants to use the Hooli values for the title (to 'Hooli'), hostname (`hooli.local`), port (`3001`), and the Client Id and Client Secret (from the admin UI application screen).
+* Change the layout so that the menu links to the Pied Piper application. Make sure to include the port.
 
 <RemoteCode
   url={frontmatter.codeRoot + "/hooli/views/layout.pug"}
@@ -348,7 +326,7 @@ And that's it. You've just created a second application. Congrats!
 
 Here's how you can test the work you've just done:
 
-* Visit the ngrok URL for the Pied Piper application. You'll be redirected to the FusionAuth login screen. 
+* Visit `http://piedpiper.local:3000`. You'll be redirected to the FusionAuth login screen. 
 * Check <InlineUIElement>Keep Me Signed In</InlineUIElement>
 * Log in.  You'll be greeted with a welcome message by the Pied Piper app.
 * Click on the 'Hooli' link and you'll be automatically signed in to that application. 
@@ -356,6 +334,10 @@ Here's how you can test the work you've just done:
 Here's a demo video of the single sign-on process from the end user perspective:
 
 <YouTube id="KxxLLoS74Ks" />
+
+### Caveat
+
+If you are testing these applications with a modern browser, logout won't work due to browser quirks when you are running over `http`. However, if you set up TLS and change the redirects to happen over `https`, then logout works.
 
 ## Other Scenarios
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
@@ -186,7 +186,8 @@ Here's the `.env` file, which should be placed at `.env`:
 
 <RemoteCode
   url={frontmatter.codeRoot + "/pied-piper/.env"}
-  title="routes/index.js" />
+  lang="properties" 
+  title="The .env File" />
 
 This contains configuration settings such as the Client Id and Client Secret. Make sure to update it with the correct values you've copied in the [Configure The Applications In FusionAuth](#configure-the-applications-in-fusionauth) section.
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
@@ -4,13 +4,17 @@ description: Learn how to implement single sign-on between applications using Fu
 navcategory: developer
 section: lifecycle
 subcategory: authenticate users
+codeRoot: https://raw.githubusercontent.com/FusionAuth/fusionauth-example-node-sso/main
 ---
 import Aside from 'src/components/Aside.astro';
 import InlineField from 'src/components/InlineField.astro';
+import Breadcrumb from 'src/components/Breadcrumb.astro';
+import InlineUIElement from 'src/components/InlineUIElement.astro';
 import LogoutBehaviorAllApplications from 'src/content/docs/get-started/core-concepts/_logout-behavior-all-applications.mdx';
 import SSOLogin from 'src/diagrams/docs/lifecycle/authenticate-users/sso-login.astro';
 import SSOLogout from 'src/diagrams/docs/lifecycle/authenticate-users/sso-logout.astro';
 import { YouTube } from '@astro-community/astro-embed-youtube';
+import {RemoteCode} from '@fusionauth/astro-components';
 
 This guide will walk you through setting up single sign-on (SSO) between two web applications using FusionAuth as their common authentication and authorization server. You will use the hosted login pages for your login form.
 
@@ -79,7 +83,7 @@ Later, when you have the code running, you can type `http://piedpiper.local:3000
 
 Next, create and configure the applications in FusionAuth. You can do this via the API, but in this guide it'll be accomplished through the administrative user interface. 
 
-Navigate to <strong>Applications</strong> and create two new applications. Configure the following for each application:
+Navigate to <Breadcrumb>Applications</Breadcrumb> and create two new applications. Configure the following for each application:
 
 * <InlineField>Name</InlineField>
 * <InlineField>Authorized redirect URL</InlineField>
@@ -103,7 +107,7 @@ For the Hooli application, the values will be:
 * <InlineField>Authorized redirect URL</InlineField>: `http://hooli.local:3001/oauth-redirect`
 * <InlineField>Logout URL</InlineField>: `http://hooli.local:3001/endsession`
 
-All of these will be configured on the <strong>OAuth</strong> tab. 
+All of these will be configured on the <Breadcrumb>OAuth</Breadcrumb> tab. 
 
 Here's what the Pied Piper application might look like when properly configured:
 
@@ -127,36 +131,20 @@ Next, set up the code. Both of the applications in this guide are written in Nod
 
 Set up two Node applications, one for Pied Piper and one for Hooli. In this guide, the applications are very similar, so let's create the Pied Piper application first. Once this is running, you can copy most of the code for the Hooli application. 
 
-First off, make a `piedpiper` directory and change into it.
+First off, make a `pied-piper` directory and change into it.
 
 ```shell script title="Creating Pied Piper directory"
-mkdir piedpiper && cd piedpiper
+mkdir pied-piper && cd pied-piper
 ```
 
 ### Required packages
 
 Set up your needed packages. Here's what the `package.json` file should look like:
 
-```json title="package.json"
-{
-  "name": "fusionauth-node-example-sso-piedpiper",
-  "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "start": "node ./bin/www"
-  },
-  "dependencies": {
-    "@fusionauth/typescript-client": "^1.22.0",
-    "cookie-parser": "~1.4.4",
-    "debug": "~2.6.9",
-    "express": "~4.16.1",
-    "express-session": "1.17.0",
-    "http-errors": "~1.6.3",
-    "morgan": "~1.9.1",
-    "pug": "2.0.0-beta11"
-  }
-}
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/package.json"}
+  lang="javascript" 
+  title="package.json" />
 
 Go ahead and install the needed modules:
 
@@ -168,183 +156,39 @@ npm install
 
 This guide uses express for each application and the [typescript client](/docs/sdks/typescript) for interactions with the FusionAuth API. Create an `app.js` file; this is what will be executed when the server starts.
 
-```javascript title="app.js"
-var createError = require('http-errors');
-var cookieParser = require('cookie-parser');
-var express = require('express');
-var expressSession = require('express-session');
-var path = require('path');
-var logger = require('morgan');
+This is a pretty standard express application which uses pug and sessions. It reads routes from files in the `routes` directory and views from the `views` directory.
 
-var indexRouter = require('./routes/index');
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/app.js"}
+  lang="javascript" 
+  title="app.js" />
 
-var app = express();
-
-// view engine setup
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'pug');
-
-app.use(logger('dev'));
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-app.use(cookieParser());
-app.use(expressSession({resave: false, saveUninitialized: false, secret: 'fusionauth-node-example', cookie: {maxAge: 60000}}));
-app.use(express.static(path.join(__dirname, 'public')));
-
-app.use('/', indexRouter);
-
-// catch 404 and forward to error handler
-app.use(function(req, res, next) {
-  next(createError(404));
-});
-
-// error handler
-app.use(function(err, req, res, next) {
-  // set locals, only providing error in development
-  res.locals.message = err.message;
-  res.locals.error = req.app.get('env') === 'development' ? err : {};
-
-  // render the error page
-  res.status(err.status || 500);
-  res.render('error');
-});
-
-module.exports = app;
-```
-
-That's a lot of code, but most of it isn't specific to these applications. 
-
-Let's look at the parts that are:
-
-```javascript title="app.js excerpts"
-//...
-var indexRouter = require('./routes/index');
-
-//...
-// view engine setup
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'pug');
-
-//...
-app.use(expressSession({resave: false, 
-                        saveUninitialized: false, 
-                        secret: 'fusionauth-node-example', 
-                        cookie: {maxAge: 60000}
-                       }));
-//...
-app.use('/', indexRouter);
-//...
-```
-
-`indexRouter` is set up and configured to read from the `routes/index.js` file. This app will use the `pug` view engine, configured with files from the `views` directory. The routes and views code will be built out in the next sections.
-
-The session length for this application is 60 seconds; the `maxAge` value is in milliseconds. When the Node application's session expires, it will redirect the end user to the FusionAuth application. If the single sign-on session has not expired, the user will be transparently redirected back. If it has expired, the user must re-authenticate.
-
-As a last step, hook up `indexRouter` to the root path. Any request to this server will be handled by that router.
+The session length for this application is 60 seconds; the `maxAge` value is in milliseconds. When the node application's session expires, it will redirect the end user to FusionAuth. If the single sign-on session has not expired, the user will be transparently redirected back. If it has expired, the user must re-authenticate.
 
 ### The `www` script
 
 The next step is to create a script which starts up express. Place the contents of this file in `bin/www`.
 
-```javascript title="bin/www"
-#!/usr/bin/env node
-
-/**
- * Module dependencies.
- */
-
-var app = require('../app');
-var debug = require('debug')('fusionauth-node-example:server');
-var http = require('http');
-
-/**
- * Get port from environment and store in Express.
- */
-
-var port = normalizePort(process.env.PORT || '3000');
-app.set('port', port);
-
-/**
- * Create HTTP server.
- */
-
-var server = http.createServer(app);
-
-/**
- * Listen on provided port, on all network interfaces.
- */
-
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
-
-/**
- * Normalize a port into a number, string, or false.
- */
-
-function normalizePort(val) {
-  var port = parseInt(val, 10);
-
-  if (isNaN(port)) {
-    // named pipe
-    return val;
-  }
-
-  if (port >= 0) {
-    // port number
-    return port;
-  }
-
-  return false;
-}
-
-/**
- * Event listener for HTTP server "error" event.
- */
-
-function onError(error) {
-  if (error.syscall !== 'listen') {
-    throw error;
-  }
-
-  var bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port;
-
-  // handle specific listen errors with friendly messages
-  switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges');
-      process.exit(1);
-      break;
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use');
-      process.exit(1);
-      break;
-    default:
-      throw error;
-  }
-}
-
-/**
- * Event listener for HTTP server "listening" event.
- */
-
-function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
-  debug('Listening on ' + bind);
-}
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/bin/www"}
+  lang="javascript" 
+  title="bin/www" />
 
 This script is what running `npm start` actually executes.
 
 This code isn't that interesting with regards to single sign-on but is included for completeness. 
 
-It looks for a port from the environment or uses `3000` as the default. It also registers some error handling code. Then it starts up a server listening on that port, based on configuration from `app.js`.
+It looks for a port from the environment or uses `3000` as the default. It also registers some error handling code. Then it starts up a server listening on that port, based on configuration from `app.js`.'
 
+### The .env File
+
+Here's the `.env` file, which should be placed at `.env`:
+
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/.env"}
+  title="routes/index.js" />
+
+This contains configuration settings such as the Client Id and Client Secret. Make sure to update it with the correct values you've copied in the [Configure The Applications In FusionAuth](#configure-the-applications-in-fusionauth) section.
 
 Next, build out the `indexRouter` code referenced from the `app.js` file above.
 
@@ -352,187 +196,66 @@ Next, build out the `indexRouter` code referenced from the `app.js` file above.
 
 Here's the entire `index.js` file, which should be placed at `routes/index.js`:
 
-```javascript title="routes/index.js"
-const express = require('express');
-const router = express.Router();
-const {FusionAuthClient} = require('@fusionauth/typescript-client');
-
-const clientId = '85a03867-dccf-4882-adde-1a79aeec50df';
-const clientSecret = '7gh9U0O1wshsrVVvflccX-UL2zxxsYccjdw8_rOfsfE';
-const client = new FusionAuthClient('noapikeyneeded', 'http://localhost:9011');
-const hostName = 'piedpiper.local';
-const port = 3000;
-const title = 'Pied Piper';
-
-const loginUrl = 'http://localhost:9011/oauth2/authorize?client_id='+clientId+'&response_type=code&redirect_uri=http%3A%2F%2F'+hostName+'%3A'+port+'%2Foauth-redirect&scope=offline_access';
-const logoutUrl = 'http://localhost:9011/oauth2/logout?client_id='+clientId;
-
-/* GET home page. */
-router.get('/', function (req, res, next) {
-
-  if (!req.session.user) {
-    res.redirect(302, loginUrl);
-    return;
-  }
-  res.render('index', {user: req.session.user, title: title + ' App', clientId: clientId, logoutUrl: "/logout", loginUrl: loginUrl});
-});
-
-/* Login page if we aren't logged in */
-router.get('/login', function (req, res, next) {
-  res.render('login', {title: title + ' Login', clientId: clientId, loginUrl: loginUrl});
-});
-
-/* Logout page */
-router.get('/logout', function (req, res, next) {
-  req.session.user = null;
-  res.redirect(302, logoutUrl);
-});
-
-/* End session for global SSO logout */
-router.get('/endsession', function (req, res, next) {
-  req.session.user = null;
-  res.redirect(302, "/login");
-});
-
-/* OAuth return from FusionAuth */
-router.get('/oauth-redirect', function (req, res, next) {
-  // This code stores the user in a server-side session
-  client.exchangeOAuthCodeForAccessToken(req.query.code,
-                                         clientId,
-                                         clientSecret,
-                                         'http://'+hostName+':'+port+'/oauth-redirect')
-      .then((response) => {
-        return client.retrieveUserUsingJWT(response.response.access_token);
-      })
-      .then((response) => {
-        if (response.response.user.registrations.length == 0 || (response.response.user.registrations.filter(reg => reg.applicationId === clientId)).length == 0) {
-          console.log("User not registered, not authorized.");
-          res.redirect(302, '/');
-          return;
-        }
-      
-        req.session.user = response.response.user;
-      })
-      .then((response) => {
-        res.redirect(302, '/');
-      }).catch((err) => {console.log("in error"); console.error(JSON.stringify(err));});
-});
-
-module.exports = router;
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
+  lang="javascript" 
+  title="routes/index.js" />
 
 This code handles a number of paths. Let's look at the code in more detail.
 
-```javascript title="Constants section"
-const express = require('express');
-const router = express.Router();
-const {FusionAuthClient} = require('@fusionauth/typescript-client');
-
-const clientId = '85a03867-dccf-4882-adde-1a79aeec50df';
-const clientSecret = '7gh9U0O1wshsrVVvflccX-UL2zxxsYccjdw8_rOfsfE';
-const client = new FusionAuthClient('noapikeyneeded', 'http://localhost:9011');
-const hostName = 'piedpiper.local';
-const title = 'Pied Piper';
-const port = 3000;
-
-const loginUrl = 'http://localhost:9011/oauth2/authorize?client_id='+clientId+'&response_type=code&redirect_uri=http%3A%2F%2F'+hostName+'%3A'+port+'%2Foauth-redirect&scope=offline_access';
-const logoutUrl = 'http://localhost:9011/oauth2/logout?client_id='+clientId;
-
-//...
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
+  tags="constants"
+  lang="javascript" 
+  title="Constants section" />
 
 The top of the `index.js` file has configuration values and some needed constants. 
 
-Update `clientId` and `clientSecret` variables with the values noted in the administrative user interface when you created the application in FusionAuth. You'll also want to make sure that the second argument to the `client` constructor matches your FusionAuth installation, typically `http://localhost:9011`. If FusionAuth lives at a place other than that, change the `loginUrl` and `logoutUrl` values as well.
+The `clientId` and `clientSecret` are the values noted in the administrative user interface when you created the application in FusionAuth. The `fusionAuthURL` value needs to match your FusionAuth location, typically `http://localhost:9011`. If the FusionAuth server is running at a different hostname, update that.
 
-The first argument is `noapikeyneeded` because the client interactions this application performs do not require an API key. If you extend these applications to update user data or make other privileged API calls, you'll need to change that value to a [real API key](/docs/apis/authentication#managing-api-keys).
+The first argument to the FusionAuth client creation is `noapikeyneeded` because the client interactions this application performs do not require an API key. If you extend these applications to update user data or make other privileged API calls, you'll need to change that value to a [real API key](/docs/apis/authentication#managing-api-keys).
 
-```javascript title="Home page route"
-//...
-
-/* GET home page. */
-router.get('/', function (req, res, next) {
-
-  if (!req.session.user) {
-    res.redirect(302, loginUrl);
-    return;
-  }
-  res.render('index', {user: req.session.user, title: title +' App', clientId: clientId, logoutUrl: "/logout", loginUrl: loginUrl});
-});
-//...
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
+  tags="homepageroute"
+  lang="javascript" 
+  title="Home page route" />
 
 In this SSO implementation, users can't view the homepage if they aren't signed in. This is a design choice you can make. The code checks for the presence of a user in the session and if it isn't present, the user is redirected to the FusionAuth login page. 
 
-```javascript title="Login page route"
-//...
-/* Login page if we aren't logged in */
-router.get('/login', function (req, res, next) {
-  res.render('login', {title: title +' Login', clientId: clientId, loginUrl: loginUrl});
-});
-//...
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
+  tags="loginpageroute"
+  lang="javascript" 
+  title="Login page route" />
 
 This page is available to users who are not logged in. For this guide, the only information on this page is a login link, but for a real application you'd probably want to entice the user to register or log in.
 
-```javascript title="Logout page route"
-//...
-/* Logout page */
-router.get('/logout', function (req, res, next) {
-  req.session.user = null;
-  res.redirect(302, logoutUrl);
-});
-//...
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
+  tags="logoutpageroute"
+  lang="javascript" 
+  title="Logout page route" />
 
 This route removes the user object from the session and then redirects to the FusionAuth logout URL. 
 
-Recall that there are three sessions present in this system: the FusionAuth session and one for each Node application. This route invalidates the local node application's session and then sends the browser to FusionAuth's logout URL, which will invalidate both the FusionAuth session and all other Node application sessions. 
+Recall that there are three sessions present in this system: the FusionAuth session and one for each application. This route invalidates the local node application's session and then sends the browser to FusionAuth's logout URL, which will invalidate both the FusionAuth session and all other Node application sessions. 
 
-```javascript title="Endsession route"
-//...
-/* End session for global SSO logout */
-router.get('/endsession', function (req, res, next) {
-  req.session.user = null;
-  res.redirect(302, "/login");
-});
-//...
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
+  tags="endsessionroute"
+  lang="javascript" 
+  title="End session route" />
 
 This route is what FusionAuth requests when a user logs out from any other application in this tenant. If a user is in the Hooli application and logs out, they will be signed out from the Pied Piper application as well. You configured this endpoint in the FusionAuth application details; FusionAuth is responsible for calling this endpoint. This is a separate endpoint from the `/logout` endpoint because in this request, the browser needs to end up on a page accessible to unauthenticated users, but in the `/logout` case, the user needs to be sent to FusionAuth. 
 
-```javascript title="OAuth redirect route"
-//...
-/* OAuth return from FusionAuth */
-router.get('/oauth-redirect', function (req, res, next) {
-  // This code stores the user in a server-side session
-  client.exchangeOAuthCodeForAccessToken(req.query.code,
-                                         clientId,
-                                         clientSecret,
-                                         'http://'+hostName+':'+port+'/oauth-redirect')
-      .then((response) => {
-        return client.retrieveUserUsingJWT(response.response.access_token);
-      })
-      .then((response) => {
-        if (response.response.user.registrations.length == 0 || (response.response.user.registrations.filter(reg => reg.applicationId === clientId)).length == 0) {
-          console.log("User not registered, not authorized.");
-          res.redirect(302, '/');
-          return;
-        }
-      
-        req.session.user = response.response.user;
-      })
-      .then((response) => {
-        res.redirect(302, '/');
-      }).catch((err) => {console.log("in error"); console.error(JSON.stringify(err));});
-});
-
-module.exports = router;
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
+  tags="oauthredirectroute"
+  lang="javascript" 
+  title="OAuth redirect route" />
 
 This route is responsible for catching the authorization code request from FusionAuth after the user has signed in. It retrieves an access token and from that gathers the user data. This code ensures that the user is registered for this application, and then places the user data in the session. 
-
-Finally, export the `router` object for express to use. And that's pretty much it for the Pied Piper application code. 
 
 Implementation of features that might cause a user to want to log in are left as an exercise for the reader.
 
@@ -540,45 +263,30 @@ Implementation of features that might cause a user to want to log in are left as
 
 Next, create the views. Each of these live in the `views` subdirectory. First, the layout view, which looks like this:
 
-```pug title="Layout view"
-doctype html
-html
-  head
-    title= title
-    link(rel='stylesheet', href='/stylesheets/style.css')
-  body
-    h2 Pied Piper | 
-       a(href='http://hooli.local:3001') Hooli
-    block content
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/views/layout.pug"}
+  lang="pug" 
+  title="Layout view" />
 
-The content is displayed using the `block content` directive. Above it is a menu which lets users switch between both applications. 
+The content is displayed using the `block content` directive. Above it is a menu which lets users switch between both applications.
 
-```pug title="Login view"
-extends layout
+Next, the login view:
 
-block content
-  h1= title
-  a(href=loginUrl) Login
-
-  p Welcome to #{title}
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/views/login.pug"}
+  lang="pug" 
+  title="Login view" />
 
 This is where you'd put information about your application for unauthorized users.
 
-```pug title="Index view"
-extends layout
+Then, create the index view:
 
-block content
-  h1= title
+<RemoteCode
+  url={frontmatter.codeRoot + "/pied-piper/views/index.pug"}
+  lang="pug" 
+  title="Index view" />
 
-  p Hello #{user.firstName}
-  a(href=logoutUrl) Log out
-
-  p Welcome to #{title}
-```
-
-This welcomes the user by name.
+This welcomes the user by name. If you were building a more complicated application, this is where you would put functionality that required a user to be authenticated..
 
 There is some CSS in this application too; the CSS is available in the GitHub repository, but won't be covered here.
 
@@ -600,19 +308,10 @@ In real life, these applications would have different functionality. For this gu
 * Change `index.js` constants to use the Hooli values for the title (to 'Hooli'), hostname (`hooli.local`), port (`3001`), and the Client Id and Client Secret (from the admin UI application screen).
 * Change the layout so that the menu links to the Pied Piper application. Make sure to include the port.
 
-```pug title="Hooli layout view"
-doctype html
-html
-  head
-    title= title
-    link(rel='stylesheet', href='/stylesheets/style.css')
-  body
-    h2
-      a(href='http://piedpiper.local:3000') Pied Piper
-      |
-      || Hooli
-    block content
-```
+<RemoteCode
+  url={frontmatter.codeRoot + "/hooli/views/layout.pug"}
+  lang="pug" 
+  title="Index view" />
 
 * Start the application on the port `3001`. Use a different terminal window so that you can have both Node applications running at once.
 
@@ -620,11 +319,16 @@ html
 PORT=3001 npm start
 ```
 
-And that's it. You've just created a second application.
+And that's it. You've just created a second application. Congrats!
 
 ## Test The Results
 
-You can visit `http://piedpiper.local:3000`. You'll be redirected to the FusionAuth login screen. Log in. You'll be greeted with a welcome message by the Pied Piper app. Click on the 'Hooli' link and you'll be automatically signed in to that application. You can log out as well.
+Here's how you can test the work you've just done:
+
+* Visit `http://piedpiper.local:3000`. You'll be redirected to the FusionAuth login screen. 
+* Check <InlineUIElement>Keep Me Signed In</InlineUIElement>
+* Log in.  You'll be greeted with a welcome message by the Pied Piper app.
+* Click on the 'Hooli' link and you'll be automatically signed in to that application. 
 
 Here's a demo video of the single sign-on process from the end user perspective:
 
@@ -632,7 +336,7 @@ Here's a demo video of the single sign-on process from the end user perspective:
 
 ### Caveat
 
-If you are testing with Safari or Chrome on macOS, the multi application logout won't work due to browser quirks. However, if you set up TLS and change the redirects to happen over `https`, then it will work. FireFox v83.0 works with either scenario.
+If you are testing these applications with a modern browser, logout won't work due to browser quirks when you are running over `http`. However, if you set up TLS and change the redirects to happen over `https`, then logout works.
 
 ## Other Scenarios
 
@@ -652,7 +356,7 @@ Please see the [SAML IdP](/docs/lifecycle/authenticate-users/saml/) and [OIDC do
 
 ### Session Expiration
 
-The single sign-on session duration can be configured at the Tenant level. Navigate to <strong>Tenant -> Your Tenant -> OAuth</strong> and edit the <InlineField>Session timeout</InlineField> value. Because this value is shared between applications, it can't be overridden in application configuration.
+The single sign-on session duration can be configured at the Tenant level. Navigate to <Breadcrumb>Tenant -> Your Tenant -> OAuth</Breadcrumb> and edit the <InlineField>Session timeout</InlineField> value. Because this value is shared between applications, it can't be overridden in application configuration.
 
 <img src="/img/docs/lifecycle/authenticate-users/tenant-single-sign-on-session-timeout.png" alt="Configuring the single sign-on session length." width="1200" role="bottom-cropped" />
 
@@ -671,7 +375,7 @@ The length of a single sign-on session can be different than the session length 
 
 The default behavior is to log a user out of all applications when they log out of one. If you want to only log the user out of the application where the user made the logout request, you can do that.
 
-Navigate to <strong>Applications -> Your Application -> OAuth</strong> and configure <InlineField>Logout behavior</InlineField> to have the value `Redirect Only`.
+Navigate to <Breadcrumb>Applications -> Your Application -> OAuth</Breadcrumb> and configure <InlineField>Logout behavior</InlineField> to have the value `Redirect Only`.
 
 <img src="/img/docs/lifecycle/authenticate-users/application-config-logout-behavior-docs.png" alt="Configuring the logout behavior for an application." width="1200" role="top-cropped" />
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
@@ -332,7 +332,7 @@ Here's how you can test the work you've just done:
 
 Here's a demo video of the single sign-on process from the end user perspective:
 
-<YouTube id="UV9FW57dfbQ" />
+<YouTube id="KxxLLoS74Ks" />
 
 ### Caveat
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
@@ -57,27 +57,50 @@ Above, note that FusionAuth automatically logs the user out of the Hooli applica
 
 ## Prerequisites
 
-To walk through this guide, you will need to have FusionAuth and Node installed. For FusionAuth installation instructions, please visit [the 5 minute setup guide](/docs/quickstarts/5-minute-setup-guide).
+To walk through this guide, you will need to have FusionAuth, ngrok and Node installed.
+
+You can [install FusionAuth in any number of ways](/docs/get-started/download-and-install/), but if [you have Docker installed](/docs/get-started/download-and-install/docker), you can get up and running quickly.
+
+[Ngrok](https://ngrok.com/download) is used to proxy local applications.
 
 ## Set Up The Domains
 
-In order to properly exercise single sign-on, applications need to live on different domains, or at least different paths. If you, for instance, set up two Node applications at `localhost:3000` and `localhost:3001`, browser sessions won't be separated and the SSO functionality won't work as intended. Cookies typically don't differ based on ports, so you'll see confusing behavior.
+In order to properly exercise single sign-on, applications need to live on different domains. You'll be starting two different applications on different hosts using ngrok, one on port 3000 and one on port 3001.
 
-You can, however, easily set up two local domains. Edit your hosts file; on macOS, this file lives at `/etc/hosts`. Look for a line starting with `127.0.0.1`, which is the address of your computer.
+Open up a terminal window and run this command:
 
-Add the following text to that line:
-
-```ini title="Additions to the /etc/hosts file"
- hooli.local piedpiper.local
+```sh
+ngrok http 3000
 ```
 
-You want it to look something like this after editing:
+The particular hostnames will be different, but you should see a screen similar to this:
 
-```ini title="The modified localhost line in /etc/hosts file"
-127.0.0.1       localhost hooli.local piedpiper.local
+```
+Session Status                online
+Account                       dan@example.com (Plan: Free)
+Update                        update available (version 3.12.1, Ctrl-U to update)
+Version                       3.3.1
+Latency                       49ms
+Web Interface                 http://127.0.0.1:4040
+Forwarding                    https://d50a-73-14-173-49.ngrok-free.app -> http://localhost:3000
+
+Connections                   ttl     opn     rt1     rt5     p50     p90
+                              0       0       0.00    0.00    0.00    0.00   
 ```
 
-Later, when you have the code running, you can type `http://piedpiper.local:3000` or `http://hooli.local:3001` into your browser's address bar and the local Node application will serve the request.
+Copy the string starting with `https://` in the forwarding line and paste it into a text file. In this case, it would be `https://d50a-73-14-173-49.ngrok-free.app`. You'll need that value later on.
+
+Later, when you have the code running, you can type `https://d50a-73-14-173-49.ngrok-free.app/` into your browser's address bar and the Node application will serve the request.
+
+Do the same for the second application, running on port 3001.
+
+```sh
+ngrok http 3001
+```
+
+Copy the string starting with `https://` in the forwarding line and paste it into a text file. You'll need that value later on as well.
+
+You are not going to use [ngrok to set up FusionAuth to run on a public facing domain](/docs/get-started/download-and-install/development/exposing-instance) because this example works without doing so.
 
 ## Configure The Applications In FusionAuth
 
@@ -98,22 +121,23 @@ The <InlineField>Authorized redirect URL</InlineField> lists all the valid redir
 For the Pied Piper application, the configuration values will be:
 
 * <InlineField>Name</InlineField>: Pied Piper
-* <InlineField>Authorized redirect URL</InlineField>: `http://piedpiper.local:3000/oauth-redirect`
-* <InlineField>Logout URL</InlineField>: `http://piedpiper.local:3000/endsession`
+* <InlineField>Authorized redirect URL</InlineField>: `<the value from ngrok for the first application>/oauth-redirect`. It will look similar to `https://d50a-73-14-173-49.ngrok-free.app/oauth-redirect`
+* <InlineField>Logout URL</InlineField>: `<the value from ngrok for the first application>/endsession`. It will look similar to `https://d50a-73-14-173-49.ngrok-free.app/endsession`
 
 For the Hooli application, the values will be:
 
 * <InlineField>Name</InlineField>: Hooli
-* <InlineField>Authorized redirect URL</InlineField>: `http://hooli.local:3001/oauth-redirect`
-* <InlineField>Logout URL</InlineField>: `http://hooli.local:3001/endsession`
+* <InlineField>Authorized redirect URL</InlineField>: `<the value from ngrok for the second application>/oauth-redirect`.
+* <InlineField>Logout URL</InlineField>: `<the value from ngrok for the second application>/endsession`
 
 All of these will be configured on the <Breadcrumb>OAuth</Breadcrumb> tab. 
 
 Here's what the Pied Piper application might look like when properly configured:
 
+TODO screenshot
 <img src="/img/docs/lifecycle/authenticate-users/add-application-docs.png" alt="Example of configured application." width="1200" />
 
-Click "Save" for each application.
+Click "Save" each time.
 
 View each application by clicking the green magnifying glass when looking at the list of applications and note the `Client Id` and `Client Secret` values:
 
@@ -189,7 +213,7 @@ Here's the `.env` file, which should be placed at `.env`:
   lang="properties" 
   title="The .env File" />
 
-This contains configuration settings such as the Client Id and Client Secret. Make sure to update it with the correct values you've copied in the [Configure The Applications In FusionAuth](#configure-the-applications-in-fusionauth) section.
+The `clientId` and `clientSecret` are the values noted in the administrative user interface when you created the application in FusionAuth and set in the `.env` file. The `fusionAuthURL` value needs to match your FusionAuth location, typically `http://localhost:9011`. If the FusionAuth server is running at a different hostname, update that. You'll need to update the `hostName` value to be your ngrok hostname.
 
 Next, build out the `indexRouter` code referenced from the `app.js` file above.
 
@@ -210,9 +234,7 @@ This code handles a number of paths. Let's look at the code in more detail.
   lang="javascript" 
   title="Constants section" />
 
-The top of the `index.js` file has configuration values and some needed constants. 
-
-The `clientId` and `clientSecret` are the values noted in the administrative user interface when you created the application in FusionAuth. The `fusionAuthURL` value needs to match your FusionAuth location, typically `http://localhost:9011`. If the FusionAuth server is running at a different hostname, update that.
+The top of the `index.js` file has configuration values pulled from the environments and required constants. 
 
 The first argument to the FusionAuth client creation is `noapikeyneeded` because the client interactions this application performs do not require an API key. If you extend these applications to update user data or make other privileged API calls, you'll need to change that value to a [real API key](/docs/apis/authentication#managing-api-keys).
 
@@ -222,7 +244,7 @@ The first argument to the FusionAuth client creation is `noapikeyneeded` because
   lang="javascript" 
   title="Home page route" />
 
-In this SSO implementation, users can't view the homepage if they aren't signed in. This is a design choice you can make. The code checks for the presence of a user in the session and if it isn't present, the user is redirected to the FusionAuth login page. 
+In this SSO implementation, users can't view the homepage if they aren't signed in. This is a design choice based on your application. The code checks for the presence of a user in the session and if it isn't present, the user is redirected to the FusionAuth login page. 
 
 <RemoteCode
   url={frontmatter.codeRoot + "/pied-piper/routes/index.js"}
@@ -293,7 +315,7 @@ There is some CSS in this application too; the CSS is available in the GitHub re
 
 ### Start It Up
 
-Start the Pied Piper application on port 3000 after you've built the above files.
+Start the Pied Piper application on port 3000 after you've created the above files.
 
 ```shell script title="Starting up the Pied Piper application"
 PORT=3000 npm start
@@ -306,8 +328,8 @@ Next, create the sibling Hooli application.
 In real life, these applications would have different functionality. For this guide, they are going to be similar. The only changes you need to make for the Hooli application are:
 
 * Put the same files in a directory called `hooli`.
-* Change `index.js` constants to use the Hooli values for the title (to 'Hooli'), hostname (`hooli.local`), port (`3001`), and the Client Id and Client Secret (from the admin UI application screen).
-* Change the layout so that the menu links to the Pied Piper application. Make sure to include the port.
+* Update `.env` to use the Hooli values for the title (to 'Hooli'), hostname (the ngrok value for the second application), and the Client Id and Client Secret (from the admin UI application screen).
+* Change the layout so that the menu links to the Pied Piper application.
 
 <RemoteCode
   url={frontmatter.codeRoot + "/hooli/views/layout.pug"}
@@ -326,7 +348,7 @@ And that's it. You've just created a second application. Congrats!
 
 Here's how you can test the work you've just done:
 
-* Visit `http://piedpiper.local:3000`. You'll be redirected to the FusionAuth login screen. 
+* Visit the ngrok URL for the Pied Piper application. You'll be redirected to the FusionAuth login screen. 
 * Check <InlineUIElement>Keep Me Signed In</InlineUIElement>
 * Log in.  You'll be greeted with a welcome message by the Pied Piper app.
 * Click on the 'Hooli' link and you'll be automatically signed in to that application. 
@@ -334,10 +356,6 @@ Here's how you can test the work you've just done:
 Here's a demo video of the single sign-on process from the end user perspective:
 
 <YouTube id="KxxLLoS74Ks" />
-
-### Caveat
-
-If you are testing these applications with a modern browser, logout won't work due to browser quirks when you are running over `http`. However, if you set up TLS and change the redirects to happen over `https`, then logout works.
 
 ## Other Scenarios
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/single-sign-on.mdx
@@ -360,7 +360,7 @@ The single sign-on session duration can be configured at the Tenant level. Navig
 
 <img src="/img/docs/lifecycle/authenticate-users/tenant-single-sign-on-session-timeout.png" alt="Configuring the single sign-on session length." width="1200" role="bottom-cropped" />
 
-The length of a single sign-on session can be different than the session length for individual applications. When a request to an application occurs, there are four possible scenarios:
+The length of a single sign-on session can be different from the session length for individual applications. When a request to an application occurs, there are four possible scenarios:
 
 *Single sign-on session scenarios*
 


### PR DESCRIPTION
As part of https://linear.app/fusionauth/issue/DAN-54/finish-sessions-documentation I'm reviewing this single sign-on guide. I updated it to:

* have the code use .env instead of hardcoding
* use kickstart
* use the `RemoteCode` component to pull in code so it stays up to date
* fixed old dependencies
* updated to use proper components for formatting (Breadcrumb, etc)

Would love to have some other eyes on these changes.