### PR TITLE
Add dep updates for 1.52.1, add missing migration to upgrade doc.

### DIFF
--- a/astro/src/content/docs/operate/deploy/upgrade.mdx
+++ b/astro/src/content/docs/operate/deploy/upgrade.mdx
@@ -272,6 +272,7 @@ fusionauth-database-schema/
       |-- 1.48.1.sql
       |-- 1.49.0.sql
       |-- 1.50.0.sql
+      |-- 1.50.1.sql
       |-- 1.51.0.sql
 ```
 

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -40,6 +40,11 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
 * The SCIM Patch operation now properly handles removing multiple array elements, such as group memberships, in a single request.
   * Resolves [GitHub Issue #2834](https://github.com/FusionAuth/fusionauth-issues/issues/2834)
 
+### Internal
+* Update dependencies.
+  * Upgrade `io.fusionauth:fusionauth-scim` `2.2.1` -> `2.2.2`
+  * Resolves [GitHub Issue #2858](https://github.com/FusionAuth/fusionauth-issues/issues/2858)
+
 <ReleaseNoteHeading version='1.52.0' releaseDate='August 8, 2024' name="Passkey Platypus" />
 
 <GeneralMigrationWarning>

--- a/config/vale/styles/config/vocabularies/FusionAuth/accept.txt
+++ b/config/vale/styles/config/vocabularies/FusionAuth/accept.txt
@@ -507,10 +507,9 @@ Getka
 GhostProject
 Giese
 Giphy
+GitHub
+GitHub's
 GitLab
-Github
-Github's
-Gitlab
 Gluecon
 Gluu
 Gmail
@@ -2175,8 +2174,6 @@ getwuphf
 gif
 gifs
 giphy
-github
-gitlab
 giverUserId
 gkrothammer
 globalRegistrations


### PR DESCRIPTION

- Add missing dep updates to `1.52.1` for the SCIM library
- Add missing migration to upgrade doc for `1.50.1`