### PR TITLE
Revert "Revert "Update quickstart intro""

### DIFF
--- a/astro/src/pages/docs/quickstarts/index.astro
+++ b/astro/src/pages/docs/quickstarts/index.astro
@@ -4,14 +4,34 @@ import Section from "../../../components/quickstarts/QuickstartSection.astro"
 import { quickstartSections } from './quickstart-sections';
 ---
 
-<Layout frontmatter={{disableTOC: true}} title="Quickstarts" description="Explore step-by-step Quickstart guides from FusionAuth to seamlessly integrate authentication into your application. Start building secure and scalable solutions in minutes." >
+<Layout frontmatter={{disableTOC: true}} title="Quickstarts" description="Explore step-by-step quickstart guides from FusionAuth to seamlessly integrate authentication into your application." >
     <div class="block group rounded-lg">
         <div class="flex object-fill justify-between">
-            <div class="flex flex-col justify-center">
-                <h1 class="mb-0 font-extrabold text-3xl sm:leading-tight md:text-4xl lg:text-5xl">Quickstarts</h1>
-                <p class="font-normal text-s">Step-by-step guides to quickly integrate FusionAuth into your application.</p>
-            </div>
+            <section>
+                <p class="font-normal text-s">
+                  Learn how you'd use FusionAuth to add authentication and authorization to an application in the framework or language of your choice in 15 minutes or less.
+                </p>
+                <p class="font-normal text-s">
+                  Each quickstart includes a complete runnable application and a shell application you can build out by following the step-by-step integration instructions. Application examples include: <a href='#web-application'>traditional web applications</a>, <a href='#spa'>single-page applications</a>, <a href='#mobile-app'>mobile applications</a>, and <a href='#api'>APIs protected with access tokens</a>.
+                </p>
+                <p class="font-normal text-s">
+                  These quickstarts help you rapidly evaluate FusionAuth and see how an integration works, rather than serve as a blueprint for integrating FusionAuth into your current system. For that, see the <a href='/docs/get-started/'>Getting Started</a> documentation.
+                </p>
+            </section>
             <img class="ml-50 my-0 h-28 lg:h-52 self-end" src="/img/icons/quickstart.svg" alt="quickstart">
+        </div>
+        <div class="flex object-fill justify-between">
+            <section>
+                <p class="font-normal text-s">
+                  You'll need the following to work through any quickstarts.
+                </p>
+                  <ul>
+                    <li>Git, for cloning the example repository</li>
+                    <li>Docker, to run FusionAuth and its dependencies</li>
+                    <li>An editor, to update files</li>
+                    <li>The language, platform or framework; for example, XCode to run the iOS quickstart or Java for the Spring example</li>
+                  </ul>
+            </section>
         </div>
 
     </div>

--- a/astro/src/pages/docs/quickstarts/quickstart-sections.ts
+++ b/astro/src/pages/docs/quickstarts/quickstart-sections.ts
@@ -22,17 +22,6 @@ interface QuickStartSection {
 
 const qsSections: QuickStartSection[] = [
   {
-      key: 'five-minute',
-      icon: '/img/icons/qs-main.svg',
-      faIcon: 'fa-code-simple',
-      color: 'indigo',
-      title: '5-minute Guides',
-      anchorTag: '5-minute',
-      desc: 'Guides for getting up and running quickly',
-      articles: [
-      ],
-  },
-  {
     key: 'web',
     icon: '/img/icons/web-application.svg',
     faIcon: 'fa-code-simple',
@@ -75,6 +64,17 @@ const qsSections: QuickStartSection[] = [
     desc: 'An API or service protected by FusionAuth and access tokens',
     articles: [
     ],
+  },
+  {
+      key: 'five-minute',
+      icon: '/img/icons/qs-main.svg',
+      faIcon: 'fa-code-simple',
+      color: 'indigo',
+      title: '5-minute Guides',
+      anchorTag: '5-minute',
+      desc: 'Integration examples against different environments',
+      articles: [
+      ],
   },
 ];
 


### PR DESCRIPTION
Reverts FusionAuth/fusionauth-site#3381

This lets us add some context to the quickstart section which was lacking before.

This is a reversion of a reversion because I didn't get the [initial PR](https://github.com/fusionauth/fusionauth-site/pull/3378) approved by folks who can approve layout changes.