### PR TITLE
fail if all keys for the redirect or indexPaths objects don't start with correct value

### DIFF
--- a/.github/workflows/publish-redirect-rules.yaml
+++ b/.github/workflows/publish-redirect-rules.yaml
@@ -32,7 +32,7 @@ jobs:
         run: cat src/redirects.json | jq empty
 
       - name: validate all redirects start with a `/`
-        run: exit `cat src/redirects.json| jq '.redirects|to_entries | map(select(.key | startswith("/") | not)) | length'`
+        run: exit $(cat src/redirects.json| jq '.redirects|to_entries | map(select(.key | startswith("/") | not)) | length')
         shell: bash
 
       - name: validate all indexPaths start with a `/`

--- a/.github/workflows/publish-redirect-rules.yaml
+++ b/.github/workflows/publish-redirect-rules.yaml
@@ -33,9 +33,11 @@ jobs:
 
       - name: validate all redirects start with a `/`
         run: exit `cat src/redirects.json| jq '.redirects|to_entries | map(select(.key | startswith("/") | not)) | length'`
+        shell: bash
 
       - name: validate all indexPaths start with a `/`
-        run: exit `cat src/redirects.json| jq '.indexPaths|to_entries | map(select(.key | startswith("/") | not)) | length'`
+        run: exit $(cat src/redirects.json| jq '.indexPaths|to_entries | map(select(.key | startswith("/") | not)) | length')
+        shell: bash
 
       - name: set aws credentials
         if: github.event_name == 'push'

--- a/.github/workflows/publish-redirect-rules.yaml
+++ b/.github/workflows/publish-redirect-rules.yaml
@@ -31,6 +31,12 @@ jobs:
       - name: validate json
         run: cat src/redirects.json | jq empty
 
+      - name: validate all redirects start with a `/`
+        run: exit `cat src/redirects.json| jq '.redirects|to_entries | map(select(.key | startswith("/") | not)) | length'`
+
+      - name: validate all indexPaths start with a `/`
+        run: exit `cat src/redirects.json| jq '.indexPaths|to_entries | map(select(.key | startswith("/") | not)) | length'`
+
       - name: set aws credentials
         if: github.event_name == 'push'
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4


### PR DESCRIPTION
fail if all keys for the redirect or indexPaths objects don't start with a `/`

This would have caught this issue: https://github.com/FusionAuth/fusionauth-site/pull/3655