### PR TITLE
redirect /community/forum/category to /community/forum/categories

### DIFF
--- a/src/redirects.json
+++ b/src/redirects.json
@@ -9,7 +9,6 @@
     "/blog/archive/category/features": "/blog/category/product",
     "/blog/archive/category/tutorial": "/blog/category/tutorial",
     "/blog/how-sso-works": "/articles/authentication/how-sso-works",
-    "/community/forum/category": "/community/forum/categories",
     "/cognito": "/docs/lifecycle/migrate-users/bulk/cognito",
     "/dev-tools/jwt-debugger": "/dev-tools/jwt-decoder",
     "/docs/getting-started": "/docs/get-started/",
@@ -609,7 +608,8 @@
     ["/learn/expert-advice/authentication/spa", "/articles/login-authentication-workflows/spa"],
     ["/learn/expert-advice/authentication/mobile", "/articles/login-authentication-workflows/mobile"],
     ["/learn/expert-advice/authentication/webapp", "/articles/login-authentication-workflows/webapp"],
-    ["/learn/expert-advice", "/articles"]
+    ["/learn/expert-advice", "/articles"],
+    ["/community/forum/category": "/community/forum/categories"]
   ],
   "redirectsByRegex": [
     ["^/blog/(category|tag|author)/([^/]*)$", "$&/"],

--- a/src/redirects.json
+++ b/src/redirects.json
@@ -9,6 +9,7 @@
     "/blog/archive/category/features": "/blog/category/product",
     "/blog/archive/category/tutorial": "/blog/category/tutorial",
     "/blog/how-sso-works": "/articles/authentication/how-sso-works",
+    "/community/forum/category": "/community/forum/categories",
     "/cognito": "/docs/lifecycle/migrate-users/bulk/cognito",
     "/dev-tools/jwt-debugger": "/dev-tools/jwt-decoder",
     "/docs/getting-started": "/docs/get-started/",

--- a/src/redirects.json
+++ b/src/redirects.json
@@ -609,7 +609,7 @@
     ["/learn/expert-advice/authentication/mobile", "/articles/login-authentication-workflows/mobile"],
     ["/learn/expert-advice/authentication/webapp", "/articles/login-authentication-workflows/webapp"],
     ["/learn/expert-advice", "/articles"],
-    ["/community/forum/category": "/community/forum/categories"]
+    ["/community/forum/category", "/community/forum/categories"]
   ],
   "redirectsByRegex": [
     ["^/blog/(category|tag|author)/([^/]*)$", "$&/"],


### PR DESCRIPTION
We have external links pointing at `/community/forum/category` that are broken. The last path element needs to be `categories`.