### PR TITLE
fix connector diagram

### DIFF
--- a/astro/src/diagrams/docs/lifecycle/migrate-users/connectors/_connector-diagram.astro
+++ b/astro/src/diagrams/docs/lifecycle/migrate-users/connectors/_connector-diagram.astro
@@ -23,7 +23,7 @@ sequenceDiagram
   DB ->> DB : Verifies Credentials
   DB -->> Connector : Returns User Data
   Connector -->> FusionAuth : Returns Data
-  FusionAuth- ->> User : Redirect With Authorization Code
+  FusionAuth ->> User : Redirect With Authorization Code
   User ->> App : Request Redirect URI
   App ->> FusionAuth : Request Tokens
   FusionAuth -->> App : Return Tokens


### PR DESCRIPTION
### Problem
An extra hyphen caused mermaid to render a second FusionAuth column

### Solution
Remove the hyphen