### PR TITLE
fix note about rehashing password on password change

### DIFF
--- a/astro/src/content/docs/_shared/_rehashing-user-passwords.mdx
+++ b/astro/src/content/docs/_shared/_rehashing-user-passwords.mdx
@@ -20,7 +20,5 @@ To import users and transparently rehash their passwords, do the following:
 
 After you have enabled this, when a user logs in, the password they provide will be transparently rehashed and they will use the stronger scheme in the future.
 
-<Aside type="note">
-Currently rehashing a password when it is changed is not supported. Here's the [tracking issue](https://github.com/FusionAuth/fusionauth-issues/issues/1450) for this feature.
-</Aside>
+Beginning in version `1.42.0`, when this configuration is enabled, in addition to re-hashing on login, the password will be re-hashed on password.
 

--- a/astro/src/content/docs/_shared/_rehashing-user-passwords.mdx
+++ b/astro/src/content/docs/_shared/_rehashing-user-passwords.mdx
@@ -20,5 +20,5 @@ To import users and transparently rehash their passwords, do the following:
 
 After you have enabled this, when a user logs in, the password they provide will be transparently rehashed and they will use the stronger scheme in the future.
 
-Beginning in version `1.42.0`, when this configuration is enabled, in addition to re-hashing on login, the password will be re-hashed on password.
+Beginning in version `1.42.0`, when this configuration is enabled, in addition to re-hashing on login, the password will be re-hashed on password change.
 


### PR DESCRIPTION
This should have been done when https://github.com/FusionAuth/fusionauth-issues/issues/1062 was fixed and released, but got missed.