### PR TITLE
added branch input to dev deploy workflow

### DIFF
--- a/.github/workflows/dev-astro.yml
+++ b/.github/workflows/dev-astro.yml
@@ -8,8 +8,8 @@ env:
   AWS_REGION: "us-east-2"
 on:
   # Runs on pushes targeting the default branch
-  push:
-    branches: ["release/1.53.0"]
+  # push:
+  #   branches: ["release/1.53.0"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/dev-astro.yml
+++ b/.github/workflows/dev-astro.yml
@@ -13,6 +13,10 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      branch:
+        required: true
+        type: string
 
 permissions:
   id-token: write # Used to get an access token, which is then used to assume an AWS IAM role
@@ -35,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
Added a branch input field to the dev deploy workflow so that you can (and have to) specify the branch to deploy from.