### PR TITLE
docs: Fix typo in Express quickstart

### DIFF
--- a/astro/src/content/quickstarts/quickstart-javascript-express-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-javascript-express-web.mdx
@@ -233,7 +233,7 @@ Now that your application is complete you can run it with the below command.
 npm run dev
 ```
 
-You can now open up an incognito window and visit the Rails app at http://localhost:8080/ . Log in with the user account mentioned above, `richard@example.com`.
+You can now open up an incognito window and visit the Express app at http://localhost:8080/ . Log in with the user account mentioned above, `richard@example.com`.
 
 <QuickstartTshirtCTA/>
 


### PR DESCRIPTION
### Problem

The [Express quickstart](https://fusionauth.io/docs/quickstarts/quickstart-javascript-express-web) references Rails, not Express.

### Solution

Fix the typo.