### PR TITLE
Corrected responses for a GET with a single Id.

### DIFF
--- a/astro/src/content/docs/apis/jwt.mdx
+++ b/astro/src/content/docs/apis/jwt.mdx
@@ -301,6 +301,12 @@ Cookie: refresh_token=xRxGGEpVawiUak6He367W3oeOfh+3irw+1G1h1jc; access_token=eyJ
 
 <XFusionauthTenantIdHeaderScopedOperation />
 
+### Response
+
+<StandardGetResponseCodes no_errors missing_message="The refresh token specified by the tokenId is missing or revoked." />
+
+<RefreshTokenResponseBody />
+
 <API method="GET" uri="/api/jwt/refresh?userId={userId}" authentication={["api-key"]} title="Retrieve Refresh Tokens issued to a User"/>
 
 #### Request Parameters
@@ -316,8 +322,6 @@ Cookie: refresh_token=xRxGGEpVawiUak6He367W3oeOfh+3irw+1G1h1jc; access_token=eyJ
 ### Response
 
 <StandardGetResponseCodes no_errors never_missing />
-
-<RefreshTokenResponseBody />
 
 <RefreshTokensResponseBody />
 


### PR DESCRIPTION
This can return a 404.

I thought it then made more sense to break out the two different API calls with different responses