### PR TITLE
Update 1.52.0 release notes with migration warning

### DIFF
--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -121,8 +121,8 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
 
 <ReleaseNoteHeading version='1.52.0' releaseDate='August 8, 2024' name="Passkey Platypus" />
 
-<GeneralMigrationWarning >
-  To ensure your premium features remain active when using an air-gapped license, please pickup a newly generated license text from your [Account](https://account.fusionauth.io/account) and reactivate FusionAuth Reactor.
+<GeneralMigrationWarning>
+  To ensure your premium features remain active when using an air-gapped license, please pick up a newly generated license text from your [FusionAuth account plan](https://account.fusionauth.io/account/plan) page and reactivate FusionAuth Reactor.
 </GeneralMigrationWarning>
 
 <GeneralMigrationWarning>

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -121,6 +121,10 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
 
 <ReleaseNoteHeading version='1.52.0' releaseDate='August 8, 2024' name="Passkey Platypus" />
 
+<GeneralMigrationWarning >
+  To ensure your premium features remain active when using an air-gapped license, please pickup a newly generated license text from your [Account](https://account.fusionauth.io/account) and reactivate FusionAuth Reactor.
+</GeneralMigrationWarning>
+
 <GeneralMigrationWarning>
   When using the User Registrations API, the `data` field for the FusionAuth application with Id `3c219e58-ed0e-4b18-ad48-f4f92793ae32` may now contain a `preferences` object. This object is reserved and should not be modified.
 </GeneralMigrationWarning>

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -124,7 +124,7 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
 <GeneralMigrationWarning>
   If you are not using an air-gapped license, this message can be disregarded. For those running in an air-gapped configuration, please continue.
   To ensure your premium features remain active after upgrading, please pick up a newly generated license text by navigating to the [Plan page](https://account.fusionauth.io/account/plan) in your FusionAuth account and reactivate FusionAuth Reactor.
-  More details on activating and deactivating your license can be found in the [Licensing docs](https://fusionauth.io/docs/get-started/core-concepts/licensing).
+  More details on activating and deactivating your license can be found in the [Licensing docs](/docs/get-started/core-concepts/licensing).
 </GeneralMigrationWarning>
 
 <GeneralMigrationWarning>

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -122,13 +122,23 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
 <ReleaseNoteHeading version='1.52.0' releaseDate='August 8, 2024' name="Passkey Platypus" />
 
 <GeneralMigrationWarning>
-  If you are not using an air-gapped license, this message can be disregarded. For those running in an air-gapped configuration, please continue.
-  To ensure your premium features remain active after upgrading, please pick up a newly generated license text by navigating to the [Plan page](https://account.fusionauth.io/account/plan) in your FusionAuth account and reactivate FusionAuth Reactor.
-  More details on activating and deactivating your license can be found in the [Licensing docs](/docs/get-started/core-concepts/licensing).
-</GeneralMigrationWarning>
+  **User Registrations API**
 
-<GeneralMigrationWarning>
   When using the User Registrations API, the `data` field for the FusionAuth application with Id `3c219e58-ed0e-4b18-ad48-f4f92793ae32` may now contain a `preferences` object. This object is reserved and should not be modified.
+
+  **Upgrading in an air-gapped configuration**
+
+  If you are not using an air-gapped license, this message can be disregarded. Have a good day!
+
+  For those running in an air-gapped configuration, you'll want to review this note. To ensure your premium features remain active after upgrading, please do the following:
+
+  * Navigate to the [Plan page](https://account.fusionauth.io/account/plan) in your FusionAuth account
+  * Pick up your license key and newly generated license text
+  * Navigate to `Reactor` in your Admin UI on your FusionAuth instance
+  * Decommission your license
+  * Reactivate FusionAuth Reactor using the license key and text
+
+  More details on activating and deactivating your license can be found in the [Licensing docs](/docs/get-started/core-concepts/licensing).
 </GeneralMigrationWarning>
 
 <DeprecationWarning>

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -122,7 +122,9 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
 <ReleaseNoteHeading version='1.52.0' releaseDate='August 8, 2024' name="Passkey Platypus" />
 
 <GeneralMigrationWarning>
-  To ensure your premium features remain active when using an air-gapped license, please pick up a newly generated license text from your [FusionAuth account plan](https://account.fusionauth.io/account/plan) page and reactivate FusionAuth Reactor.
+  If you are not using an air-gapped license, this message can be disregarded. For those running in an air-gapped configuration, please continue.
+  To ensure your premium features remain active after upgrading, please pick up a newly generated license text by navigating to the [Plan page](https://account.fusionauth.io/account/plan) in your FusionAuth account and reactivate FusionAuth Reactor.
+  More details on activating and deactivating your license can be found in the [Licensing docs](https://fusionauth.io/docs/get-started/core-concepts/licensing).
 </GeneralMigrationWarning>
 
 <GeneralMigrationWarning>


### PR DESCRIPTION
#### Changes Made

Updated the `1.52.0` release notes with a migration warning to inform air-gapped license holders that they will need to reactivate FusionAuth Reactor with a newly generated air-gapped license to ensure all active premium feature remain active. 