### PR TITLE
remove reference to specific ubuntu version in Docker extension example

### DIFF
--- a/astro/src/content/docs/get-started/download-and-install/docker.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/docker.mdx
@@ -140,7 +140,7 @@ Here's a Dockerfile which extends the latest FusionAuth image:
 
 <RemoteCode title="Example Dockerfile for building fusionauth-app including a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/build/fusionauth-app/Dockerfile" lang="docker" />
 
-Here's an example docker compose YAML file which uses this new image.
+Here's an example docker compose YAML file which uses this new image:
 
 <RemoteCode title="Example docker-compose.yml for building fusionauth-app including a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/build/docker-compose.yml" lang="yaml" />
 

--- a/astro/src/content/docs/get-started/download-and-install/docker.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/docker.mdx
@@ -134,7 +134,7 @@ To generally clean up your images on your system ,`docker image prune` will remo
 
 ## Custom Docker Images
 
-If you want to build your own image starting with our base image, start with the `fusionauth/fusionauth-app` image. Just as the FusionAuth Docker image is based on an ubunut image, you can build a Docker file which is based on the `fusionauth/fusionauth-app:latest` image. This can be useful if you want to permanently add a password hashing plugin, configuration file, or other customization directly in to the image.
+If you want to build your own image starting with our base image, start with the `fusionauth/fusionauth-app` image. Just as the FusionAuth Docker image is based on an Ubuntu container image, you can build a Docker file which is based on the `fusionauth/fusionauth-app:latest` image. This can be useful if you want to permanently add a password hashing plugin, configuration file, or other customization to the image.
 
 Here's a Dockerfile which extends the latest FusionAuth image:
 

--- a/astro/src/content/docs/get-started/download-and-install/docker.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/docker.mdx
@@ -134,11 +134,15 @@ To generally clean up your images on your system ,`docker image prune` will remo
 
 ## Custom Docker Images
 
-If you want to build your own image starting with our base image, start with the `fusionauth/fusionauth-app` image. Just as the FusionAuth Docker image is based on the `ubuntu:jammy` image, you can build a Docker file which is based on the `fusionauth/fusionauth-app:latest` image. This can be useful if you want to permanently add a password hashing plugin, configuration file, or other customization directly in to the image.
+If you want to build your own image starting with our base image, start with the `fusionauth/fusionauth-app` image. Just as the FusionAuth Docker image is based on an ubunut image, you can build a Docker file which is based on the `fusionauth/fusionauth-app:latest` image. This can be useful if you want to permanently add a password hashing plugin, configuration file, or other customization directly in to the image.
 
-<RemoteCode title="Example docker-compose.yml for building fusionauth-app including a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/build/docker-compose.yml" lang="yaml" />
+Here's a Dockerfile which extends the latest FusionAuth image:
 
 <RemoteCode title="Example Dockerfile for building fusionauth-app including a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/build/fusionauth-app/Dockerfile" lang="docker" />
+
+Here's an example docker compose YAML file which uses this new image.
+
+<RemoteCode title="Example docker-compose.yml for building fusionauth-app including a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/build/docker-compose.yml" lang="yaml" />
 
 With this example, you can use `docker compose build` to only run the build steps in the referenced Dockerfile. This will create you a custom Docker image which is consequentially used in the creation of the container in Docker Compose when running `docker compose up -d`. Alternatively you can run only `docker compose up -d` which will automatically take care of the build as well if not present.
 


### PR DESCRIPTION
also clean how we call out to the referenced files a bit.

Also checked that we don't mention `jammy` elsewhere.

This fixes the issue raised by @stuzzo here: https://github.com/FusionAuth/fusionauth-site/issues/3218