### PR TITLE
Run shrink images on push and pull_request open

### DIFF
--- a/.github/workflows/shrink-images.yml
+++ b/.github/workflows/shrink-images.yml
@@ -6,6 +6,11 @@ on:
       - main
     paths:
       - 'astro/public/**'
+  pull_request:
+    branches-ignore:
+      - main
+    paths:
+      - 'astro/public/**'
 
 jobs:
   shrink:

--- a/.github/workflows/shrink-images.yml
+++ b/.github/workflows/shrink-images.yml
@@ -5,12 +5,12 @@ on:
     branches-ignore:
       - main
     paths:
-      - 'astro/public/**'
+      - 'astro/public/img/**/*.png'
   pull_request:
     branches-ignore:
       - main
     paths:
-      - 'astro/public/**'
+      - 'astro/public/img/**/*.png'
 
 jobs:
   shrink:


### PR DESCRIPTION
Is if you only run it on push, it misses the first time you push up new images, because there is no PR open at that time, so the script fails. See this run for example: https://github.com/FusionAuth/fusionauth-site/actions/runs/11731437467

So we need to run this both on PR open (so it runs the first time a PR is opened) and on push, so that when an image is updated in a PR or a new image is added based on feedback, we catch and shrink the image.

There's some worry about degradation of images due to repeated shrinking, but I haven't seen that play out in practice.

Also tightened up the paths since this only works on png images.