### PR TITLE
Correct email configuration field name

### DIFF
--- a/astro/src/content/docs/apis/_tenant-application-email-configuration.mdx
+++ b/astro/src/content/docs/apis/_tenant-application-email-configuration.mdx
@@ -19,7 +19,7 @@ import InlineField from 'src/components/InlineField.astro';
     The default From Name used in sending emails when a from name is not provided on an individual email template. This is the display name part of the email address ( i.e. **Jared Dunn**  `jared@piedpiper.com`).
   </APIField>
 
-  <APIField name={ props.base_field_name + ".emailConfiguration.verificationEmailTemplateId" } type="UUID" optional since="1.19.0" renderif={!props.is_tenant}>
+  <APIField name={ props.base_field_name + ".emailConfiguration.emailVerificationEmailTemplateId" } type="UUID" optional since="1.19.0" renderif={!props.is_tenant}>
     The Id of the Email Template used to send emails to users to verify that their email address is valid. {props.application_email_config_override_text}
   </APIField>
 

--- a/astro/src/content/docs/apis/_tenant-application-email-configuration.mdx
+++ b/astro/src/content/docs/apis/_tenant-application-email-configuration.mdx
@@ -19,7 +19,7 @@ import InlineField from 'src/components/InlineField.astro';
     The default From Name used in sending emails when a from name is not provided on an individual email template. This is the display name part of the email address ( i.e. **Jared Dunn**  `jared@piedpiper.com`).
   </APIField>
 
-  <APIField name={ props.base_field_name + ".emailConfiguration.emailVerificationEmailTemplateId" } type="UUID" optional since="1.19.0" renderif={!props.is_tenant}>
+  <APIField name={ props.base_field_name + ".emailConfiguration.verificationEmailTemplateId" } type="UUID" optional since="1.19.0" renderif={!props.is_tenant}>
     The Id of the Email Template used to send emails to users to verify that their email address is valid. {props.application_email_config_override_text}
   </APIField>
 

--- a/astro/src/content/docs/apis/_tenant-request-body.mdx
+++ b/astro/src/content/docs/apis/_tenant-request-body.mdx
@@ -80,7 +80,7 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
     An object that can hold any information about the Tenant that should be persisted.
   </APIField>
 
-  <TenantApplicationEmailConfiguration base_field_name="tenant" />
+  <TenantApplicationEmailConfiguration base_field_name="tenant" is_tenant={true} />
 
   <APIField name="tenant.eventConfiguration.events" type="Object" optional since="1.8.0">
     A mapping of the configuration for each event type that FusionAuth sends. The event types that are the keys into this Object are:

--- a/astro/src/content/docs/apis/_tenant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_tenant-response-body-base.mdx
@@ -68,7 +68,7 @@ import JSON from 'src/components/JSON.astro';
     An object that can hold any information about the Tenant that should be persisted.
   </APIField>
 
-  <TenantApplicationEmailConfiguration base_field_name={props.base_field_name} />
+  <TenantApplicationEmailConfiguration base_field_name={props.base_field_name} is_tenant={true} />
 
   <APIField name={props.base_field_name + '.eventConfiguration.events'} type="Object" since="1.8.0">
     A mapping of the configuration for each event type that FusionAuth sends. The event types that are the keys into this Object are:


### PR DESCRIPTION
Everything else in `emailConfiguration` appears to be correct.

The reason the check api test did not pick this up is it's correct in the sample requests/responses, but not the actual `<APIField>`.