### PR TITLE
fix(api): add 403 forbidden message to the "Verify a User’s Email" section

### DIFF
--- a/astro/src/content/docs/apis/_standard-put-response-codes.astro
+++ b/astro/src/content/docs/apis/_standard-put-response-codes.astro
@@ -39,9 +39,9 @@ const {success_code, success_message, forbidden_message, never_missing, never_se
         You did not supply a valid Authorization header. The header was omitted or your API key was not valid. The response will be empty. See <a href="/docs/apis/authentication">Authentication</a>.
       </td>
     </tr>
-    {forbidden_message && <tr>
+    {Astro.slots.has('forbidden-message') && <tr>
       <td>403</td>
-      <td>{ forbidden_message }</td>
+      <td><slot name="forbidden-message" /></td>
     </tr>}
     {!never_missing && <tr>
       <td>404</td>

--- a/astro/src/content/docs/apis/users.mdx
+++ b/astro/src/content/docs/apis/users.mdx
@@ -33,6 +33,7 @@ import XFusionauthTenantIdHeaderAmbiguousOperation from 'src/content/docs/apis/_
 import XFusionauthTenantIdHeaderCreateOperation from 'src/content/docs/apis/_x-fusionauth-tenant-id-header-create-operation.mdx';
 import XFusionauthTenantIdHeaderScopedOperation from 'src/content/docs/apis/_x-fusionauth-tenant-id-header-scoped-operation.mdx';
 import ChangePassResponseCodes from './_change-pass-response-codes.astro';
+import Breadcrumb from 'src/components/Breadcrumb.astro';
 
 ## Overview
 
@@ -677,8 +678,9 @@ This API can be used to mark a user as verified without requiring the user to ac
 
 The response does not contain a body. It only contains one of the status codes below.
 
-<StandardPutResponseCodes />
-
+<StandardPutResponseCodes>
+    <Fragment slot="forbidden-message">The verify email functionality has been disabled. See <Breadcrumb>Tenants -> Email -> Email verification settings</Breadcrumb> in the FusionAuth admin UI.</Fragment>
+</StandardPutResponseCodes>
 
 ## Resend Verification Email
 


### PR DESCRIPTION
This pull request includes the following changes:
- Adds documentation for the `403 Forbidden` response code to the "Verify a User’s Email" API endpoint.
- Refactors the implementation of the forbidden message by moving it from a parameter to a slot in the `StandardPutResponseCodes` component.