### PR TITLE
missing excerpt defn from zod config, caused excerpts to show up

### DIFF
--- a/astro/src/content/config.js
+++ b/astro/src/content/config.js
@@ -87,6 +87,7 @@ const blogCollection = defineCollection({
     updated_date: z.date().optional(),
     featured_tag: z.string().optional(),
     featured_category: z.string().optional(),
+    excerpt_separator: z.string().optional(),
     blurb: z.string().optional(),
   }),
 });


### PR DESCRIPTION
Not sure how this happened, but we lost the `excerpt_separator` definition, which led to the blurbs not being correctly created. See attached screenshot of the blog front page. You can clearly see `{/* more */}` and should not be able to.

<img width="351" alt="Screenshot 2025-04-04 at 10 39 32 AM" src="https://github.com/user-attachments/assets/5a732de9-86a3-40cd-a5e2-50a6f3e19202" />

This fixes this issue.