### PR TITLE
added debug enabled field

### DIFF
--- a/astro/src/content/docs/get-started/core-concepts/tenants.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/tenants.mdx
@@ -68,7 +68,7 @@ Using the icons on this screen, you can:
 
 ### Create a Tenant
 
-To create a new tenant, navigate to <strong>Tenants</strong>.
+To create a new tenant, navigate to <Breadcrumb>Tenants</Breadcrumb>.
 
 ![Create a Tenant.](/img/docs/get-started/core-concepts/create-tenant.png)
 

--- a/astro/src/content/docs/get-started/core-concepts/tenants.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/tenants.mdx
@@ -10,6 +10,7 @@ import APIField from 'src/components/api/APIField.astro';
 import AvailableSince from 'src/components/api/AvailableSince.astro';
 import DefaultSMTPConfigurationProperties from 'src/content/docs/_shared/default-smtp-configuration-properties.mdx';
 import PremiumPlanBlurb from 'src/content/docs/_shared/_premium-plan-blurb.astro';
+import Breadcrumb from 'src/components/Breadcrumb.astro';
 import InlineField from 'src/components/InlineField.astro';
 import InlineUIElement from 'src/components/InlineUIElement.astro';
 import ScrollRef from 'src/components/ScrollRef.astro';
@@ -43,7 +44,7 @@ Here's a brief video covering some aspects of tenants:
 
 Below is a visual reminder of the relationships between FusionAuth's primary core concepts.
 
-<img src="/img/docs/get-started/core-concepts/core-concepts-relationships-tenants.png" alt="Diagram showing Tenants used within FusionAuth" />
+![Diagram showing Tenants used within FusionAuth.](/img/docs/get-started/core-concepts/core-concepts-relationships-tenants.png)
 
 ## Admin UI
 
@@ -51,7 +52,7 @@ This page describes the admin UI for creating and configuring a Tenant.
 
 ### List of Tenants
 
-To display a list of tenants, navigate to <strong>Tenants</strong>.
+To display a list of tenants, navigate to <Breadcrumb>Tenants</Breadcrumb>.
 
 <img src="/img/docs/get-started/core-concepts/tenant-configuration-list.png" alt="List of Tenants" width="1200" role="bottom-cropped" />
 
@@ -69,7 +70,7 @@ Using the icons on this screen, you can:
 
 To create a new tenant, navigate to <strong>Tenants</strong>.
 
-<img src="/img/docs/get-started/core-concepts/create-tenant.png" alt="Create a Tenant" width="1200" role="shadowed" />
+![Create a Tenant.](/img/docs/get-started/core-concepts/create-tenant.png)
 
 ### Tenant Configuration
 A majority of your FusionAuth configuration is managed at the Tenant-level.  Some of these configuration options act as defaults and can be overridden by the Application.

--- a/astro/src/content/docs/get-started/core-concepts/tenants.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/tenants.mdx
@@ -170,6 +170,9 @@ Once you have configured your email settings, you may test your configuration wi
   <APIField name="Additional Headers" optional since="1.32.0">
     One or more line separated SMTP headers to be added to each outgoing email. The header name and value should be separated by an equals sign. ( i.e. `X-SES-CONFIGURATION-SET=Value`).
   </APIField>
+  <APIField name="Debug enabled" optional since="1.37.0">
+    When enabled SMTP and JavaMail debug information will be output to the Event Log.
+  </APIField>
 </APIBlock>
 
 <img src="/img/docs/get-started/core-concepts/tenant-configuration-email-verification-settings.png" alt="Tenant Configuration - Email verification settings" width="1200" role="shadowed" />


### PR DESCRIPTION
We don't have the SMTP 'debug' field documented in the tenants core concepts page.

Note that the image isn't updated with this change, but I'll submit another PR for that, #3488 .