### PR TITLE
Update rss feeds

### DIFF
--- a/astro/src/pages/articles/feed.xml.js
+++ b/astro/src/pages/articles/feed.xml.js
@@ -9,6 +9,8 @@ function convertToRSS(post) {
     // Compute RSS link from post `slug`
     // This example assumes all posts are rendered as `/blog/[slug]` routes
     link: `/articles/${post.slug}`,
+    author: post.data.author,
+    categories: post.data.section.split(",").map(item => item.trim()),
   }
 }
 

--- a/astro/src/pages/blog/feed.xml.js
+++ b/astro/src/pages/blog/feed.xml.js
@@ -9,6 +9,8 @@ function convertToRSS(post) {
     // Compute RSS link from post `slug`
     // This example assumes all posts are rendered as `/articles/[slug]**` routes
     link: `/blog/${post.slug}`,
+    author: post.data.authors,
+    categories: post.data.categories.split(",").map(item => item.trim()),
   }
 }
 


### PR DESCRIPTION
Added author and categories to the rss feed.

Note that according to the spec, author should be an email address, but https://stackoverflow.com/questions/5855993/multiple-authors-in-rss-or-atoms states:  

> The basic consensus is that you cannot expect to parse this field. Since that is the case, you can list it any way you want and if someone is using the <author> tag, most likely they are just displaying it so you should be good to go.