### PR TITLE
remove 404 sitemaps

### DIFF
--- a/astro/public/sitemap-all.xml
+++ b/astro/public/sitemap-all.xml
@@ -6,10 +6,4 @@
   <sitemap>
     <loc>https://fusionauth.io/sitemap-index.xml</loc>
   </sitemap>
-  <sitemap>
-    <loc>https://fusionauth.io/docs/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://fusionauth.io/how-to/sitemap.xml</loc>
-  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
Removing sitemaps that are 404. 
All other sitemaps are now created by Astro except for marketing pages, which have been added to `astro/public/sitemap.xml`

howto redirects to docs
docs are now included in the generated `sitemap-0.xml` which is available in the `sitemap-index.xml`

Will now match our search console as well

<img width="926" alt="image" src="https://github.com/user-attachments/assets/fec822d7-995e-485d-b2eb-b8c5fb3628d7">
