### PR TITLE
parse inline markdown in event description

### DIFF
--- a/astro/src/content/docs/extend/events-and-webhooks/events/_event.astro
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/_event.astro
@@ -3,6 +3,7 @@ import Aside from 'src/components/Aside.astro';
 import EnterprisePlanBlurb from 'src/content/docs/_shared/_enterprise-plan-blurb.astro';
 import InlineField from 'src/components/InlineField.astro';
 import PremiumPlanBlurb from 'src/content/docs/_shared/_premium-plan-blurb.astro';
+import { parseInline } from 'marked';
 import semver from 'semver';
 
 const { description, plan, eventType, name, scope, transactional, version } = Astro.props;
@@ -23,9 +24,7 @@ const { description, plan, eventType, name, scope, transactional, version } = As
 }
 
 { description && 
-  <p>
-    {description}
-  </p>
+  <p set:html={parseInline(description)}/>
 }
 <slot name="description" />
 


### PR DESCRIPTION
### Problem

The https://fusionauth.io/docs/extend/events-and-webhooks/events/user-bulk-create page has link markdown in its description that is not being parsed as markdown.

### Solution

Add inline markdown parsing to the event description.