### PR TITLE
Fix application api inconsistency

### DIFF
--- a/astro/src/content/docs/apis/_application-request-body.mdx
+++ b/astro/src/content/docs/apis/_application-request-body.mdx
@@ -1,5 +1,6 @@
 import AdvancedPlanBlurbApi from 'src/content/docs/_shared/_advanced-plan-blurb-api.astro';
 import APIBlock from 'src/components/api/APIBlock.astro';
+import Aside from 'src/components/Aside.astro';
 import APIField from 'src/components/api/APIField.astro';
 import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import InlineField from 'src/components/InlineField.astro';
@@ -227,11 +228,11 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
      * com.myApp://example
      * com.myApp:/example
 
-    <span class="text-green-600">Available since 1.32.0</span>
+    <Aside type="version">Available since 1.32.0</Aside>
 
     You may now use URLs that do not begin with `http` to support native application origins. Prior to this version the value will be validated to begin with `http`. This also includes authorized origins that use a single slash to denote there is no naming authority for the scheme. Prior to this version a URL such as `com.myApp:/example` would fail validation as an invalid URL.
 
-    <OauthWildcardUsage validation_policy_field_name="application.oauthConfiguration.authorizedURLValidationPolicy" validation_policy_wildcard="AllowWildcards" />
+    <OauthWildcardUsage fieldName="application.oauthConfiguration.authorizedURLValidationPolicy" wildcard="AllowWildcards" />
   </APIField>
   <APIField name="application.oauthConfiguration.authorizedRedirectURLs" type="Array<String>" optional>
     An array of URLs that are the authorized redirect URLs for FusionAuth OAuth.
@@ -242,15 +243,15 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
      * com.myApp://redirect
      * com.myApp:/redirect
 
-    <span class="text-green-600">Available since 1.7.0</span>
+    <Aside type="version">Available since 1.7.0</Aside>
 
     You may now use URLs that do not begin with `http` to support native application redirect. Prior to this version the value will be validated to begin with `http`.
 
-    <span class="text-green-600">Available since 1.12.0</span>
+    <Aside type="version">Available since 1.12.0</Aside>
 
     You may now use URLs for application redirects that use a single slash to denote there is no naming authority for the scheme. Prior to this version a URL such as `com.myApp:/redirect` would fail validation as in invalid URL.
 
-    <OauthWildcardUsage validation_policy_field_name="application.oauthConfiguration.authorizedURLValidationPolicy" validation_policy_wildcard="AllowWildcards" />
+    <OauthWildcardUsage fieldName="application.oauthConfiguration.authorizedURLValidationPolicy" wildcard="AllowWildcards" />
   </APIField>
   <APIField name="application.oauthConfiguration.authorizedURLValidationPolicy" optional since="1.43.0">
     Controls the validation policy for <InlineField>application.oauthConfiguration.authorizedOriginURLs</InlineField> and <InlineField>application.oauthConfiguration.authorizedRedirectURLs</InlineField>.

--- a/astro/src/content/docs/apis/_application-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_application-response-body-base.mdx
@@ -178,12 +178,12 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
     The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.
   </APIField>
   <APIField name={ props.base_field_name + ".oauthConfiguration.authorizedOriginURLs" } type="Array<String>">
-    An array of URLs that are the authorized origins for FusionAuth OAuth.
+    An array of URLs that are the authorized origins for this Application.
 
     When this configuration is omitted, all HTTP origins are allowed to use the browser based grants and the HTTP response header of `X-Frame-Options: DENY` will be added to each response to disallow iframe loading.
   </APIField>
   <APIField name={ props.base_field_name + ".oauthConfiguration.authorizedRedirectURLs" } type="Array<String>">
-    An array of URLs that are the authorized redirect URLs for FusionAuth OAuth.
+    An array of URLs that are the authorized redirect URLs for this Application.
   </APIField>
   <APIField name={ props.base_field_name + ".oauthConfiguration.authorizedURLValidationPolicy" } type="String" since="1.43.0">
     Controls the validation policy for <InlineField>{props.base_field_name}.oauthConfiguration.authorizedOriginURLs</InlineField> and <InlineField>{props.base_field_name}.oauthConfiguration.authorizedRedirectURLs</InlineField>.


### PR DESCRIPTION
A couple of kinds of inconsistency:

- we refer to FusionAuth OAuth in the response, and that felt weird and non-standard
- the authorized redirect URL and origin fields used both green spans and asides for version info, converted both to asides.
- the oauth-wildcard-usage fragment parameters were incorrectly used, resulting in blanks in the fragment

Open question: maybe we want to avoid asides inside the API doc and I should switch all back to the green span? Looked at tenants and application API doc and we aren't really consistent.