### PR TITLE
Added a release note for a fix brought in by a prime update.

### DIFF
--- a/astro/src/content/docs/release-notes/index.mdx
+++ b/astro/src/content/docs/release-notes/index.mdx
@@ -73,6 +73,11 @@ Looking for release notes older than 1.44.0? Look in the [release notes archive]
 * <Issue issue="2737">
   The confirmation page shown when users are completing verification and other workflows shows a FreeMarker error when some cookies are unavailable. This could happen when cookies are deleted by a user, removed by a proxy, or when running in an iframe.
   </Issue>
+
+* <Issue issue="2767">
+  When an OAuth workflow ends in redirecting with an error to a `redirect_uri` that contains query parameters, the resulting URL is being built incorrectly.
+  </Issue>
+
 * <Issue issue="2793" thanks="runely">
   The SCIM ResourceTypes endpoint is returning resource type URLs with incorrect paths. The endpoint is returning a path prefix of `/api/scim/v2/` when it should be `/api/scim/resource/v2/`.
   </Issue>


### PR DESCRIPTION
This adds https://github.com/FusionAuth/fusionauth-issues/issues/2767 to the 1.55.1 release notes. The fix was delivered as a prime update and version bump in FusionAuth, and slipped through the release notes process.