### PR TITLE
new device does send ip location info

### DIFF
--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-new-device.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-new-device.mdx
@@ -24,7 +24,6 @@ export const eventType = 'user.login.new-device';
 <EventBody eventType={eventType}
            sinceThreatDetection="1.30.0"
            sinceIpAddress="1.27.0"
-           skipStandardFields="true"
            jsonFile="user-login-new-device.json">
 
   <APIField slot="leading-fields" name="event.applicationId" type="UUID">


### PR DESCRIPTION
For some reason we were not showing the location info for this event. Nothing informative showed up in git blame.

But it does get set up the same way in the `send` and `handleEmail` method of `DefaultEventService`.

