### PR TITLE
Theme changes for Google IdP SSO fix

### DIFF
--- a/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
@@ -15,10 +15,24 @@ This page contains notes on changes in recent versions of FusionAuth that requir
 
 Version `1.53.3` includes a change to persist the value of the `Keep me signed in` checkbox, which indicates whether the user wishes to create an SSO session after login, through an external identity provider workflow. If the Google IdP's `loginMethod` is configured as `UsePopup` or `UseVendorJavaScript`, existing custom advanced themes require an update to incorporate the fix for the Google IdP. You can update the template via the API using `theme.templates.helpers` or by modifying the *Helpers* template in the admin UI.
 
-To allow the `Keep me signed in` value to be persisted through a Google IdP login in an existing custom advanced theme, remove the `data-login_uri` attribute from the `div` with Id `g_id_onload` in the `googleButton` macro and add the following attribute in its place:
+To allow the `Keep me signed in` value to be persisted through a Google IdP login in an existing custom advanced theme, remove the `data-login_uri` attribute and its value from the `div` with Id `g_id_onload` in the `googleButton` macro and add the `data-callback` attribute in its place.
+
+Replace
 
 ```html
-data-callback="googleLoginCallback"
+<div id="g_id_onload" [#list identityProvider.lookupAPIProperties(clientId)!{} as attribute, value] data-${attribute}="${value}" [/#list]
+     data-client_id="${identityProvider.lookupClientId(clientId)}"
+     data-login_uri="${currentBaseURL}/oauth2/callback?state=${idpRedirectState}&identityProviderId=${identityProvider.id}" >
+</div>
+```
+
+with
+
+```html
+<div id="g_id_onload" [#list identityProvider.lookupAPIProperties(clientId)!{} as attribute, value] data-${attribute}="${value}" [/#list]
+     data-client_id="${identityProvider.lookupClientId(clientId)}"
+     data-callback="googleLoginCallback" >
+</div>
 ```
 
 ## Version 1.52.0

--- a/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
@@ -13,7 +13,7 @@ This page contains notes on changes in recent versions of FusionAuth that requir
 
 ## Version 1.53.3
 
-Version `1.53.3` includes a change to persist the value of the `Keep me signed in` checkbox, which indicates whether the user wishes to create an SSO session after login, through an external identity provider workflow. If the Google IdP's `loginMethod` is configured as `UsePopup` or `UseVendorJavaScript`, existing custom advanced themes require an update to the `helpers` template to incorporate the fix for the Google IdP. You can update the template via the API or by modifying the *Helpers* template in the admin UI.
+Version `1.53.3` includes a change to persist the value of the `Keep me signed in` checkbox, which indicates whether the user wishes to create an SSO session after login, through an external identity provider workflow. If the Google IdP's `loginMethod` is configured as `UsePopup` or `UseVendorJavaScript`, existing custom advanced themes require an update to incorporate the fix for the Google IdP. You can update the template via the API using `theme.templates.helpers` or by modifying the *Helpers* template in the admin UI.
 
 To allow the `Keep me signed in` value to be persisted through a Google IdP login in an existing custom advanced theme, remove the `data-login_uri` attribute from the `div` with Id `g_id_onload` in the `googleButton` macro and add the following attribute in its place:
 
@@ -23,7 +23,7 @@ data-callback="googleLoginCallback"
 
 ## Version 1.52.0
 
-Version `1.52.0` includes a change to use the browser-default date picker to enhance the experience on mobile. Existing custom advanced themes require an update to the `helpers` template to incorporate the change. You can update the template via the API or by modifying the *Helpers* template in the admin UI.
+Version `1.52.0` includes a change to use the browser-default date picker to enhance the experience on mobile. Existing custom advanced themes require an update to incorporate the change. You can update the template via the API using `theme.templates.helpers` or by modifying the *Helpers* template in the admin UI.
 
 To include the new date picker in an existing custom advanced theme, replace the `Prime.Document.query('.date-picker')` line in the `head` macro with the following:
 
@@ -42,9 +42,9 @@ document.querySelectorAll('.date-picker').forEach(datePicker => {
 
 Version `1.50.0` added the ability to prompt users for consent to custom OAuth scopes in third-party applications. This change requires a new themed template `oauth2Consent` as well as a new macro and function in the `helpers` template.
 
-The `oauth2Consent` template from the default theme will be used until it is added to an existing custom theme. You can copy the new template from the default theme as a starting point and add it to a custom theme using the API or the _Consent prompt_ template in the admin UI.
+The `oauth2Consent` template from the default theme will be used until it is added to an existing custom theme. You can copy the new template from the default theme as a starting point and add it to a custom theme via the API using `theme.templates.oauth2Consent` or the _Consent prompt_ template in the admin UI.
 
-The new `scopeConsentField` macro and `resolveScopeMessaging` function *must* be added to an existing custom theme's `helpers` template in order for the theme to continue functioning. Add these new items to the template via the API or the *Helpers* template in the admin UI. You can copy them from the default template or use the following:
+The new `scopeConsentField` macro and `resolveScopeMessaging` function *must* be added to an existing custom theme's `helpers` template in order for the theme to continue functioning. Add these new items to the template via the API using `theme.templates.helpers` or the *Helpers* template in the admin UI. You can copy them from the default template or use the following:
 
 ```html
 [#macro scopeConsentField application scope type]

--- a/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
@@ -13,7 +13,7 @@ This page contains notes on changes in recent versions of FusionAuth that requir
 
 ## Version 1.53.3
 
-Version `1.53.3` includes a change to persist the value of the `Keep me signed in` checkbox, which indicates whether the user wishes to create an SSO session after login, through an external identity provider workflow. If the Google IdP's `loginMethod` is configured as `UsePopup` or `UseVendorJavaScript`, existing custom advanced themes require an update to incorporate the fix for the Google IdP. You can update the template via the API using `theme.templates.helpers` or by modifying the *Helpers* template in the admin UI.
+Version `1.53.3` includes a change to persist the value of the `Keep me signed in` checkbox from the hosted login pages through an external identity provider workflow. This checkbox value indicates whether the user wishes to create an SSO session after login. If the Google IdP's `loginMethod` is configured as `UsePopup` or `UseVendorJavaScript`, existing custom advanced themes require an update to incorporate the fix for the Google IdP. You can update the template via the API using `theme.templates.helpers` or by modifying the *Helpers* template in the admin UI. Google IdPs configured with a `loginMethod` value of `UseRedirect` do not require this update, but you may consider making the change preemptively in case the `loginMethod` is changed later.
 
 To allow the `Keep me signed in` value to be persisted through a Google IdP login in an existing custom advanced theme, remove the `data-login_uri` attribute and its value from the `div` with Id `g_id_onload` in the `googleButton` macro and add the `data-callback` attribute in its place.
 

--- a/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
@@ -13,9 +13,9 @@ This page contains notes on changes in recent versions of FusionAuth that requir
 
 ## Version 1.53.3
 
-Version `1.53.3` includes a change to persist the user's SSO decision through an external identity provider workflow. If the Google IdP's `loginMethod` is configured as `UsePopup` or `UseVendorJavaScript`, existing custom advanced themes require an update to the `helpers` template to incorporate the fix for the Google IdP. You can update the template via the API or by modifying the *Helpers* template in the admin UI.
+Version `1.53.3` includes a change to persist the value of the `Keep me signed in` checkbox, which indicates whether the user wishes to create an SSO session after login, through an external identity provider workflow. If the Google IdP's `loginMethod` is configured as `UsePopup` or `UseVendorJavaScript`, existing custom advanced themes require an update to the `helpers` template to incorporate the fix for the Google IdP. You can update the template via the API or by modifying the *Helpers* template in the admin UI.
 
-To allow the user's SSO decision to be persisted through a Google IdP login in an existing custom advanced theme, remove the `data-login_uri` attribute from the `div` with Id `g_id_onload` in the `googleButton` macro and add the following attribute in its place:
+To allow the `Keep me signed in` value to be persisted through a Google IdP login in an existing custom advanced theme, remove the `data-login_uri` attribute from the `div` with Id `g_id_onload` in the `googleButton` macro and add the following attribute in its place:
 
 ```html
 data-callback="googleLoginCallback"

--- a/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
@@ -4,15 +4,6 @@ description: This page contains upgrade notes for required theme changes in rece
 section: customize
 subcategory: look and feel
 ---
-import InlineField from 'src/components/InlineField.astro';
-import APIBlock from 'src/components/api/APIBlock.astro';
-import APIField from 'src/components/api/APIField.astro';
-import MessagesExample from 'src/content/docs/customize/look-and-feel/_messages-example.mdx';
-import ThemeEnvironments from 'src/content/docs/operate/deploy/_theme-environment-management.mdx';
-import ThemeTroubleshooting from 'src/content/docs/customize/look-and-feel/_theme-troubleshooting.mdx';
-import ThemeUpgrade from 'src/content/docs/customize/look-and-feel/_theme-upgrade.mdx';
-import Templates from 'src/content/docs/_shared/_theme_templates.astro';
-import Aside from 'src/components/Aside.astro';
 
 ## Overview
 

--- a/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
@@ -20,6 +20,16 @@ New versions of FusionAuth sometimes include new or updated theme templates. If 
 
 This page contains notes on changes in recent versions of FusionAuth that require changes to a customized theme.
 
+## Version 1.53.3
+
+Version `1.53.3` includes a change to persist the user's SSO decision through an external identity provider workflow. If the Google IdP's `loginMethod` is configured as `UsePopup` or `UseVendorJavaScript`, existing custom advanced themes require an update to the `helpers` template to incorporate the fix for the Google IdP. You can update the template via the API or by modifying the *Helpers* template in the admin UI.
+
+To allow the user's SSO decision to be persisted through a Google IdP login in an existing custom advanced theme, remove the `data-login_uri` attribute from the `div` with Id `g_id_onload` in the `googleButton` macro and add the following attribute in its place:
+
+```html
+data-callback="googleLoginCallback"
+```
+
 ## Version 1.52.0
 
 Version `1.52.0` includes a change to use the browser-default date picker to enhance the experience on mobile. Existing custom advanced themes require an update to the `helpers` template to incorporate the change. You can update the template via the API or by modifying the *Helpers* template in the admin UI.

--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -46,6 +46,10 @@ Looking for release notes older than 1.23.0? Look in the [release notes archive]
 
 <ReleaseNoteHeading version='1.53.3' releaseDate='October 25, 2024'/>
 
+<ThemeUpdateWarning version="1.53.3">
+  A fix for FusionAuth SSO session management with external identity providers requires a change to Google IdP usage.
+</ThemeUpdateWarning>
+
 ### Fixed
 * <Issue issue="2764">
   In order to better protect 3rd party logins via SAML v2, OpenID Connect, and other 3rd party identity providers, a CSRF (cross site request forgery) token was added in version `1.47.0`. This token was not being used when all identity providers configured for the requested `client_id` were also configured to use managed domains, and the authorize request also contained the `idp_hint` request parameter.


### PR DESCRIPTION
We missed documenting required theme changes for the Google IdP related to an SSO fix when using external IdPs.