### PR TITLE
added a missing is_tenant param to the req body include

### DIFF
--- a/astro/src/content/docs/apis/_application-request-body.mdx
+++ b/astro/src/content/docs/apis/_application-request-body.mdx
@@ -43,7 +43,7 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
 
   </APIField>
 
-  <TenantApplicationEmailConfiguration base_field_name={"application"} show_feature_blurb="true" />
+  <TenantApplicationEmailConfiguration base_field_name={"application"} show_feature_blurb="true" is_tenant={false} />
 
   <APIField name="application.externalIdentifierConfiguration.twoFactorTrustIdTimeToLiveInSeconds" type="Integer" optional since="1.37.0">
     The time in seconds until an issued Two Factor trust Id is no longer valid and the User will be required to complete Two Factor authentication


### PR DESCRIPTION
The `Create an Application` request body include wasn't getting the is_tenant value passed in, which was causing tenant request body fields to be incorrectly shown on the application API page.