### PR TITLE
update generic connector page components

### DIFF
--- a/astro/src/content/docs/lifecycle/migrate-users/connectors/index.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/connectors/index.mdx
@@ -86,7 +86,7 @@ The user will be placed into the same tenant as the application they are authent
 
 If you are migrating a user, you must provide the following fields in the user object you return.
 
-* `user.username` or `user.email`
+* `user.username`, `user.email`, or `user.phoneNumber`
 * `user.id`: a FusionAuth compatible UUID
 
 If you are using the generic connector, you are building the `user` object, so ensure these fields are in the JSON. If you are using the LDAP connector, make sure you set these fields in the lambda.

--- a/astro/src/content/docs/lifecycle/migrate-users/connectors/index.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/connectors/index.mdx
@@ -35,7 +35,7 @@ The following Connectors are available:
 
 If you're looking for a Connector not listed here, review the open feature requests in [GitHub](https://github.com/FusionAuth/fusionauth-issues/issues) and either vote or comment on an existing feature, or open a new feature request if you do not find an existing issue.
 
-Find Connectors in the administrative user interface by navigating to <strong>Settings -> Connectors</strong> or use the [Connectors](/docs/apis/connectors/) APIs.
+Find Connectors in the administrative user interface by navigating to **Settings -> Connectors** or use the [Connectors](/docs/apis/connectors/) APIs.
 
 <img src="/img/docs/lifecycle/migrate-users/connectors/connectors-screen.png" alt="Choose what type of Connector to create." width="1200" role="shadowed" />
 

--- a/astro/src/content/docs/lifecycle/migrate-users/connectors/index.mdx
+++ b/astro/src/content/docs/lifecycle/migrate-users/connectors/index.mdx
@@ -61,12 +61,12 @@ The user will be placed into the same tenant as the application they are authent
 
 If you are authenticating a user, you must provide the following fields in the user object you return.
 
-* `user.username` or `user.email`
+* `user.username`, `user.email`, or `user.phoneNumber`
 * `user.id`: a FusionAuth compatible UUID
 
 If you are using the generic connector, you are building the `user` object, so ensure these fields are in the JSON. If you are using the LDAP connector, make sure you set these fields in the configured LDAP Reconcile lambda.
 
-In addition, ensure that the same `user.id` is returned each time a user is retrieved. If you have an LDAP attribute in the form of a UUID or a value that can be translated to a UUID, using that attribute or its translation is recommended. If you have to generate a UUID, ensure that you are able to return the same value each time the user authenticates. Doing so ensures that FusionAuth knows which user is being referenced, even if the username or email address changes.
+In addition, ensure that the same `user.id` is returned each time a user is retrieved. If you have an LDAP attribute in the form of a UUID or a value that can be translated to a UUID, using that attribute or its translation is recommended. If you have to generate a UUID, ensure that you are able to return the same value each time the user authenticates. Doing so ensures that FusionAuth knows which user is being referenced, even if the username, email address, or phone number changes.
 
 ### Suggested Fields
 

--- a/astro/src/content/json/login/request.json
+++ b/astro/src/content/json/login/request.json
@@ -1,7 +1,11 @@
 {
-  "loginId": "example@fusionauth.io",
-  "password": "password",
   "applicationId": "10000000-0000-0002-0000-000000000001",
+  "eventInfo" : {
+    "ipAddress" : "127.0.0.1"
+  },
+  "loginId": "example@fusionauth.io",
+  "loginIdTypes": ["email"],
+  "newDevice" : false,
   "noJWT": false,
-  "ipAddress": "192.168.1.42"
+  "password": "password"
 }


### PR DESCRIPTION
Update Generic Connector page components with new `loginIdTypes` and `user.phoneNumber`.
Noticed the `login/request.json` was out of date and updated. 

Also seeing our `/api/login` page never got updated 2.5 years ago when fields were deprecated. Maybe we address that with issue1 doc updates?