### PR TITLE
Correct path wildcard example

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/url-validation.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/url-validation.mdx
@@ -74,7 +74,7 @@ _Path Wildcards_
 |-------------------------------------------|-------------------------------------------------------|----------------------------------------------|
 | `https://example.com/path/*/resource`     | <i class="fas fa-check text-green-600 font-bold"></i> |                                              |
 | `https://example.com/p*/to/resource`      | <i class="fas fa-check text-green-600 font-bold"></i> |                                              |
-| `https://example.com/*/par*tial/*`        | <i class="fas fa-times text-red-600 font-bold"></i>   |                                              |
+| `https://example.com/*/par*tial/*`        | <i class="fas fa-check text-green-600 font-bold"></i> |                                              |
 | `https://example.com/path/*mid*/resource` | <i class="fas fa-times text-red-600 font-bold"></i>   | The path segment contains multiple wildcards |
 
 ### Query String Values


### PR DESCRIPTION
One of the path segment wildcard examples was incorrectly marked as invalid. Change the icon to indicate it is valid.