### PR TITLE
canonical urls for all docs

### DIFF
--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -14,13 +14,20 @@ const openGraphImageUrl = openGraphImage ? new URL(openGraphImage, Astro.url): n
 const normalizedUrl = Astro.url.toString().replace(/.html$/, '');
 const hasDark = !Astro.url.pathname.startsWith('/blog');
 const isProd = import.meta.env.PROD as boolean;
+
+let canonical = canonicalUrl;
+if (!canonical) {
+  canonical = Astro.url.href;
+} else if (!canonical.startsWith('http')) {
+  canonical = new URL(canonical, Astro.url).href;
+}
 ---
 <head>
   <meta charSet="UTF-8"/>
   <meta name="viewport" content="width=device-width"/>
   <!-- TODO: Implement favicons by following this blog post https://dev.to/masakudamatsu/favicon-nightmare-how-to-maintain-sanity-3al7 -->
   <link rel="icon" type="image/png" href="/img/favicon.png"/>
-  { canonicalUrl && <link rel="canonical" href={canonicalUrl} /> }
+  { canonical && <link rel="canonical" href={canonical} /> }
   <link rel="sitemap" href="/sitemap-index.xml">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="/css/brands.min.css"/>


### PR DESCRIPTION
Issue
- https://linear.app/fusionauth/issue/WRQ-25/fix-duplicate-content-warnings

Sets the canonical url on all docs pages. Based on `https://fusionauth.io/*`

ex: https://fusionauth.io/docs/extend/examples/multi-tenant.html
