### PR TITLE
iframe cookie notes

### DIFF
--- a/astro/src/content/docs/reference/cookies.mdx
+++ b/astro/src/content/docs/reference/cookies.mdx
@@ -20,7 +20,7 @@ The domain of all cookies is the domain on which the FusionAuth instance is runn
 
 In other words, if FusionAuth serves requests at `auth.piedpiper.com`, it will only set cookies for this value: `auth.piedpiper.com`. It will never set cookies for `.piedpiper.com`. The ability to control the domain of the cookie set is an [open feature request](https://github.com/FusionAuth/fusionauth-issues/issues/1991).
 
-Additionally, most cookies set by FusionAuth will use the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) value of `Strict` or `Lax`. This is to protect against [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf). Practically, it means that a browser will block those cookies on a cross-site request unless the browser is navigating to the origin site from an external site, which is something to consider if you intend to access FusionAuth from a different domain using something like an IFRAME.
+Additionally, most cookies set by FusionAuth will use the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) value of `Strict` or `Lax`. This is to protect against [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf). Practically, it means a browser will block those cookies on a cross-site request unless the browser is navigating to the origin site from an external site, which is something to consider if you intend to access FusionAuth from a different domain using something like an IFRAME.
 
 ## Cookie List
 

--- a/astro/src/content/docs/reference/cookies.mdx
+++ b/astro/src/content/docs/reference/cookies.mdx
@@ -20,7 +20,7 @@ The domain of all cookies is the domain on which the FusionAuth instance is runn
 
 In other words, if FusionAuth serves requests at `auth.piedpiper.com`, it will only set cookies for this value: `auth.piedpiper.com`. It will never set cookies for `.piedpiper.com`. The ability to control the domain of the cookie set is an [open feature request](https://github.com/FusionAuth/fusionauth-issues/issues/1991).
 
-Additionally, most cookies set by FusionAuth will use the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) value of `Strict` or `Lax`. This is to protect against [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf). Practically it means that those cookies will never be sent in a cross-site request, which is something to consider if you intend to access FusionAuth from a different domain using something like an iframe.
+Additionally, most cookies set by FusionAuth will use the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) value of `Strict` or `Lax`. This is to protect against [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf). Practically, it means that those cookies will never be sent in a cross-site request, which is something to consider if you intend to access FusionAuth from a different domain using something like an iframe.
 
 ## Cookie List
 

--- a/astro/src/content/docs/reference/cookies.mdx
+++ b/astro/src/content/docs/reference/cookies.mdx
@@ -20,6 +20,8 @@ The domain of all cookies is the domain on which the FusionAuth instance is runn
 
 In other words, if FusionAuth serves requests at `auth.piedpiper.com`, it will only set cookies for this value: `auth.piedpiper.com`. It will never set cookies for `.piedpiper.com`. The ability to control the domain of the cookie set is an [open feature request](https://github.com/FusionAuth/fusionauth-issues/issues/1991).
 
+Additionally, most cookies set by FusionAuth will use the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) value of `Strict` or `Lax`. This is to protect against [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf). Practically it means that those cookies will never be sent in a cross-site request, which is something to consider if you intend to access FusionAuth from a different domain using something like an iframe.
+
 ## Cookie List
 
 <Aside type="caution">
@@ -29,17 +31,18 @@ Cookies set by the hosted login pages are displayed here for informational purpo
 {/* Pulled from Cookies.java */}
 
 *Hosted Login Page Cookies*
-| Name | Type | Description
-| ---| ---| --- |
-| `fusionauth.flash-message` | Request | Used to display a message across requests. |
-| `fusionauth.known-device.*` | Persistent | Identifies a device known to FusionAuth. More than one cookie may be set. |
-| `fusionauth.locale` | Persistent | The locale used to localize the themed pages. |
-| `fusionauth.pkce-verifier` | Request | Used to support Proof Key for Code Exchange during login. |
-| `fusionauth.remember-device` | Persistent | Records if the user wants to remain logged in on this device. |
-| `fusionauth.sso` | Persistent | Represents a single sign-on session. |
-| `fusionauth.timezone` | Persistent | The configured or approximated timezone used to adjust displayed dates and times. |
-| `fusionauth.trusted-device.*` | Persistent | Identifies a trusted device. More than one cookie may be set. |
-| `fusionauth.trust_c` | Request | Implements security functionality. |
-| `fusionauth.trust_t` | Request | Implements security functionality. |
-| `fusionauth.trust` | Persistent | Allows a 2FA challenge to be bypassed during login. |
-| `fusionauth.webauthn-reauth.*` | Persistent | Records user choices about WebAuthn and passkeys. |
+
+| Name                           | Type       | Description                                                                       |
+|--------------------------------|------------|-----------------------------------------------------------------------------------|
+| `fusionauth.flash-message`     | Request    | Used to display a message across requests.                                        |
+| `fusionauth.known-device.*`    | Persistent | Identifies a device known to FusionAuth. More than one cookie may be set.         |
+| `fusionauth.locale`            | Persistent | The locale used to localize the themed pages.                                     |
+| `fusionauth.pkce-verifier`     | Request    | Used to support Proof Key for Code Exchange during login.                         |
+| `fusionauth.remember-device`   | Persistent | Records if the user wants to remain logged in on this device.                     |
+| `fusionauth.sso`               | Persistent | Represents a single sign-on session.                                              |
+| `fusionauth.timezone`          | Persistent | The configured or approximated timezone used to adjust displayed dates and times. |
+| `fusionauth.trusted-device.*`  | Persistent | Identifies a trusted device. More than one cookie may be set.                     |
+| `fusionauth.trust_c`           | Request    | Implements security functionality.                                                |
+| `fusionauth.trust_t`           | Request    | Implements security functionality.                                                |
+| `fusionauth.trust`             | Persistent | Allows a 2FA challenge to be bypassed during login.                               |
+| `fusionauth.webauthn-reauth.*` | Persistent | Records user choices about WebAuthn and passkeys.                                 |

--- a/astro/src/content/docs/reference/cookies.mdx
+++ b/astro/src/content/docs/reference/cookies.mdx
@@ -20,7 +20,7 @@ The domain of all cookies is the domain on which the FusionAuth instance is runn
 
 In other words, if FusionAuth serves requests at `auth.piedpiper.com`, it will only set cookies for this value: `auth.piedpiper.com`. It will never set cookies for `.piedpiper.com`. The ability to control the domain of the cookie set is an [open feature request](https://github.com/FusionAuth/fusionauth-issues/issues/1991).
 
-Additionally, most cookies set by FusionAuth will use the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) value of `Strict` or `Lax`. This is to protect against [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf). Practically, it means that those cookies will never be sent in a cross-site request, which is something to consider if you intend to access FusionAuth from a different domain using something like an iframe.
+Additionally, most cookies set by FusionAuth will use the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) value of `Strict` or `Lax`. This is to protect against [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf). Practically, it means that a browser will block those cookies on a cross-site request unless the browser is navigating to the origin site from an external site, which is something to consider if you intend to access FusionAuth from a different domain using something like an IFRAME.
 
 ## Cookie List
 

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -95,8 +95,8 @@ Update dependencies.
   flow without cookies being set as long as there were no additional redirects to FusionAuth before the final redirect to the configured
   <InlineField>redirect_url</InlineField>. As a result it did not matter if the `Set-Cookie` headers were blocked.
 
-  However, in this version the redirect to `/oauth2/consent` will be missing the FusionAuth cookies that are required to maintain user state and the login flow will fail. The user will be
-  redirected back to `/oauth2/authorize` and will be unable to log in.
+  However, in this version the browser will not be able to send the FusionAuth cookies required to maintain user state along with the redirect to
+  `/oauth2/consent` and the login flow will fail. The user will be redirected back to `/oauth2/authorize` and will be unable to log in.
 </GeneralMigrationWarning>
 
 <DeprecationWarning>

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -10,6 +10,7 @@ import DeprecationWarning from 'src/content/docs/release-notes/__deprecation-war
 import GeneralMigrationWarning from 'src/content/docs/release-notes/__general-migration-warning.astro';
 import ReleaseNotesSelector from 'src/components/docs/release-notes/ReleaseNotesSelector.astro';
 import ReleaseNoteHeading from 'src/components/docs/release-notes/ReleaseNoteHeading.astro';
+import InlineField from 'src/components/InlineField.astro';
 
 <ReleaseNotesSelector />
 
@@ -82,6 +83,16 @@ Update dependencies.
   This release makes significant changes to the default behavior of new Applications with regard to scopes in OAuth workflows.
   The database migration will update existing Applications to behave in a backwards compatible manner.
   See the OAuth [Scopes](/docs/lifecycle/authenticate-users/oauth/scopes) documentation for more information, in particular the `Relationship`, `Unknown scope policy`, and `Scope handling policy` configurations.
+</GeneralMigrationWarning>
+
+<GeneralMigrationWarning>
+  If you are using iframes to access the FusionAuth hosted login pages please check that the iframe `src` is from the same domain as the FusionAuth pages.
+
+  [FusionAuth uses cookies](/docs/reference/cookies) to manage user state with the `SameSite` attribute set to `Lax` or `Strict`. Browsers will block these cookies on cross-domain requests.
+  This release introduces a new redirect into the OAuth flows to `/oauth2/consent` as part of the OAuth [Scopes](/docs/lifecycle/authenticate-users/oauth/scopes) feature. This redirect
+  will happen for every interaction with FusionAuth's OAuth endpoints. Prior to this change it was possible to only visit the `/oauth2/authorize` endpoint before being sent to the configured
+  <InlineField>redirect_url</InlineField>, and as a result it did not matter if the cookies were blocked. However, with this change the redirect to `/oauth2/consent` will be missing the FusionAuth
+  cookies that are required to maintain user state and the login flow will fail.
 </GeneralMigrationWarning>
 
 <DeprecationWarning>

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -86,13 +86,17 @@ Update dependencies.
 </GeneralMigrationWarning>
 
 <GeneralMigrationWarning>
-  If you are using iframes to access the FusionAuth hosted login pages please check that the iframe `src` is from the same domain as the FusionAuth pages.
+  If you are using IFRAMEs to access the FusionAuth hosted login pages please check that the IFRAME `src` is from the same domain as the FusionAuth pages.
 
-  [FusionAuth uses cookies](/docs/reference/cookies) to manage user state with the `SameSite` attribute set to `Lax` or `Strict`. Browsers will block these cookies on cross-domain requests.
-  This release introduces a new redirect into the OAuth flows to `/oauth2/consent` as part of the OAuth [Scopes](/docs/lifecycle/authenticate-users/oauth/scopes) feature. This redirect
-  will happen for every interaction with FusionAuth's OAuth endpoints. Prior to this change it was possible to only visit the `/oauth2/authorize` endpoint before being sent to the configured
-  <InlineField>redirect_url</InlineField>, and as a result it did not matter if the cookies were blocked. However, with this change the redirect to `/oauth2/consent` will be missing the FusionAuth
-  cookies that are required to maintain user state and the login flow will fail.
+  [FusionAuth uses cookies](/docs/reference/cookies) to manage user state with the `SameSite` attribute set to `Lax` or `Strict`. Browsers will block `Set-Cookie` headers on cross-domain requests.
+
+  This release introduces a new redirect into the OAuth flows to `/oauth2/consent` as part of the OAuth [Scopes](/docs/lifecycle/authenticate-users/oauth/scopes)
+  feature. This redirect will occur during each browser based interactive OAuth workflow. Prior to this version it was possible to complete an OAuth code grant
+  flow without cookies being set as long as there were no additional redirects to FusionAuth before the final redirect to the configured
+  <InlineField>redirect_url</InlineField>. As a result it did not matter if the `Set-Cookie` headers were blocked.
+
+  However, in this version the redirect to `/oauth2/consent` will be missing the FusionAuth cookies that are required to maintain user state and the login flow will fail. The user will be
+  redirected back to `/oauth2/authorize` and will be unable to log in.
 </GeneralMigrationWarning>
 
 <DeprecationWarning>

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -91,9 +91,9 @@ Update dependencies.
   [FusionAuth uses cookies](/docs/reference/cookies) to manage user state with the `SameSite` attribute set to `Lax` or `Strict`. Browsers will block `Set-Cookie` headers on cross-domain requests.
 
   This release introduces a new redirect into the OAuth flows to `/oauth2/consent` as part of the OAuth [Scopes](/docs/lifecycle/authenticate-users/oauth/scopes)
-  feature. This redirect will occur during each browser based interactive OAuth workflow. Prior to this version it was possible to complete an OAuth code grant
+  feature. This redirect will occur during each browser-based interactive OAuth workflow. Prior to this version it was possible to complete an OAuth code grant
   flow without cookies being set as long as there were no additional redirects to FusionAuth before the final redirect to the configured
-  <InlineField>redirect_url</InlineField>. As a result it did not matter if the `Set-Cookie` headers were blocked.
+  <InlineField>redirect_url</InlineField>. As a result it did not matter if the `Set-Cookie` headers were blocked. The redirect with the code would still work.
 
   However, in this version the browser will not be able to send the FusionAuth cookies required to maintain user state along with the redirect to
   `/oauth2/consent` and the login flow will fail. The user will be redirected back to `/oauth2/authorize` and will be unable to log in.


### PR DESCRIPTION
Added notes describing the potential issue with iframes and cross-domain requests now that the consent route is mandatory for oauth flows