### PR TITLE
added theme history repo doc

### DIFF
--- a/astro/src/content/docs/customize/look-and-feel/_theme-upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/_theme-upgrade.mdx
@@ -57,6 +57,12 @@ Once you have both sets of theme files downloaded, you can run the `diff-themes.
 ```
 The script will output a list of files with differences between the two themes along with the detailed diff for each file. You can use this output to update your customized theme files or use the file list as a guide along with an external diff tool.
 
+#### Using The Theme History Repo
+
+There's a FusionAuth maintained repository which tracks the history of hosted theme pages across releases. Each release is tagged with the version. This repository has theme files back to version 1.23.0.
+
+You can view [the repository](https://github.com/FusionAuth/fusionauth-theme-history) and use GitHub tooling to compare different the themes from different versions. You can also clone the repository and use your preferred git diffing tools.
+
 ### Messages
 
 When new functionality is introduced to [the hosted login pages](/docs/get-started/core-concepts/integration-points#hosted-login-pages), new theme message keys are sometimes required. They are added to the default theme `messages` file by the upgrade process. 

--- a/astro/src/content/docs/customize/look-and-feel/_theme-upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/_theme-upgrade.mdx
@@ -57,7 +57,7 @@ Once you have both sets of theme files downloaded, you can run the `diff-themes.
 ```
 The script will output a list of files with differences between the two themes along with the detailed diff for each file. You can use this output to update your customized theme files or use the file list as a guide along with an external diff tool.
 
-#### Using The Theme History Repo
+#### Using The Theme History Repository
 
 There's a FusionAuth maintained repository which tracks the history of hosted theme pages across releases. Each release is tagged with the version. This repository has theme files back to version 1.23.0.
 


### PR DESCRIPTION
This depends on updating the PAT used to do the commits, but would love to get this live.

More context here: https://inversoft.slack.com/archives/C06639QPHHQ/p1723760785327879