### PR TITLE
fix pagefind ignore tag

### DIFF
--- a/astro/src/components/search/IndexableBody.astro
+++ b/astro/src/components/search/IndexableBody.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  excludeFromSearchIndex: boolean,
+}
+
+const { excludeFromSearchIndex } = Astro.props;
+---
+{ excludeFromSearchIndex &&
+<body data-pagefind-ignore class="antialiased bg-articles bg-right-top bg-no-repeat bg-white min-h-full text-slate-700 dark:bg-articles-dark dark:bg-slate-900 dark:text-slate-200">
+  <slot></slot>
+</body>
+}
+{ !excludeFromSearchIndex &&
+<body class="antialiased bg-articles bg-right-top bg-no-repeat bg-white min-h-full text-slate-700 dark:bg-articles-dark dark:bg-slate-900 dark:text-slate-200">
+  <slot></slot>
+</body>
+}
+

--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -12,6 +12,7 @@ import Article from './Article.astro';
 import ArticleNav from '../components/nav/ArticleNav.astro';
 import Icon from '../components/icon/Icon.astro';
 import { specialCaps } from '../tools/string';
+import IndexableBody from '../components/search/IndexableBody.astro';
 
 interface Props {
   author?: string;
@@ -121,9 +122,7 @@ const tocStyles = [
 <!DOCTYPE html>
 <html class="antialiased min-h-full" lang="en">
 <Head title={title} description={description} canonicalUrl={frontmatter.canonicalUrl} {openGraphImage} {searchFilters} />
-<body
-  class="antialiased bg-articles bg-right-top bg-no-repeat bg-white min-h-full text-slate-700 dark:bg-articles-dark dark:bg-slate-900 dark:text-slate-200"
-  data-pagefind-ignore={excludeFromSearchIndex ? 'all' : false}>
+<IndexableBody {excludeFromSearchIndex}>
   <slot name="nav"/>
   <main class:list={mainStyles}>
   <!-- Left sidebar -->
@@ -171,13 +170,13 @@ const tocStyles = [
         <div class="flex-grow">
           {breadcrumbs.length > 0 && <div class="flex flex-row not-prose hidden lg:block items-center pb-6">
             { breadcrumbs.map((crumb, i) => <>
-            <a href={crumb.href} class="font-medium text-slate-500 mb-4 mt-0 text-sm hover:text-indigo-600 dark:text-slate-400 dark:hover:text-indigo-400 hover:underline capitalize">{ specialCaps(crumb.title) }</a>
-            { i !== breadcrumbs.length - 1 && <span class="mx-2 text-slate-500">/</span> }
-          </>) }
+              <a href={crumb.href} class="font-medium text-slate-500 mb-4 mt-0 text-sm hover:text-indigo-600 dark:text-slate-400 dark:hover:text-indigo-400 hover:underline capitalize">{ specialCaps(crumb.title) }</a>
+              { i !== breadcrumbs.length - 1 && <span class="mx-2 text-slate-500">/</span> }
+            </>) }
           </div> }
 
           {breadcrumbs.length === 0 && section && <p class="font-semibold mb-4 mt-0 text-indigo-700 text-lg dark:text-indigo-500">{ specialCaps(section) }</p>}
-          <h1 data-pagefind-meta="title" data-pagefind-body class:list={["text-3xl", image ? "mt-16" : "", author ? "mb-0" : ""]}>{title}</h1>
+          <h1 data-pagefind-meta="title" class:list={["text-3xl", image ? "mt-16" : "", author ? "mb-0" : ""]}>{title}</h1>
           {author &&
             <p class="m-0 text-sm">By {author} {date && <span>- {new Date(date).toDateString()}</span>}</p>
           }
@@ -189,8 +188,8 @@ const tocStyles = [
           <img src={darkIcon} alt={title} class="ml-8 mr-4 my-0 w-20 hidden dark:block" />
         }
       </div>
-      {/* helps encourage pagefind to actually index the markdown content */}
-      <section data-pagefind-body>
+      {/* Corrected: No inner data-pagefind-body */}
+      <section>
         <slot/>
       </section>
 
@@ -212,5 +211,5 @@ const tocStyles = [
     }
   </main>
   <Search/>
-</body>
+</IndexableBody>
 </html>


### PR DESCRIPTION
Looks like the latest update to pagefind doesn't respect the `data-pagefind-ignore="false"` attributes and just treats those as ignores, so articles and docs were getting excluded.

This fixes that by only putting that attribute there if we really want stuff to be excluded