### PR TITLE
refactor(SDK): move up quickstart to getting started

### DIFF
--- a/astro/src/content/docs/sdks/android-sdk.mdx
+++ b/astro/src/content/docs/sdks/android-sdk.mdx
@@ -14,8 +14,17 @@ import RemoteContent from 'src/components/RemoteContent.astro';
 
 ## Getting Started
 
+If you are new to Android development, you may want to start with the Quickstart guide. If you are already familiar with Android development, skip to the Configuration section.
+
+### Quickstart
+
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-android-sdk/main/README.md"
-    tags="forDocSiteGettingStarted" />
+               tags="forDocSiteQuickstart" />
+
+### Configuration
+
+<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-android-sdk/main/README.md"
+               tags="forDocSiteGettingStarted" />
 
 ## Usage
 
@@ -26,11 +35,6 @@ import RemoteContent from 'src/components/RemoteContent.astro';
 
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-android-sdk/main/README.md"
     tags="forDocSiteExampleApp" />
-
-## Quickstart
-
-<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-android-sdk/main/README.md"
-    tags="forDocSiteQuickstart" />
 
 ## Documentation
 

--- a/astro/src/content/docs/sdks/swift-sdk.mdx
+++ b/astro/src/content/docs/sdks/swift-sdk.mdx
@@ -14,6 +14,15 @@ import RemoteContent from 'src/components/RemoteContent.astro';
 
 ## Getting Started
 
+If you are new to iOS development, you may want to start with the Quickstart guide. If you are already familiar with iOS development, skip to the Configuration section.
+
+### Quickstart
+
+<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-swift-sdk/main/README.md"
+               tags="forDocSiteQuickstart" />
+
+### Configuration
+
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-swift-sdk/main/README.md"
     tags="forDocSiteGettingStarted" />
 
@@ -26,11 +35,6 @@ import RemoteContent from 'src/components/RemoteContent.astro';
 
 <RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-swift-sdk/main/README.md"
     tags="forDocSiteExampleApp" />
-
-## Quickstart
-
-<RemoteContent url="https://raw.githubusercontent.com/FusionAuth/fusionauth-swift-sdk/main/README.md"
-    tags="forDocSiteQuickstart" />
 
 ## Documentation
 


### PR DESCRIPTION
- To early on direct the different knowledge-level of visitors, we move quickstart to the top and add a quick introduction when to use quickstart.
- To algin all SDKs with the same introduction section, the following PR needs to be merged too https://github.com/FusionAuth/fusionauth-javascript-sdk/pull/179