### PR TITLE
align diagram with label

### DIFF
--- a/astro/src/components/mermaid/SequenceDiagram.astro
+++ b/astro/src/components/mermaid/SequenceDiagram.astro
@@ -48,7 +48,7 @@ props.infoBoxes.forEach(i => {
 
 {
   cache[uniqueKey] && (
-    <div class="mermaid-diagram">
+    <div class="mermaid-diagram flex justify-center">
       <Fragment set:html={cache[uniqueKey]} data-test="mermaid" />
     </div>
   )


### PR DESCRIPTION
I'm not sure if or when this got messed up, but the labels for sequence diagrams were off alignment.

This was because the diagrams were left aligned while the labels were centered. So I centered the diagram. If you think it should behave differently let me know.

Before:
<img width="1508" alt="Screenshot 2024-07-29 at 2 49 11 PM" src="https://github.com/user-attachments/assets/a104d920-68e7-4fd2-8f80-65cf84bef3a2">

After:
<img width="1508" alt="Screenshot 2024-07-29 at 2 49 26 PM" src="https://github.com/user-attachments/assets/d28e03b8-633e-43c3-9c76-43e9584873c3">

