### PR TITLE
Add note re: registration arg being undefined when applicationId is omitted

### DIFF
--- a/astro/src/content/docs/extend/code/lambdas/_reconcile-lambda-user-registration-parameters.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/_reconcile-lambda-user-registration-parameters.mdx
@@ -1,2 +1,2 @@
-* `user` - the FusionAuth User object. You can modify this, except the `email` or `username` attribute may not be modified after the user has been linked.
-* `registration` - the FusionAuth UserRegistration object. You can modify this.
+* `user` - the FusionAuth User object. You can modify this object, except the `email` or `username` attribute may not be modified after the user has been linked.
+* `registration` - the FusionAuth UserRegistration object. You can modify this object.

--- a/astro/src/content/docs/extend/code/lambdas/apple-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/apple-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, idToken) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `idToken` - the JSON payload of the validated and decoded Id Token returned from Apple. This is read-only.
+* `idToken` - the JSON payload of the validated and decoded Id Token returned from Apple. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The Id Token object that contains the payload returned by Apple and may contain well known OpenID Connect registered claims as well as any custom claims defined by Apple.
 

--- a/astro/src/content/docs/extend/code/lambdas/client-credentials-jwt-populate.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/client-credentials-jwt-populate.mdx
@@ -25,10 +25,10 @@ function populate(jwt, recipientEntity, targetEntities, permissions) {
 
 This lambda must contain a function named `populate` that takes four parameters. The parameters that the lambda is passed are:
 
-* `jwt` - the claims object to be signed and return as the JWT payload
-* `recipientEntity` - the Recipient Entity. See an example below.
-* `targetEntities` - the Target Entities. See an example below.
-* `permissions` - the permissions assigned to the Entity. Example below.
+* `jwt` - the claims object to be signed and return as the JWT payload. You can modify this object.
+* `recipientEntity` - the Recipient Entity. This object is read-only. See an example below.
+* `targetEntities` - the Target Entities. This object is read-only. See an example below.
+* `permissions` - the permissions assigned to the Entity. This object is read-only. Example below.
 
 The `recipientEntity` and `targetEntities` objects are well documented here in the [Permissions & Entity Types APIs](/docs/apis/entities/entity-types) and [Entities API](/docs/apis/entities/entities) documentation. The JWT object is a JavaScript object containing the JWT payload. See [here for more](/docs/lifecycle/authenticate-users/oauth/tokens).
 
@@ -45,7 +45,7 @@ The `tid` claim was added in version 1.36.0.
 
 ## Assigning The Lambda
 
-Once a lambda is created, you must assign it. To do so via the administrative user interface, navigate to <strong>Tenants -> Your Tenant -> OAuth</strong> and update the <InlineField>Client credentials populate lambda</InlineField> setting. 
+Once a lambda is created, you must assign it. To do so via the administrative user interface, navigate to <strong>Tenants -> Your Tenant -> OAuth</strong> and update the <InlineField>Client credentials populate lambda</InlineField> setting.
 
 ### Example Entities And Permissions Objects
 

--- a/astro/src/content/docs/extend/code/lambdas/epic-games-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/epic-games-reconcile.mdx
@@ -24,8 +24,7 @@ function reconcile(user, registration, userInfo) {
 This lambda must contain a function named `reconcile` that takes the following parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `userInfo` - data returned by the Epic Games Account API. This is read-only.
-* `accessToken` - the JSON payload returned by the Epic Token API. This is read-only.
+* `userInfo` - data returned by the Epic Games Account API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `idToken` may contain various user claims depending upon the user's Epic Games configuration.
 

--- a/astro/src/content/docs/extend/code/lambdas/external-jwt-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/external-jwt-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, jwt)  {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `jwt` - the JSON payload returned by the external identity provider JWT. This is read-only.
+* `jwt` - the JSON payload returned by the external identity provider JWT. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `jwt` may contain various user claims to utilize during the reconcile process.
 

--- a/astro/src/content/docs/extend/code/lambdas/facebook-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/facebook-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, facebookUser) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `facebookUser` - the User returned from the Facebook Me API. This is read-only.
+* `facebookUser` - the User returned from the Facebook Me API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `facebookUser` may contain various user claims depending upon the user's Facebook configuration.
 

--- a/astro/src/content/docs/extend/code/lambdas/google-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/google-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, idToken) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `idToken` - the JSON payload returned by the Google Token Info API. This is read-only.
+* `idToken` - the JSON payload returned by the Google Token Info API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `idToken` may contain various user claims to utilize during the reconcile process.
 

--- a/astro/src/content/docs/extend/code/lambdas/jwt-populate.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/jwt-populate.mdx
@@ -16,6 +16,8 @@ Here's a brief video showing how to set up a JWT populate lambda:
 
 When you create a new lambda using the FusionAuth UI we will provide you an empty function for you to implement.
 
+Note that this lambda is not executed if you call the Login API directly and omit `applicationId` request parameter.
+
 ## Lambda Structure
 
 If you are using the API to create the lambda you will need to ensure your function has the following signature:
@@ -28,9 +30,9 @@ function populate(jwt, user, registration) {
 
 This lambda must contain a function named `populate` that takes three parameters. The parameters that the lambda is passed are:
 
-* `jwt` - the claims object to be signed and return as the JWT payload
-* `user` - the FusionAuth User object
-* `registration` - the FusionAuth UserRegistration object
+* `jwt` - the claims object to be signed and return as the JWT payload. You can modify this object.
+* `user` - the FusionAuth User object. This object is read-only.
+* `registration` - the FusionAuth UserRegistration object. This parameter may be `undefined` when the user is not registered for the application. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The JWT object is a JavaScript object containing the JWT payload. See [OpenID Connect & OAuth 2.0 Token](/docs/lifecycle/authenticate-users/oauth/tokens).
 

--- a/astro/src/content/docs/extend/code/lambdas/ldap-connector-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/ldap-connector-reconcile.mdx
@@ -24,8 +24,8 @@ function reconcile(user, userAttributes) {
 
 This lambda must contain a function named `reconcile` that takes two parameters. The parameters that the lambda is passed are:
 
-* `user` - the FusionAuth User object. You can modify this, however you cannot modify the `username` or `email` attributes once the account is linked.
-* `userAttributes` - the user attributes returned from LDAP during authentication. This is read-only.
+* `user` - the FusionAuth User object. You can modify this object, however you cannot modify the `username` or `email` attributes once the account is linked.
+* `userAttributes` - the user attributes returned from LDAP during authentication. This object is read-only.
 
 The FusionAuth user object is well documented the [User API](/docs/apis/users) documentation. The `userAttributes` object may contain various values returned by the LDAP server.
 

--- a/astro/src/content/docs/extend/code/lambdas/linkedin-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/linkedin-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, linkedInUser) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `linkedInUser` - the JSON payload returned by the LinkedIn Email and Me APIs. This is read-only.
+* `linkedInUser` - the JSON payload returned by the LinkedIn Email and Me APIs. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `linkedInUser` may contain various user claims depending upon the user's LinkedIn configuration and the scopes requested in the LinkedIn configuration.
 

--- a/astro/src/content/docs/extend/code/lambdas/login-validation.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/login-validation.mdx
@@ -27,10 +27,10 @@ function validate(result, user, registration, context) {
 
 This lambda must contain a function named `validate` that takes four parameters. The parameters that the lambda is passed are:
 
-* `result` - An [Errors](/docs/apis/errors) object used for communicating validation errors
-* `user` - the FusionAuth User object. This is read-only.
-* `registration` - the FusionAuth UserRegistration object. This is read-only.
-* `context` - an object containing context for the current request. This is read-only.
+* `result` - An [Errors](/docs/apis/errors) object used for communicating validation errors. You can modify this object.
+* `user` - the FusionAuth User object. This object is read-only.
+* `registration` - the FusionAuth UserRegistration object. This object is read-only.
+* `context` - an object containing context for the current request. This object is read-only.
 
 The `user` and `registration` objects are well documented in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `context` object has the following structure:
 

--- a/astro/src/content/docs/extend/code/lambdas/nintendo-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/nintendo-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, userInfo) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `userInfo` - the JSON payload returned by the Nintendo Token Info API. This is read-only.
+* `userInfo` - the JSON payload returned by the Nintendo Token Info API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `userInfo` may contain various user claims depending upon the user's Nintendo configuration.
 

--- a/astro/src/content/docs/extend/code/lambdas/openid-connect-response-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/openid-connect-response-reconcile.mdx
@@ -27,9 +27,9 @@ function reconcile(user, registration, jwt, id_token, tokens) {
 This lambda must contain a function named `reconcile` that takes at least three parameters, the fourth and fifth parameters are optional. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `jwt` - the JSON payload returned from the OpenID Connect UserInfo endpoint. This is read-only.
-* `id_token` - the JSON payload returned in the `id_token` when available. This parameter may not be provided and will be `undefined` in that case. This is read-only. <span class="px-3 text-green-500 italic capitalize">Available since 1.31.0</span>
-* `tokens` - an object containing the encoded versions of the `access_token` and optionally the `id_token` when available. This is read-only. <span class="px-3 text-green-500 italic capitalize">Available since 1.48.0</span>
+* `jwt` - the JSON payload returned from the OpenID Connect UserInfo endpoint. This object is read-only.
+* `id_token` - the JSON payload returned in the `id_token` when available. This parameter may not be provided and will be `undefined` in that case. This object is read-only. <span class="px-3 text-green-500 italic capitalize">Available since 1.31.0</span>
+* `tokens` - an object containing the encoded versions of the `access_token` and optionally the `id_token` when available. This object is read-only. <span class="px-3 text-green-500 italic capitalize">Available since 1.48.0</span>
 
 The two FusionAuth objects are well documented in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation.
 

--- a/astro/src/content/docs/extend/code/lambdas/samlv2-response-populate.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/samlv2-response-populate.mdx
@@ -24,9 +24,9 @@ function populate(samlResponse, user, registration) {
 
 This lambda must contain a function named `populate` that takes three parameters. The parameters that the lambda is passed are:
 
-* `samlResponse` - the SAML v2 response object
-* `user` - the FusionAuth User object
-* `registration` - the FusionAuth UserRegistration object
+* `samlResponse` - the SAML v2 response object. You can modify this object.
+* `user` - the FusionAuth User object. This object is read-only.
+* `registration` - the FusionAuth UserRegistration object. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The SAML response object mimics the format of the XML document, but is designed to be much simpler to use than dealing with the DOM object model. Here is a list of the fields you have access to manipulate in the SAML response:
 

--- a/astro/src/content/docs/extend/code/lambdas/scim-group-request-converter.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/scim-group-request-converter.mdx
@@ -23,16 +23,16 @@ function convert(group, members, options, scimGroup) {
 
 This lambda must contain a function named `convert` that takes four parameters. The parameters that the lambda is passed are:
 
-* `group` - the FusionAuth Group object
-* `members` - the members in this FusionAuth Group
+* `group` - the FusionAuth Group object. You can modify this object.
+* `members` - the members in this FusionAuth Group. You can modify this object.
   * `members[x].userId` - The Id of the FusionAuth User
   * `members[x].data.$ref` - The URI to retrieve the SCIM User representation of the FusionAuth User
 
     * ex. `https://login.piedpiper.com/api/scim/v2/Users/902c246b-6245-4190-8e05-00816be7344a`
 
-* `options` - options contains optional FusionAuth request options
+* `options` - request options. You can modify this object.
   * `options.roleIds`
-* `scimGroup` - the SCIM request object
+* `scimGroup` - the SCIM request object. This object is read-only.
 
 The FusionAuth object is well documented here in the [Group API](/docs/apis/groups) documentation. The SCIM Group object is a JavaScript object containing the SCIM Group request JSON payload. See [SCIM Group](https://datatracker.ietf.org/doc/html/rfc7643#section-4.2).
 

--- a/astro/src/content/docs/extend/code/lambdas/scim-group-response-converter.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/scim-group-response-converter.mdx
@@ -23,9 +23,9 @@ function convert(scimGroup, group, members) {
 
 This lambda must contain a function named `convert` that takes three parameters. The parameters that the lambda is passed are:
 
-* `scimGroup` - the SCIM Group object
-* `group` - the FusionAuth Group object
-* `members` - the members in this FusionAuth Group
+* `scimGroup` - the SCIM Group object. You can modify this object.
+* `group` - the FusionAuth Group object. This object is read-only.
+* `members` - the members in this FusionAuth Group. This object is read-only.
 
 The FusionAuth `group` object is well documented here in the [Group API](/docs/apis/groups) documentation. The `members` object is an array of `user` objects, well documented in the [User API](/docs/apis/users). The SCIM Group object is a JavaScript object containing the SCIM Group response JSON payload. See [SCIM Group](https://datatracker.ietf.org/doc/html/rfc7643#section-4.2).
 

--- a/astro/src/content/docs/extend/code/lambdas/scim-user-request-converter.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/scim-user-request-converter.mdx
@@ -23,13 +23,13 @@ function convert(user, options, scimUser) {
 
 This lambda must contain a function named `convert` that takes three parameters. The parameters that the lambda is passed are:
 
-* `user` - the FusionAuth User object
-* `options` - options contains optional FusionAuth request options
+* `user` - the FusionAuth User object. You can modify this object.
+* `options` - request options. This object is read-only. This object has the following properties:
 ** `options.applicationId`
 ** `options.disableDomainBlock`
 ** `options.sendSetPasswordEmail`
 ** `options.skipVerification` NOTE: only applies during a User create request
-* `scimUser` - the SCIM request object
+* `scimUser` - the SCIM request object. This object is read-only.
 
 The FusionAuth objects are well documented here in the [User API](/docs/apis/users) documentation. The `options` object contains parameters matching the non-User object Create User API parameters, such as `disableDomainBlock`.
 

--- a/astro/src/content/docs/extend/code/lambdas/scim-user-response-converter.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/scim-user-response-converter.mdx
@@ -23,8 +23,8 @@ function convert(scimUser, user) {
 
 This lambda must contain a function named `convert` that takes two parameters. The parameters that the lambda is passed are:
 
-* `scimUser` - the SCIM response object
-* `user` - the FusionAuth User object
+* `scimUser` - the SCIM response object. You can modify this object.
+* `user` - the FusionAuth User object. This object is read-only.
 
 The FusionAuth `user` object is well documented here in the [User API](/docs/apis/users) documentation. The SCIM User object is a JavaScript object containing the SCIM User and optionally the SCIM EnterpriseUser response JSON payload. See [SCIM User](https://datatracker.ietf.org/doc/html/rfc7643#section-4.1) and [SCIM EnterpriseUser extension](https://datatracker.ietf.org/doc/html/rfc7643#section-4.3).
 

--- a/astro/src/content/docs/extend/code/lambdas/self-service-registration.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/self-service-registration.mdx
@@ -9,7 +9,7 @@ tertcategory: lambdas
 
 When you have an [Advanced Registration Form](/docs/lifecycle/register-users/advanced-registration-forms) you may add a lambda to perform additional validation of the form fields as the user completes steps in the form.
 
-When you create a new lambda using the FusionAuth UI, we will provide you an empty function for you to implement. 
+When you create a new lambda using the FusionAuth UI, we will provide you an empty function for you to implement.
 
 ## Lambda Structure
 
@@ -23,11 +23,11 @@ function validate(result, user, registration, formContext) {
 
 This lambda must contain a function named `validate` that takes four parameters. The parameters that the lambda is passed are:
 
-* `result` - this is a FormValidationResult object with one property
+* `result` - this is a FormValidationResult object with one property. You can modify this object.
   - `errors` which is a FusionAuth Errors object to append form errors to, and is the output of the function. The Errors object is documented in the [Errors API](/docs/apis/errors).
-* `user` - the FusionAuth User object which is documented in the [User API](/docs/apis/users).
-* `registration` - the FusionAuth UserRegistration object which is documented in the [Registration API](/docs/apis/registrations).
-* `formContext` - an object containing data about the current form state. If has the following properties:
+* `user` - the FusionAuth User object which is documented in the [User API](/docs/apis/users). This object is read-only.
+* `registration` - the FusionAuth UserRegistration object which is documented in the [Registration API](/docs/apis/registrations). This object is read-only.
+* `formContext` - an object containing data about the current form state. This object is read-only. This object has the following properties:
   - `fields` - an array of [Form Fields](/docs/apis/custom-forms/form-fields) in the current form step.
   - `form` - the FusionAuth Form object which is documented in the [Forms API](/docs/apis/custom-forms/forms).
   - `step` - the current step number

--- a/astro/src/content/docs/extend/code/lambdas/sony-playstation-network-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/sony-playstation-network-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, userInfo) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `userInfo` - the JSON payload returned by the Sony PlayStation Network UserInfo API. This is read-only.
+* `userInfo` - the JSON payload returned by the Sony PlayStation Network UserInfo API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `userInfo` may contain various user claims depending upon the user's Sony PlayStation Network configuration.
 

--- a/astro/src/content/docs/extend/code/lambdas/steam-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/steam-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, userInfo) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `userInfo` - the JSON payload returned by the Steam Token Details API. This is read-only.
+* `userInfo` - the JSON payload returned by the Steam Token Details API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `userInfo` may contain various user claims depending upon the user's Steam configuration.
 

--- a/astro/src/content/docs/extend/code/lambdas/twitch-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/twitch-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, userInfo) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `userInfo` - the JSON payload returned by the Twitch Token Info API. This is read-only.
+* `userInfo` - the JSON payload returned by the Twitch Token Info API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `userInfo` may contain various user claims depending upon the user's Twitch configuration.
 

--- a/astro/src/content/docs/extend/code/lambdas/twitter-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/twitter-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, twitterUser) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `twitterUser` - the JSON user object returned by the Twitter Verify Credentials API. This is read-only.
+* `twitterUser` - the JSON user object returned by the Twitter Verify Credentials API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `twitterUser` may contain various user claims to utilize during the reconcile process.
 

--- a/astro/src/content/docs/extend/code/lambdas/userinfo-populate.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/userinfo-populate.mdx
@@ -24,10 +24,10 @@ function populate(userInfo, user, registration, jwt) {
 
 This lambda must contain a function named `populate` that takes four parameters. The parameters that the lambda is passed are:
 
-* `userInfo` - the claims object to be returned as a JSON payload
-* `user` - the FusionAuth User object. This is read-only.
-* `registration` - the FusionAuth UserRegistration object. This is read-only.
-* `jwt` - the claims object from the provided JWT. This is read-only.
+* `userInfo` - the claims object to be returned as a JSON payload. You can modify this object.
+* `user` - the FusionAuth User object. This object is read-only.
+* `registration` - the FusionAuth UserRegistration object. This object is read-only.
+* `jwt` - the claims object from the provided JWT. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The JWT object is a JavaScript object containing the JWT payload. See [OpenID Connect & OAuth 2.0 Token](/docs/lifecycle/authenticate-users/oauth/tokens).
 

--- a/astro/src/content/docs/extend/code/lambdas/xbox-reconcile.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/xbox-reconcile.mdx
@@ -24,7 +24,7 @@ function reconcile(user, registration, userInfo) {
 This lambda must contain a function named `reconcile` that takes three parameters. The parameters that the lambda is passed are:
 
 <ReconcileLambdaUserRegistrationParameters />
-* `userInfo` - the JSON payload returned by the Xbox Token Info API. This is read-only.
+* `userInfo` - the JSON payload returned by the Xbox Token Info API. This object is read-only.
 
 The two FusionAuth objects are well documented here in the [User API](/docs/apis/users) and [Registration API](/docs/apis/registrations) documentation. The `userInfo` may contain various user claims depending upon the user's Xbox configuration.
 


### PR DESCRIPTION
### Issue
- https://github.com/FusionAuth/fusionauth-app/pull/565
- https://linear.app/fusionauth/issue/ENG-1805/populate-lambda-does-not-execute-without-a-registration-when-calling

### Summary
1. Document that the registration arg may be undefined for the JWT populate.
2. Normalize usage of read-only, and can modify comments for lambda arguments.
2. Correct Epic Lambda args. Reviewed against source code for accuracy.