### PR TITLE
backrev to ubuntu 22.04 to avoid pip error

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   vale:
     name: runner / vale
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: errata-ai/vale-action@reviewdog


### PR DESCRIPTION
https://github.com/errata-ai/vale-action/issues/128 indicates that ubuntu 24.04 is the new 'latest' but that the vale action has issues with it. Backrevving to 22.04 fixes it.

> ...  I think in the next release I will stop installing them.

https://github.com/errata-ai/vale-action/issues/128#issuecomment-2405758847

Indicates we can revert this after the next vale action release, but until then every reviewdog run will fail.