### PR TITLE
add note about identity provider modification

### DIFF
--- a/astro/src/content/docs/apis/applications.mdx
+++ b/astro/src/content/docs/apis/applications.mdx
@@ -27,7 +27,7 @@ import XFusionauthTenantIdHeaderScopedOperation from 'src/content/docs/apis/_x-f
 
 ## Overview
 
-This page contains the APIs that are used to manage Applications as well as the Roles of an Application. Here are the APIs:
+This page contains the APIs that are used to manage Applications as well as the Roles of an Application. 
 
 ## Create an Application
 
@@ -149,6 +149,13 @@ To create, update or remove an OAuth scope from the Application, you need to cal
 * [Delete an OAuth Scope](/docs/apis/scopes#delete-an-oauth-scope)
 
 </Aside>
+
+<Aside type="note">
+If you want to enable, disable or otherwise configure an Identity Provider, such as an OIDC or SAML v2 Identity Provider, for an Application, use the specific [Identity Provider's API update method](/docs/apis/identity-providers/).
+
+You'll want to modify the `identityProvider.applicationConfiguration` object and its fields.
+</Aside>
+
 
 ### Request
 


### PR DESCRIPTION
Documenting something that confused a user.

I'm not thrilled with the double `Note` blue, but didn't think it made sense to consolidate the `Asides`.

Internal: #77697