### PR TITLE
document that newlines separate the managed domains 

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/_managed-domains-description.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/_managed-domains-description.mdx
@@ -1,0 +1,7 @@
+---
+---
+You may optionally scope this identity provider to one or more managed domains. For example, if you were to use an {props.type} identity provider only for your employees, add your company domain `piedpiper.com` to this field. You can add multiple domains, one on each line. 
+
+Adding one or more managed domains for this configuration will cause this provider not to be displayed as a button on your login page. Instead of a button the login form will first ask the user for their email address. If the user's email address matches one of the configured domains the user will then be redirected to this login provider to complete authentication. If the user's email address does not match one of the configured domains, the user will be prompted for a password and they will be authenticated using FusionAuth.
+
+These configured domains will be used by the [Lookup API](/docs/apis/identity-providers/#lookup-an-identity-provider).

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/overview-oidc.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/overview-oidc.mdx
@@ -10,6 +10,7 @@ import InlineField from 'src/components/InlineField.astro';
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
 import Aside from 'src/components/Aside.astro';
+import ManagedDomainsDescription from 'src/content/docs/lifecycle/authenticate-users/identity-providers/_managed-domains-description.mdx';
 import IdpManagedDomainsTroubleshooting from 'src/content/docs/lifecycle/authenticate-users/identity-providers/_idp-managed-domains-troubleshooting.mdx';
 import Diagram from 'src/diagrams/docs/identity-providers/oidc-redirect-urls.astro';
 
@@ -133,11 +134,7 @@ That's it, now the `Login with PiedPiper` button will show up on the login page.
 
 <APIBlock>
   <APIField name="Managed domains" optional>
-    You may optionally scope this identity provider to one or more managed domains. For example, if you were to use an OpenID Connect identity provider only for your employees, add your company domain `piedpiper.com` to this field.
-
-    Adding one or more managed domains for this configuration will cause this provider not to be displayed as a button on your login page. Instead of a button the login form will first ask the user for their email address. If the user's email address matches one of the configured domains the user will then be redirected to this login provider to complete authentication. If the user's email address does not match one of the configured domains, the user will be prompted for a password and they will be authenticated using FusionAuth.
-
-    These configured domains will be used by the [Lookup API](/docs/apis/identity-providers/#lookup-an-identity-provider).
+    <ManagedDomainsDescription type="OpenID Connect"/>
   </APIField>
 </APIBlock>
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/overview-samlv2.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/overview-samlv2.mdx
@@ -13,6 +13,7 @@ import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
 import SamlIdpInitWarning from 'src/content/docs/_shared/_saml-idp-init-warning.mdx';
 import InlineField from 'src/components/InlineField.astro';
+import ManagedDomainsDescription from 'src/content/docs/lifecycle/authenticate-users/identity-providers/_managed-domains-description.mdx';
 import Samlv2IntegrationDetailsFields from 'src/content/docs/lifecycle/authenticate-users/identity-providers/_samlv2-integration-details-fields.mdx';
 import IdpManagedDomainsTroubleshooting from 'src/content/docs/lifecycle/authenticate-users/identity-providers/_idp-managed-domains-troubleshooting.mdx';
 import SamlSpLimitations from 'src/content/docs/_shared/_saml-sp-limitations.mdx';
@@ -158,11 +159,7 @@ This will take you to the `Add SAML v2` screen. Here you will need to fill out t
 
 <APIBlock>
   <APIField name="Managed domains" optional>
-    You may optionally scope this identity provider to one or more managed domains. For example, if you were to use a SAML v2 identity provider for your employees, you may add your company domain `piedpiper.com` to this field.
-
-    Adding one or more managed domains for this configuration will cause this provider not to be displayed as a button on your login page. Instead of a button the login form will first ask the user for their email address. If the user's email address matches one of the configured domains the user will then be redirected to this login provider to complete authentication. If the user's email address does not match one of the configured domains, the user will be prompted for a password and they will be authenticated using FusionAuth.
-
-    These configured domains will be used by the [Lookup API](/docs/apis/identity-providers/#lookup-an-identity-provider).
+    <ManagedDomainsDescription type="SAML v2"/>
   </APIField>
 </APIBlock>
 


### PR DESCRIPTION
Only applicable when adding in the admin UI.

Also abstracted out some repeated text for easier maintenance.

Checked [the API doc](https://fusionauth.io/docs/apis/identity-providers/openid-connect) and the API takes them as an array of strings, so no changes needed there.

