### PR TITLE
Update monitoring guide: less telemetry

### DIFF
--- a/astro/src/content/docs/operate/secure-and-monitor/opentelemetry.mdx
+++ b/astro/src/content/docs/operate/secure-and-monitor/opentelemetry.mdx
@@ -5,8 +5,15 @@ navcategory: admin
 section: operate
 subcategory: secure and monitor
 ---
+import Aside from 'src/components/Aside.astro';
 
 FusionAuth is a Java application. You can use the [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java-instrumentation) project to instrument it. Doing so can assist troubleshooting performance issues and make it easier to run.
+
+<Aside type="note">
+As of FusionAuth version 1.37.0, FusionAuth has switched to a lighter weight HTTP server backend. The `java-http` server does not have out of the box instrumentation from the `opentelemetry-javaagent.jar`. As of this version, you can not get traces of requests made to FusionAuth.
+
+See [this open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1665) for more discussion and to upvote or comment.
+</Aside>
 
 FusionAuth has no custom tracing spans embedded, but it can be set up as an OpenTelemetry exporter. Doing so provides useful data about types of requests, database queries, and more.
 

--- a/astro/src/content/docs/operate/secure-and-monitor/opentelemetry.mdx
+++ b/astro/src/content/docs/operate/secure-and-monitor/opentelemetry.mdx
@@ -10,7 +10,7 @@ import Aside from 'src/components/Aside.astro';
 FusionAuth is a Java application. You can use the [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java-instrumentation) project to instrument it. Doing so can assist troubleshooting performance issues and make it easier to run.
 
 <Aside type="note">
-As of FusionAuth version 1.37.0, FusionAuth has switched to a lighter weight HTTP server backend. The `java-http` server does not have out of the box instrumentation from the `opentelemetry-javaagent.jar`. As of this version, you can not get traces of requests made to FusionAuth.
+As of FusionAuth version 1.37.0, FusionAuth has switched to a lighter weight HTTP server backend. The `java-http` server does not have out of the box instrumentation from the `opentelemetry-javaagent.jar`. In versions 1.37.0 or later, you can not get request traces from FusionAuth.
 
 See [this open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1665) for more discussion and to upvote or comment.
 </Aside>


### PR DESCRIPTION
Per discussion on https://github.com/FusionAuth/fusionauth-issues/issues/1665 wanted to dial down our documented support for OpenTelemetry