### PR TITLE
Added in missing claims to api doc and examples for external JWT Identity Provider

### DIFF
--- a/astro/src/content/docs/apis/identity-providers/_external-jwt-request-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_external-jwt-request-body.mdx
@@ -34,14 +34,6 @@ import IdentityProviderLinkingStrategyRequestParameter from 'src/content/docs/ap
   <APIField name="identityProvider.enabled" type="Boolean" optional defaults="false">
     Determines if this provider is enabled. If it is false then it will be disabled globally.
   </APIField>
-  <APIField name="identityProvider.oauth2.emailClaim" type="String" optional defaults="email">
-    The name of the claim that contains the user's email address. This will only be used when the <InlineField>identityProvider.linkingStrategy</InlineField> is equal to `LinkByEmail` or `LinkByEmailForExistingUser`.
-  </APIField>
-  <APIField name="identityProvider.oauth2.emailVerifiedClaim" type="String" optional defaults="email_verified" since="1.48.0">
-    The name of the claim that identities if the user's email address has been verified.
-
-    When the <InlineField>identityProvider.linkingStrategy</InlineField> is equal to `LinkByEmail` or `LinkByEmailForExistingUser` and this claim is present and the value is `false` a link will not be established and an error will be returned indicating a link cannot be established using an unverified email address.
-  </APIField>
   <APIField name="identityProvider.headerKeyParameter" type="String" required>
     The name header claim that identifies the public key used to verify the signature. In most cases this be `kid` or `x5t`.
   </APIField>
@@ -56,7 +48,7 @@ import IdentityProviderLinkingStrategyRequestParameter from 'src/content/docs/ap
   <APIField name="identityProvider.lambdaConfiguration.reconcileId" type="UUID" optional since="1.17.0">
     The unique Id of the lambda to used during the user reconcile process to map custom claims from the external identity provider to the FusionAuth user. This may be used in addition to, or in place of the claim mappings.
 
-    The specified Lambda Id must be of type `ExternalJWTReconcile`
+    The specified Lambda Id must be of type `ExternalJWTReconcile`.
   </APIField>
 
   <IdentityProviderLinkingStrategyRequestParameter idp_display_name={props.idp_display_name}
@@ -71,6 +63,14 @@ import IdentityProviderLinkingStrategyRequestParameter from 'src/content/docs/ap
     The authorization endpoint for this Identity Provider. This value is not utilized by FusionAuth is only provided to be returned by the
     Lookup Identity Provider API response. During integration you may then utilize this value to perform the browser redirect to the OAuth2
     authorize endpoint.
+  </APIField>
+  <APIField name="identityProvider.oauth2.emailClaim" type="String" optional defaults="email">
+    The name of the claim that contains the user's email address. This will only be used when the <InlineField>identityProvider.linkingStrategy</InlineField> is equal to `LinkByEmail` or `LinkByEmailForExistingUser`.
+  </APIField>
+  <APIField name="identityProvider.oauth2.emailVerifiedClaim" type="String" optional defaults="email_verified" since="1.48.0">
+    The name of the claim that identities if the user's email address has been verified.
+
+    When the <InlineField>identityProvider.linkingStrategy</InlineField> is equal to `LinkByEmail` or `LinkByEmailForExistingUser` and this claim is present and the value is `false` a link will not be established and an error will be returned indicating a link cannot be established using an unverified email address.
   </APIField>
   <APIField name="identityProvider.oauth2.token_endpoint" type="String" optional>
     The token endpoint for this Identity Provider. This value is not utilized by FusionAuth is only provided to be returned by the
@@ -89,7 +89,7 @@ import IdentityProviderLinkingStrategyRequestParameter from 'src/content/docs/ap
     This field must be set to `ExternalJWT`.
   </APIField>
   <APIField name="identityProvider.uniqueIdentityClaim" type="String" optional deprecated>
-    The name of the claim that represents the unique identify of the User. This will generally be `email` or the name of the claim that provides the email address.
+    The name of the claim that represents the unique identity of the User. This will generally be `email` or the name of the claim that provides the email address.
 
     This parameter has been deprecated, prefer the use of <InlineField>uniqueIdClaim</InlineField>.
   </APIField>

--- a/astro/src/content/docs/apis/identity-providers/_external-jwt-response-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_external-jwt-response-body.mdx
@@ -69,10 +69,26 @@ import InlineField from 'src/components/InlineField.astro';
     Lookup Identity Provider API response. During integration you may then utilize this value to perform the browser redirect to the OAuth2
     authorize endpoint.
   </APIField>
+  <APIField name="identityProvider.oauth2.emailClaim" type="String">
+    The name of the claim that contains the user's email address. This will only be used when the <InlineField>identityProvider.linkingStrategy</InlineField> is equal to `LinkByEmail` or `LinkByEmailForExistingUser`.
+  </APIField>
+  <APIField name="identityProvider.oauth2.emailVerifiedClaim" type="String">
+    The name of the claim that identities if the user's email address has been verified.
+
+    When the <InlineField>identityProvider.linkingStrategy</InlineField> is equal to `LinkByEmail` or `LinkByEmailForExistingUser` and this claim is present and the value is `false` a link will not be established and an error will be returned indicating a link cannot be established using an unverified email address.
+  </APIField>
   <APIField name="identityProvider.oauth2.token_endpoint" type="String">
     The token endpoint for this Identity Provider. This value is not utilized by FusionAuth is only provided to be returned by the
     Lookup Identity Provider API response. During integration you may then utilize this value to complete the OAuth2 grant workflow.
   </APIField>
+  <APIField name="identityProvider.oauth2.uniqueIdClaim" type="String">
+    The name of the claim that contains the user's unique user Id.
+  </APIField>
+  <APIField name="identityProvider.oauth2.usernameClaim" type="String">
+    The name of the claim that contains the user's username. This will only be used when the <InlineField>identityProvider.linkingStrategy</InlineField> is equal to `LinkByUsername` or `LinkByUsernameForExistingUser`.
+  </APIField>
+
+  <IdentityProviderTenantConfiguration />
 
   <IdentityProviderTenantConfiguration />
 
@@ -80,7 +96,7 @@ import InlineField from 'src/components/InlineField.astro';
     The type of this provider, this field will always be set to `ExternalJWT`.
   </APIField>
   <APIField name="identityProvider.uniqueIdentityClaim" type="String">
-    The name of the claim that represents the unique identify of the User. This will generally be `email` or the name of the claim that provides
+    The name of the claim that represents the unique identity of the User. This will generally be `email` or the name of the claim that provides
     the email address.
   </APIField>
 </APIBlock>

--- a/astro/src/content/json/identity-providers/external-jwt-request.json
+++ b/astro/src/content/json/identity-providers/external-jwt-request.json
@@ -15,7 +15,11 @@
     "name": "Acme Corp. ADFS",
     "oauth2": {
       "authorization_endpoint": "https://acme.com/adfs/oauth2/authorize?client_id=cf3b00da-9551-460a-ad18-33232e6cbff0&response_type=code&redirect_uri=https://acme.com/oauth2/redirect",
-      "token_endpoint": "https://acme.com/adfs/oauth2/token"
+      "emailClaim": "email",
+      "emailVerifiedClaim": "email_verified",
+      "token_endpoint": "https://acme.com/adfs/oauth2/token",
+      "uniqueIdClaim": "sub",
+      "usernameClaim": "preferred_username"
     },
     "tenantConfiguration": {
       "e872a880-b14f-6d62-c312-cb40f22af465": {

--- a/astro/src/content/json/identity-providers/external-jwt-response.json
+++ b/astro/src/content/json/identity-providers/external-jwt-response.json
@@ -17,7 +17,11 @@
     "name": "Acme Corp. ADFS",
     "oauth2": {
       "authorization_endpoint": "https://acme.com/adfs/oauth2/authorize?client_id=cf3b00da-9551-460a-ad18-33232e6cbff0&response_type=code&redirect_uri=https://acme.com/oauth2/redirect",
-      "token_endpoint": "https://acme.com/adfs/oauth2/token"
+      "emailClaim": "email",
+      "emailVerifiedClaim": "email_verified",
+      "token_endpoint": "https://acme.com/adfs/oauth2/token",
+      "uniqueIdClaim": "sub",
+      "usernameClaim": "preferred_username"
     },
     "type": "ExternalJWT",
     "tenantConfiguration": {


### PR DESCRIPTION
This is a fix for https://github.com/FusionAuth/fusionauth-issues/issues/2070

There were some misordered api doc in the request and missing response parameters.

Was unsure about whether the `oauth2.clientAuthenticationMethod` should be documented. 