### PR TITLE
add blog title schema and enforce no period at the end of titles

### DIFF
--- a/astro/src/content/blog/like-avatar-can-keep.mdx
+++ b/astro/src/content/blog/like-avatar-can-keep.mdx
@@ -1,6 +1,6 @@
 ---
 publish_date: 2019-03-14 
-title: Like your avatar? You can keep it.
+title: Like your avatar? You can keep it
 description: FusionAuth can take advantage of your existing Gravatar account. No problem.
 authors: Daniel DeGroff
 image: /img/blogs/keep-avatar/keep-avatar.jpg

--- a/astro/src/content/config.js
+++ b/astro/src/content/config.js
@@ -63,6 +63,25 @@ const docsCollection = defineCollection({
   }),
 });
 
+const blogCollection = defineCollection({
+  schema: z.object({
+    title: z.string().refine(
+        title => !title.endsWith('.'),
+        { message: "Title cannot end with a period (.)" }
+    ),
+    description: z.string(),
+    image: z.string().optional(),
+    authors: z.string().optional(), // comma-separated string
+    categories: z.string().optional(), // comma-separated string
+    tags: z.string().optional(), // comma-separated string
+    publish_date: z.date(),
+    updated_date: z.date().optional(),
+    featured_tag: z.string().optional(),
+    featured_category: z.string().optional(),
+    blurb: z.string().optional(),
+  }),
+});
+
 const jsonCollection = defineCollection({
   type: 'data',
 })
@@ -73,4 +92,5 @@ export const collections = {
   'quickstarts': quickstartsCollection,
   'docs': docsCollection,
   'json': jsonCollection,
+  'blog': blogCollection,
 };


### PR DESCRIPTION
Example output that will trigger at dev time:

```
20:53:31 [ERROR] [UnhandledRejection] Astro detected an unhandled rejection. Here's the stack trace:
InvalidContentEntryDataError: blog → like-avatar-can-keep data does not match collection schema.
Title cannot end with a period (.)
    at getEntryDataAndImages (file:///Users/slyle/dev/inversoft/fusionauth/fusionauth-site/astro/node_modules/astro/dist/content/utils.js:151:26)
    at async parseData (file:///Users/slyle/dev/inversoft/fusionauth/fusionauth-site/astro/node_modules/astro/dist/content/content-layer.js:193:40)
    at async syncData (file:///Users/slyle/dev/inversoft/fusionauth/fusionauth-site/astro/node_modules/astro/dist/content/loaders/glob.js:94:28)
    at async FSWatcher.onChange (file:///Users/slyle/dev/inversoft/fusionauth/fusionauth-site/astro/node_modules/astro/dist/content/loaders/glob.js:234:9)
  Hint:
```
