### PR TITLE
updated to reflect that FQDN should include prefix for OIDC compliance.

### DIFF
--- a/astro/src/content/docs/apis/_tenant-request-body.mdx
+++ b/astro/src/content/docs/apis/_tenant-request-body.mdx
@@ -406,7 +406,7 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
   </APIField>
 
   <APIField name="tenant.issuer" type="String" optional since="1.8.0" defaults="acme.com">
-    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://fusionauth.io`.
+    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://example.com`.
 
     Prior to version `1.30.0` this value was required.
   </APIField>

--- a/astro/src/content/docs/apis/_tenant-request-body.mdx
+++ b/astro/src/content/docs/apis/_tenant-request-body.mdx
@@ -405,8 +405,8 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
     Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
   </APIField>
 
-  <APIField name="tenant.issuer" type="String" optional since="1.8.0">
-    The named issuer used to sign tokens, this is generally your public fully qualified domain.
+  <APIField name="tenant.issuer" type="String" optional since="1.8.0" defaults="acme.com">
+    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://fusionauth.io`.
 
     Prior to version `1.30.0` this value was required.
   </APIField>

--- a/astro/src/content/docs/apis/_tenant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_tenant-response-body-base.mdx
@@ -324,7 +324,7 @@ import JSON from 'src/components/JSON.astro';
   </APIField>
 
   <APIField name={props.base_field_name + '.issuer'} type="String" since="1.8.0">
-    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://fusionauth.io`.
+    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://example.com`.
   </APIField>
 
   <APIField name={props.base_field_name + '.jwtConfiguration.accessTokenKeyId'} type="UUID" since="1.8.0">

--- a/astro/src/content/docs/apis/_tenant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_tenant-response-body-base.mdx
@@ -324,7 +324,7 @@ import JSON from 'src/components/JSON.astro';
   </APIField>
 
   <APIField name={props.base_field_name + '.issuer'} type="String" since="1.8.0">
-    The named issuer used to sign tokens, this is generally your public fully qualified domain.
+    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://fusionauth.io`.
   </APIField>
 
   <APIField name={props.base_field_name + '.jwtConfiguration.accessTokenKeyId'} type="UUID" since="1.8.0">

--- a/astro/src/content/docs/get-started/core-concepts/tenants.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/tenants.mdx
@@ -81,7 +81,7 @@ A majority of your FusionAuth configuration is managed at the Tenant-level.  Som
 
 <APIBlock>
   <APIField name="Issuer" required>
-    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://fusionauth.io`.
+    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://example.com`.
   </APIField>
   <APIField name="Login Theme" optional>
     The Theme associated with this Tenant; determines which templates to render for interactive work-flows.

--- a/astro/src/content/docs/get-started/core-concepts/tenants.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/tenants.mdx
@@ -67,7 +67,7 @@ Using the icons on this screen, you can:
 
 ### Create a Tenant
 
-To create a new tenant, navigate to <strong>Tenants</strong>.
+To create a new tenant, navigate to <Breadcrumb>Tenants</Breadcrumb>.
 
 <img src="/img/docs/get-started/core-concepts/create-tenant.png" alt="Create a Tenant" width="1200" role="shadowed" />
 

--- a/astro/src/content/docs/get-started/core-concepts/tenants.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/tenants.mdx
@@ -81,7 +81,7 @@ A majority of your FusionAuth configuration is managed at the Tenant-level.  Som
 
 <APIBlock>
   <APIField name="Issuer" required>
-    The named issuer used to sign tokens.  Typically a fully-qualified domain name.
+    The named issuer used to sign tokens. This is generally your public fully qualified domain with the `https://` protocol prefix. For example, `https://fusionauth.io`.
   </APIField>
   <APIField name="Login Theme" optional>
     The Theme associated with this Tenant; determines which templates to render for interactive work-flows.

--- a/astro/src/content/docs/get-started/core-concepts/tenants.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/tenants.mdx
@@ -10,6 +10,7 @@ import APIField from 'src/components/api/APIField.astro';
 import AvailableSince from 'src/components/api/AvailableSince.astro';
 import DefaultSMTPConfigurationProperties from 'src/content/docs/_shared/default-smtp-configuration-properties.mdx';
 import PremiumPlanBlurb from 'src/content/docs/_shared/_premium-plan-blurb.astro';
+import Breadcrumb from 'src/components/Breadcrumb.astro';
 import InlineField from 'src/components/InlineField.astro';
 import InlineUIElement from 'src/components/InlineUIElement.astro';
 import ScrollRef from 'src/components/ScrollRef.astro';
@@ -43,7 +44,7 @@ Here's a brief video covering some aspects of tenants:
 
 Below is a visual reminder of the relationships between FusionAuth's primary core concepts.
 
-<img src="/img/docs/get-started/core-concepts/core-concepts-relationships-tenants.png" alt="Diagram showing Tenants used within FusionAuth" />
+![Diagram showing Tenants used within FusionAuth.](/img/docs/get-started/core-concepts/core-concepts-relationships-tenants.png)
 
 ## Admin UI
 
@@ -51,7 +52,7 @@ This page describes the admin UI for creating and configuring a Tenant.
 
 ### List of Tenants
 
-To display a list of tenants, navigate to <strong>Tenants</strong>.
+To display a list of tenants, navigate to <Breadcrumb>Tenants</Breadcrumb>.
 
 <img src="/img/docs/get-started/core-concepts/tenant-configuration-list.png" alt="List of Tenants" width="1200" role="bottom-cropped" />
 
@@ -69,7 +70,7 @@ Using the icons on this screen, you can:
 
 To create a new tenant, navigate to <Breadcrumb>Tenants</Breadcrumb>.
 
-<img src="/img/docs/get-started/core-concepts/create-tenant.png" alt="Create a Tenant" width="1200" role="shadowed" />
+![Create a Tenant.](/img/docs/get-started/core-concepts/create-tenant.png)
 
 ### Tenant Configuration
 A majority of your FusionAuth configuration is managed at the Tenant-level.  Some of these configuration options act as defaults and can be overridden by the Application.


### PR DESCRIPTION
https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata says

the issuer is 'REQUIRED. URL using the https scheme with no query or fragment components that the OP asserts as its Issuer Identifier. If Issuer discovery is supported (see Section 2), this value MUST be identical to the issuer value returned by WebFinger. This also MUST be identical to the iss Claim value in ID Tokens issued from this Issuer. '

We should recommend that the user use the full URL, not just the FQDN (which does not include `https://`)

I also updated the image, but decided to submit that as #3488 .