### PR TITLE
Update 404 status code to 401 when there is no access token.

### DIFF
--- a/astro/src/diagrams/quickstarts/resource-server.astro
+++ b/astro/src/diagrams/quickstarts/resource-server.astro
@@ -10,7 +10,7 @@ const diagram = `
         participant FusionAuth
 
         Client ->> App : GET /resource
-        App ->> Client : 404 Not Authorized
+        App ->> Client : 401 Not Authorized
         Client ->> FusionAuth : POST /api/login
         FusionAuth ->> Client : 200 Ok<br/>(token)
         Client ->> App : GET /resource


### PR DESCRIPTION
In the General Architecture diagram for the Backend/API Quickstarts, change the status code to a 401 when contacting the resource server without an access token.

For reference:
- Backend/API (the backend quickstarts) - /docs/quickstarts/#api

[Issue](https://github.com/FusionAuth/fusionauth-site/issues/3322)