### PR TITLE
roll back change which looks bad in list

### DIFF
--- a/astro/src/content/quickstarts/quickstart-javascript-nextjs-web.mdx
+++ b/astro/src/content/quickstarts/quickstart-javascript-nextjs-web.mdx
@@ -1,5 +1,5 @@
 ---
-title: FusionAuth Next.js Authentication | Quickstart Guide
+title: Next.js
 description: Set up authentication in a Next.js app using FusionAuth. Follow this quickstart guide to integrate secure login, user management, and authentication in your Next.js project.
 navcategory: getting-started
 prerequisites: npm, node


### PR DESCRIPTION
This looks ... not great in our list.

<img width="1002" alt="Screenshot 2025-04-15 at 9 43 54 AM" src="https://github.com/user-attachments/assets/fa8060c5-6bbb-4106-ad3e-45488111cf73" />

If we need to modify quickstart templates so they have a different title tag than the title shown in the list, we can do that, but if the text is shared, we want it to look good in the list.