### PR TITLE
run api check when PR is opened against api docs

### DIFF
--- a/.github/workflows/apicheck.yml
+++ b/.github/workflows/apicheck.yml
@@ -2,11 +2,14 @@ name: check_apis
 
 # Controls when the action will run. 
 on:
+  # run when api docs change
+  pull_request:
+    paths:
+      - 'astro/src/content/docs/apis/**'
+      - '.github/workflows/apicheck.yml'
   # Triggers the workflow once a day
   schedule:
     - cron: '31 18 * * *'
-  # don't run on every push
-  #push:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/closedissues.yml
+++ b/.github/workflows/closedissues.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for closed issues referenced in documentation
         run: |
-          # check out last released version of the client libs
+          # check docs for references to closed issues
           count=`src/scripts/check-for-closed-github-issues-in-docs.sh`
           exit $count
         shell: bash


### PR DESCRIPTION
Previously we were just running this on a schedule.