### PR TITLE
fix for incorrect parameter name

### DIFF
--- a/astro/src/content/docs/apis/hosted-backend.mdx
+++ b/astro/src/content/docs/apis/hosted-backend.mdx
@@ -283,8 +283,8 @@ To use this API, redirect the browser to this route and the router will respond 
   <APIField name="clientId" type="UUID" required>
     The client Id for your Application.
   </APIField>
-  <APIField name="redirect_uri" type="String" optional>
-    The URL encoded URL that the browser will be redirected to at the end of the logout flow. If not provided, this will be the <InlineField>Logout URL</InlineField> configured for the Application. If another value is used, it must be defined in the <InlineField>Authorized Redirect URLs</InlineField> for the Application.
+  <APIField name="post_logout_redirect_uri" type="String" optional>
+    The URL encoded URL that the browser will be redirected to at the end of the logout flow. This value must be in the Application's <InlineField>Authorized Redirect URLs</InlineField> list. If no `post_logout_redirect_uri` is provided, the user will be redirected to the <InlineField>Logout URL</InlineField> configured for the Application.
   </APIField>
 </APIBlock>
 


### PR DESCRIPTION
This was reported by @peter-greenatlas here: https://github.com/FusionAuth/fusionauth-site/issues/3227

Verified that the parameter was incorrect.