### PR TITLE
note about log files in FusionAuth Cloud

### DIFF
--- a/astro/src/content/docs/get-started/run-in-the-cloud/cloud.mdx
+++ b/astro/src/content/docs/get-started/run-in-the-cloud/cloud.mdx
@@ -5,6 +5,7 @@ section: get started
 subcategory: run in the cloud
 ---
 import Aside from 'src/components/Aside.astro';
+import Breadcrumb from 'src/components/Breadcrumb.astro';
 import InlineField from 'src/components/InlineField.astro';
 import EnterpriseEditionBlurb from 'src/content/docs/_shared/_enterprise-edition-blurb.astro';
 import LoadTestingIntro from 'src/content/docs/get-started/run-in-the-cloud/_load-testing-intro.mdx';
@@ -810,3 +811,4 @@ Since it is a managed service, there are additional limitations as well:
 * You may not modify the Elasticsearch settings or view the Elasticsearch index directly. Among other things, this means that you can't use some of the [troubleshooting steps](/docs/operate/troubleshooting/troubleshooting) available to users self-hosting FusionAuth.
 * OpenTelemetry data is not available on FusionAuth Cloud deployments.
 * There is a limit of 1000 indexed fields. These include `user.data`, `registration.data` and standard indexed fields like `email`.
+* In certain cases, only current log files are available for download under <Breadcrumb>System -> Logs</Breadcrumb>. If you need all log files, including those previously rotated, please [open a support ticket](https://account.fusionauth.io/account/support/).


### PR DESCRIPTION
due to changes from the new cloud platform, all system log files are not available for download.

this verbiage lets folks know that and how to get older files (ask support)