### PR TITLE
trim .html and index.html from canonical urls

### DIFF
--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -21,6 +21,15 @@ if (!canonical) {
 } else if (!canonical.startsWith('http')) {
   canonical = new URL(canonical, Astro.url).href;
 }
+
+if (canonical.endsWith('index.html')) {
+  canonical = canonical.slice(0, canonical.indexOf('index.html'));
+  if (!canonical.endsWith('/')) {
+    canonical += '/';
+  }
+} else if (canonical.endsWith('.html')) {
+  canonical = canonical.slice(0, canonical.indexOf('.html'));
+}
 ---
 <head>
   <meta charSet="UTF-8"/>


### PR DESCRIPTION
We were basing this off `Astro.url.href` which included these suffixes, this should fix that