### PR TITLE
fix(fusionauth-swift-sdk): update swift sdk references

### DIFF
--- a/astro/src/content/quickstarts/quickstart-swift-ios-native.mdx
+++ b/astro/src/content/quickstarts/quickstart-swift-ios-native.mdx
@@ -25,7 +25,7 @@ import {RemoteCode} from '@fusionauth/astro-components';
 import RemoteContent from 'src/components/RemoteContent.astro';
 import QuickstartTshirtCTA from '/src/components/quickstarts/QuickstartTshirtCTA.astro'
 
-This quickstart is built on top of [FusionAuth iOS SDK](/docs/sdks/ios-sdk) demonstrating the different functionalities of the SDK available.
+This quickstart is built on top of [FusionAuth iOS SDK](/docs/sdks/swift-sdk) demonstrating the different functionalities of the SDK available.
 
 <Intro fulltext="an iOS app with Swift" repositoryUrl="https://github.com/FusionAuth/fusionauth-quickstart-swift-ios-native"/>
 
@@ -68,7 +68,7 @@ Now you have a standard "Hello World" app. You can run it in the simulator by cl
 
 ## Authentication
 
-We'll use the [FusionAuth iOS SDK](/docs/sdks/ios-sdk), which simplifies integrating with FusionAuth and creating a secure web application.
+We'll use the [FusionAuth iOS SDK](/docs/sdks/swift-sdk), which simplifies integrating with FusionAuth and creating a secure web application.
 
 Add the [FusionAuth Swift SDK as a dependency](https://github.com/FusionAuth/fusionauth-swift-sdk) to your project by [Add Package Dependencies..](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) with the latest version. Select the Quickstart Application as a target and click `Add Package`.
 


### PR DESCRIPTION
This solves broken links discovered in https://github.com/FusionAuth/fusionauth-site/actions/runs/13660620363/job/38190656246