### PR TITLE
Add missing release notes for 1.50.0

### DIFF
--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -149,6 +149,16 @@ Update dependencies.
 * A new, optional First Time Setup wizard has been added, which guides a developer through the basic setup needed to integrate their first application. After installing FusionAuth, you'll be able to access this from the main admin dashboard, as well as from the top of the left hand navigation.
   * Resolves [GitHub Issue #2717](https://github.com/FusionAuth/fusionauth-issues/issues/2717)
 
+### Internal
+* Update 3rd party dependencies.
+* Upgrade `ch.qos.logback:logback-*` `1.4.14` to `1.5.6`
+* Upgrade `com.fasterxml.jackson.*` `2.15.3` to `2.15.4`
+* Upgrade `io.fusionauth:java-http` `0.2.10` to `0.3.2`
+* Upgrade `org.mybatis:mybatis` `3.5.15` to `3.5.16`
+* Upgrade `org.primeframework:prime-mvc` `4.22.0` to `4.22.7`
+* Upgrade `org.postgresql:postgresql` `42.7.2` to `42.7.3`
+* Upgrade `org.slf4j:slf4j-api` `2.0.7` to `2.0.13`
+* Resolves [GitHub Issue #2678](https://github.com/FusionAuth/fusionauth-issues/issues/2678)
 
 <ReleaseNoteHeading version='1.49.2' releaseDate='March 20th, 2024' />
 
@@ -266,7 +276,7 @@ Update dependencies.
 ### Internal
 * Update 3rd party dependencies.
   * Upgrade `org.postgresql:postgresql` `42.6.0` to `42.7.2`
-  * Upgrade `com.fasterxml.jackson` `2.15.2` to `2.15.3`
+  * Upgrade `com.fasterxml.jackson.*` `2.15.2` to `2.15.3`
   * Upgrade `org.mybatis:mybatis` `3.5.13` to `3.5.15`
   * Resolves [GitHub Issue #2534](https://github.com/FusionAuth/fusionauth-issues/issues/2534)
 * During a reindex operation, log the progress based upon a fixed time interval instead of every 250k records. This ensures the output is predictable regardless of the reindex performance.
@@ -395,12 +405,12 @@ Update dependencies.
 
 ### Internal
 * Update dependencies to remove CVE scan warnings and to stay current. These upgrades are simply a precautionary measure to stay current.
-  * Upgrade `google-guice` `5.1.0` to `6.0.0`
-  * Upgrade `google-guava` `30.1.0` to `32.1.2`
-  * Upgrade `java-http` `0.2.0` to `0.2.9`
-  * Upgrade `kafka-clients` `2.8.2` to `3.6.0`
-  * Upgrade `prime-mvc` `4.11.0` to `4.17.1`
-  * Upgrade `snappy-java` `1.1.8.1` to `1.1.10.4`
+  * Upgrade `com.google.inject:guice` `5.1.0` to `6.0.0`
+  * Upgrade `com.google.guava:guava` `30.1.0` to `32.1.2`
+  * Upgrade `io.fusionauth:java-http` `0.2.0` to `0.2.9`
+  * Upgrade `org.apache.kafka:kafka-clients` `2.8.2` to `3.6.0`
+  * Upgrade `org.primeframework:prime-mvc` `4.11.0` to `4.17.1`
+  * Upgrade `org.xerial.snappy:snappy-java` `1.1.8.1` to `1.1.10.4`
   * Resolves [GitHub Issue #2385](https://github.com/FusionAuth/fusionauth-issues/issues/2385)
 * Upgrade to the latest Java 17 LTS. Upgraded from `17.0.3+7` to `17.0.8+1`.
   * Resolves [GitHub Issue #2386](https://github.com/FusionAuth/fusionauth-issues/issues/2386)


### PR DESCRIPTION
Normalize a few internal dep updates, and add missing dep updates from the `1.50.0` release.