### PR TITLE
fix missing env token which causes the gh workflow to never succeed

### DIFF
--- a/.github/workflows/closedissues.yml
+++ b/.github/workflows/closedissues.yml
@@ -17,6 +17,8 @@ jobs:
   check_closed_github_issues:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
https://github.com/FusionAuth/fusionauth-site/actions/runs/11221815367/job/31192928464 shows an example