### PR TITLE
remove extra 'notice' text

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/index.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/index.mdx
@@ -126,8 +126,6 @@ Next, learn how to perform a [Client Credentials Grant](/docs/lifecycle/authenti
 ## Example Authorization Code Grant
 
 <Aside type="note">
-*Notice*
-
 Mobile applications require additional security in implementing the Authorization Code Grant Flow due to inability to safely store a client-secret and the potential of the authorization code being intercepted.
 
 For these reasons, it is best practice to implement the Authorization Code Grant Flow with [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) (PKCE, pronounced "pixie").


### PR DESCRIPTION
this is already in an aside so no need for the italicized 'notice'.

You can see it on prod here: https://fusionauth.io/docs/lifecycle/authenticate-users/oauth/#example-authorization-code-grant under `note`.