### PR TITLE
Fix links 2024 website launch

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -13,7 +13,7 @@ const { sections = [
   {
     "heading": "product",
     "items": [
-      { "label": "features", "href": "/features/authentication" },
+      { "label": "features", "href": "/platform/authentication" },
       { "label": "pricing", "href": "/pricing" },
     ]
   },

--- a/src/redirects.json
+++ b/src/redirects.json
@@ -439,6 +439,7 @@
     "/docs/quickstarts/quickstart-springboot-web": "/docs/quickstarts/quickstart-java-springboot-web",
     "/features/advanced-registration-forms": "/platform/registration-forms",
     "/features/architecture": "/platform/built-for-developers",
+    "/features/authentication": "/platform/authentication",
     "/features/breached-password-detection": "/features/authentication",
     "/features/built-for-developers": "/platform/built-for-developers",
     "/features/connectors": "/features/authentication",


### PR DESCRIPTION
Updated the footer link to deal with issues found here: https://github.com/FusionAuth/fusionauth-site/actions/runs/10616483955/job/29426997935

Also added a redirect for any external links to this page.