### PR TITLE
updated grant doc because it was wrong

### DIFF
--- a/astro/src/content/docs/apis/entities/grants.mdx
+++ b/astro/src/content/docs/apis/entities/grants.mdx
@@ -75,7 +75,7 @@ This is an upsert operation. If the grant to this Entity for the specified User 
 
 This API does not return a JSON response body.
 
-<StandardPostResponseCodes success_message="The request was successful." success_code="200" />
+<StandardPostResponseCodes success_message="The request was successful." success_code="200" missing_message="The Entity to which access is being granted was not found. The response will contain a JSON body." />
 
 ## Retrieve Grants
 

--- a/astro/src/content/docs/apis/entities/grants.mdx
+++ b/astro/src/content/docs/apis/entities/grants.mdx
@@ -75,7 +75,7 @@ This is an upsert operation. If the grant to this Entity for the specified User 
 
 This API does not return a JSON response body.
 
-<StandardPostResponseCodes success_message="The request was successful." success_code="200" missing_message="The Entity to which access is being granted was not found. The response will contain a JSON body." />
+<StandardPostResponseCodes success_message="The request was successful." success_code="200" missing_message="The Entity to which access is being granted was not found." />
 
 ## Retrieve Grants
 


### PR DESCRIPTION
To test, attempt to do a grant using an entity id that does not exist:

```
 curl -vv \
         -H 'Authorization: 90d8fb62-6f13-47d4-8ef6-1c3e687883c6'  \
        -H 'content-type: application/json'  \
        -d '{"grant":{"recipientEntityId":"2147cb6b-82c0-470b-89de-f4759c1e6eaf"}}' \
https://sandbox.fusionauth.io/api/entity/e732d60c-1ea3-47ec-bc81-075f880f9a71/grant 
```

Both these uuids are made up, but the API key is not.