### PR TITLE
Add known issue for SSO with external IdPs in 1.53.0

### DIFF
--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -62,6 +62,7 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
 <DatabaseMigrationWarning />
 
 ### Known Issues
+* FusionAuth's hosted login pages no longer create an SSO session when signing in using an external IdP.
 * <IssueResolvedVia resolvedIn="1.53.1" viaIssue="2861">A user may fail to enroll a new Passkey (WebAuthn credential) used for reauthentication during a login workflow. Previously configured Passkeys should continue to work as expected.</IssueResolvedVia>
 
 ### Changed


### PR DESCRIPTION
Version `1.53.0` introduced a regression in behavior. SSO sessions are no longer being created when signing in with an external IdP.