### PR TITLE
Fix check apis Sep 2024

### DIFF
--- a/astro/src/content/docs/apis/_lambda-request-body.mdx
+++ b/astro/src/content/docs/apis/_lambda-request-body.mdx
@@ -21,6 +21,6 @@ import LambdaType from './_lambda-type.astro';
   <APIField name="lambda.name" type="String" required>
     The name of the lambda.
   </APIField>
-  <LambdaType prefix={'lambda'} showRequired={true} showSince={true}/>
+  <LambdaType prefix={'lambda.'} showRequired={true} showSince={true}/>
 </APIBlock>
 

--- a/astro/src/content/docs/apis/_lambda-response-body.mdx
+++ b/astro/src/content/docs/apis/_lambda-response-body.mdx
@@ -30,6 +30,6 @@ import LambdaType from './_lambda-type.astro';
   <APIField name="lambda.name" type="String">
     The name of the lambda.
   </APIField>
-  <LambdaType prefix={'lambda'} />
+  <LambdaType prefix={'lambda.'} />
 </APIBlock>
 

--- a/astro/src/content/docs/apis/_lambda-responses-body.mdx
+++ b/astro/src/content/docs/apis/_lambda-responses-body.mdx
@@ -33,6 +33,6 @@ import LambdaType from './_lambda-type.astro';
   <APIField name="lambdas[x].name" type="String">
     The name of the lambda.
   </APIField>
-  <LambdaType prefix='lambdas[x]'/>
+  <LambdaType prefix='lambdas[x].'/>
 </APIBlock>
 

--- a/astro/src/content/docs/apis/_lambda-type.astro
+++ b/astro/src/content/docs/apis/_lambda-type.astro
@@ -15,7 +15,7 @@ const lambdas: LambdaDoc[] = (lambdasEntry.data as LambdaDoc[])
     .sort((a, b) => a.typeText.localeCompare(b.typeText));
 
 const { prefix, showRequired, showSince } = Astro.props;
-const name = `${prefix || ''}.type`;
+const name = `${prefix || ''}type`;
 ---
 <APIField {name} type="String" required={showRequired}>
   <p>The lambda type. The possible values are:</p>

--- a/astro/src/content/docs/apis/_lambda-type.astro
+++ b/astro/src/content/docs/apis/_lambda-type.astro
@@ -15,7 +15,7 @@ const lambdas: LambdaDoc[] = (lambdasEntry.data as LambdaDoc[])
     .sort((a, b) => a.typeText.localeCompare(b.typeText));
 
 const { prefix, showRequired, showSince } = Astro.props;
-const name = `${prefix || ''}type`;
+const name = `${prefix || ''}.type`;
 ---
 <APIField {name} type="String" required={showRequired}>
   <p>The lambda type. The possible values are:</p>

--- a/astro/src/content/docs/apis/_lambda-type.astro
+++ b/astro/src/content/docs/apis/_lambda-type.astro
@@ -15,7 +15,16 @@ const lambdas: LambdaDoc[] = (lambdasEntry.data as LambdaDoc[])
     .sort((a, b) => a.typeText.localeCompare(b.typeText));
 
 const { prefix, showRequired, showSince } = Astro.props;
+
+if (typeof prefix !== 'undefined' && prefix !== '') {
+  if (!prefix.endsWith(".")) {
+     throw new Error(`Prefix, if provided, must end with a ".". Prefix: '${prefix}'`);
+  }
+}
+
 const name = `${prefix || ''}type`;
+
+
 ---
 <APIField {name} type="String" required={showRequired}>
   <p>The lambda type. The possible values are:</p>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
@@ -47,6 +47,22 @@ export const eventType = 'user.login.failed';
     Moved to <InlineField>event.info</InlineField> in 1.30.0
   </APIField>
 
+  <APIField slot="trailing-fields" name="event.reason" type="Object" since="1.53.0">
+    An object containing data on the reason the login failed if it was prevented by a [Login Validation Lambda](/docs/extend/code/lambdas/login-validation).
+  </APIField>
+
+  <APIField slot="trailing-fields" name="event.reason.code" type="String" since="1.53.0">
+    The theme message key used to find a message to display to the end user.
+  </APIField>
+
+  <APIField slot="trailing-fields" name="event.reason.lambdaId" type="UUID" since="1.53.0">
+    The lambda Id which triggered the login failure.
+  </APIField>
+
+  <APIField slot="trailing-fields" name="event.reason.lambdaResult" type="Errors" since="1.53.0">
+    The [Errors](/docs/apis/errors) displayed to the end user. 
+  </APIField>
+
   <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">
     The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
@@ -48,19 +48,26 @@ export const eventType = 'user.login.failed';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.reason" type="Object" since="1.53.0">
-    An object containing data on the reason the login failed if it was prevented by a [Login Validation Lambda](/docs/extend/code/lambdas/login-validation).
+    An object containing data on the reason the login failed.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.reason.code" type="String" since="1.53.0">
-    The theme message key used to find a message to display to the end user.
+    The cause of the event. The possible values are:
+
+    * `credentials` 
+    * `lambdaValidation`
   </APIField>
 
   <APIField slot="trailing-fields" name="event.reason.lambdaId" type="UUID" since="1.53.0">
-    The lambda Id which triggered the login failure.
+    This is the unique Id of the lambda that caused the login to fail.
+
+    This field is only present if `reason.code` is `lambdaValidation`.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.reason.lambdaResult" type="Errors" since="1.53.0">
-    The [Errors](/docs/apis/errors) displayed to the end user. 
+    The [Errors](/docs/apis/errors) object returned by the lambda function which caused the login to fail.
+
+    This field is only present if `reason.code` is `lambdaValidation`.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-failed.mdx
@@ -61,13 +61,13 @@ export const eventType = 'user.login.failed';
   <APIField slot="trailing-fields" name="event.reason.lambdaId" type="UUID" since="1.53.0">
     This is the unique Id of the lambda that caused the login to fail.
 
-    This field is only present if `reason.code` is `lambdaValidation`.
+    This field is only present if <InlineField>reason.code</InlineField> is `lambdaValidation`.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.reason.lambdaResult" type="Errors" since="1.53.0">
     The [Errors](/docs/apis/errors) object returned by the lambda function which caused the login to fail.
 
-    This field is only present if `reason.code` is `lambdaValidation`.
+    This field is only present if <InlineField>reason.code</InlineField> is `lambdaValidation`.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.8.0">

--- a/src/check-apis-against-client-json.rb
+++ b/src/check-apis-against-client-json.rb
@@ -254,7 +254,7 @@ def process_file(fn, missing_fields, options, prefix = "", type = nil, page_cont
   known_types = ["ZoneId", "LocalDate", "char", "HTTPHeaders", "LocalizedStrings", "int", "URI", "Object", "String", "Map", "long", "ZonedDateTime", "List", "boolean", "UUID", "Set", "LocalizedIntegers", "double", "EventType", "SortedSet" ]
 
   # these are attributes that point to more complex objects at the leaf node, but aren't documented in the page. Instead, we point to the complex object doc page
-  nested_attributes = ["grant.entity", "entity.type", "event.auditLog", "event.eventLog", "event.user", "event.email", "event.existing", "event.registration", "event.original", "event.method", "event.identityProviderLink", "event.group", "event.refreshToken", "webhookEventLog.event"]
+  nested_attributes = ["grant.entity", "entity.type", "event.auditLog", "event.eventLog", "event.user", "event.email", "event.existing", "event.registration", "event.original", "event.method", "event.identityProviderLink", "event.group", "event.refreshToken", "webhookEventLog.event", "event.reason.lambdaResult"]
 
   # these are enums represented as strings in the API, but enums in java. We should still see them on the page
   enums = ["lambda.type", "lambda.engineType"]

--- a/src/check-apis-against-client-json.rb
+++ b/src/check-apis-against-client-json.rb
@@ -254,7 +254,7 @@ def process_file(fn, missing_fields, options, prefix = "", type = nil, page_cont
   known_types = ["ZoneId", "LocalDate", "char", "HTTPHeaders", "LocalizedStrings", "int", "URI", "Object", "String", "Map", "long", "ZonedDateTime", "List", "boolean", "UUID", "Set", "LocalizedIntegers", "double", "EventType", "SortedSet" ]
 
   # these are attributes that point to more complex objects at the leaf node, but aren't documented in the page. Instead, we point to the complex object doc page
-  nested_attributes = ["grant.entity", "entity.type", "event.auditLog", "event.eventLog", "event.user", "event.email", "event.existing", "event.registration", "event.original", "event.method", "event.identityProviderLink", "event.group", "event.refreshToken"]
+  nested_attributes = ["grant.entity", "entity.type", "event.auditLog", "event.eventLog", "event.user", "event.email", "event.existing", "event.registration", "event.original", "event.method", "event.identityProviderLink", "event.group", "event.refreshToken", "webhookEventLog.event"]
 
   # these are enums represented as strings in the API, but enums in java. We should still see them on the page
   enums = ["lambda.type", "lambda.engineType"]


### PR DESCRIPTION
https://github.com/FusionAuth/fusionauth-site/actions/runs/10873397915/job/30169460987 shows a failed check apis run.

We were missing some fields on the lambda page and the login failed webhook page.

I did try to document the login failed webhook fields, but may have missed some nuance around these fields.