### PR TITLE
Update jwks endpoint doc

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
@@ -11,6 +11,7 @@ import API from 'src/components/api/API.astro';
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
 import AvailableSince from 'src/components/api/AvailableSince.astro';
+import Breadcrumb from 'src/components/Breadcrumb.astro';
 import InlineField from 'src/components/InlineField.astro';
 import OauthAuthorizeRedirectParameters from 'src/content/docs/_shared/_oauth-authorize-redirect-parameters.mdx';
 import AuthorizationHeader from 'src/content/docs/lifecycle/authenticate-users/oauth/_authorization-header.mdx';
@@ -1593,7 +1594,7 @@ A default FusionAuth installation has no public/private keypairs.
 
 HMAC shared secret keys will not be published at this endpoint. If they were, anyone would be able to retrieve such a key and then sign tokens with it. Those tokens would be indistinguishable from those created by FusionAuth. That would be bad.
 
-You may add keys using the admin UI by navigating to <strong>Settings -> Key Master</strong> and generating or importing them.
+You may add keys using the admin UI by navigating to <Breadcrumb>Settings -> Key Master</Breadcrumb> and generating or importing them.
 You may also use the [Keys API](/docs/apis/keys) to generate or import keys.
 </Aside>
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
@@ -1591,6 +1591,8 @@ You may also use the [JWT Public Key](/docs/apis/jwt#retrieve-public-keys) API t
 You must add an asymmetric key to FusionAuth to have keys at this endpoint.
 A default FusionAuth installation has no public/private keypairs.
 
+HMAC shared secret keys will not be published at this endpoint. If they were, anyone would be able to retrieve such a key and then sign tokens with it. Those tokens would be indistinguishable from those created by FusionAuth. That would be bad.
+
 You may add keys using the admin UI by navigating to <strong>Settings -> Key Master</strong> and generating or importing them.
 You may also use the [Keys API](/docs/apis/keys) to generate or import keys.
 </Aside>

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
@@ -1590,11 +1590,11 @@ You may also use the [JWT Public Key](/docs/apis/jwt#retrieve-public-keys) API t
 
 <Aside type="note">
 You must add an asymmetric key to FusionAuth to have keys at this endpoint.
-Since version 1.50.0, a default FusionAuth installation has a single RSA public/private keypair.
+Since version 1.50.0, default FusionAuth installations have a single RSA public/private key pair.
 
-HMAC shared secret keys will not be published at this endpoint. If they were, anyone would be able to retrieve such a key and then sign tokens with it. Those tokens would be indistinguishable from those created by FusionAuth. That would be bad.
+HMAC shared secret keys are not published by this endpoint. If they were, anyone would be able to retrieve these keys and then sign tokens with them. Those tokens would be indistinguishable from those created by FusionAuth. That would be bad.
 
-You may add keys using the admin UI by navigating to <Breadcrumb>Settings -> Key Master</Breadcrumb> and generating or importing them.
+You may add key pairs using the admin UI by navigating to <Breadcrumb>Settings -> Key Master</Breadcrumb> and generating or importing them.
 You may also use the [Keys API](/docs/apis/keys) to generate or import keys.
 </Aside>
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
@@ -1590,7 +1590,7 @@ You may also use the [JWT Public Key](/docs/apis/jwt#retrieve-public-keys) API t
 
 <Aside type="note">
 You must add an asymmetric key to FusionAuth to have keys at this endpoint.
-A default FusionAuth installation has no public/private keypairs.
+Since version 1.50.0, a default FusionAuth installation has a single RSA public/private keypair.
 
 HMAC shared secret keys will not be published at this endpoint. If they were, anyone would be able to retrieve such a key and then sign tokens with it. Those tokens would be indistinguishable from those created by FusionAuth. That would be bad.
 


### PR DESCRIPTION
Added clarity around why HMAC keys are not displayed (confused this user: https://fusionauth.io/community/forum/topic/2795/oauth-introspect-endpoint-works-only-with-the-credentials-of-the-creator-of-the-access-token-being-verified )

Also added note about default RSA key.