### PR TITLE
Rework api since tags

### DIFF
--- a/DocsDevREADME.md
+++ b/DocsDevREADME.md
@@ -48,7 +48,7 @@ Here are some guidelines to follow when writing documentation (everything under 
 - When using images that are cropped, add `top-cropped` and/or `bottom-cropped` roles as appropriate. Use `box-shadow` only when an image isn't captured in the manner documented below. It's used only when we have screenshots of things that do not have a box shadow and are all white and blend in too much with our white background. No other image classes are needed when creating documentation.
 - Include fragments that are shared between different sections of the doc should be stored in the [shared](astro/src/content/docs/_shared) directory.
 - All links elements should be fully-qualified and never include a slash at the end (i.e. `[users](/docs/apis/users)` not `[users](./users)`)
-- If something is new in a version, mark it with something like this (this is great in toward the top of a page):
+- If something is new in a version, mark it with something like this (this is great toward the top of a page documenting a version introduced in a particular version):
 
   <Aside type="version">
     Available since 1.5.0

--- a/DocsDevREADME.md
+++ b/DocsDevREADME.md
@@ -55,7 +55,7 @@ Here are some guidelines to follow when writing documentation (everything under 
   </Aside>
 
 If there is a description of the feature that is part of a set of paragraphs, use the title element and put the description in the slot.
-  <Aside since="Available since 1.5.0" type="version">
+  <Aside title="Available since 1.5.0" type="version">
     You can use the advanced version of the feature with ...
   </Aside>
 

--- a/DocsDevREADME.md
+++ b/DocsDevREADME.md
@@ -48,10 +48,15 @@ Here are some guidelines to follow when writing documentation (everything under 
 - When using images that are cropped, add `top-cropped` and/or `bottom-cropped` roles as appropriate. Use `box-shadow` only when an image isn't captured in the manner documented below. It's used only when we have screenshots of things that do not have a box shadow and are all white and blend in too much with our white background. No other image classes are needed when creating documentation.
 - Include fragments that are shared between different sections of the doc should be stored in the [shared](astro/src/content/docs/_shared) directory.
 - All links elements should be fully-qualified and never include a slash at the end (i.e. `[users](/docs/apis/users)` not `[users](./users)`)
-- If something is new in a version, mark it with something like this:
+- If something is new in a version, mark it with something like this (this is great in toward the top of a page):
 
   <Aside type="version">
-    Available Since Version 1.5.0
+    Available since 1.5.0
+  </Aside>
+
+If there is a description of the feature that is part of a set of paragraphs, use the title element and put the description in the slot.
+  <Aside since="Available since 1.5.0" type="version">
+    You can use the advanced version of the feature with ...
   </Aside>
 
 If it is inline (for a field), use <AvailableSince since="1.5.0"> - [AvailableSince](astro/src/components/api/AvailableSince.astro)

--- a/astro/src/content/docs/_shared/_oauth-wildcard-usage.mdx
+++ b/astro/src/content/docs/_shared/_oauth-wildcard-usage.mdx
@@ -1,7 +1,7 @@
 import Aside from 'src/components/Aside.astro';
 import InlineField from 'src/components/InlineField.astro';
 
-<Aside type="version">Available since 1.43.0</Aside>
+<Aside type="version" title="Available since 1.43.0">
 
 Configured URLs containing wildcards are considered during validation when <InlineField>{props.fieldName}</InlineField> is set to <code>{props.wildcard}</code>. Wildcards are allowed in the following positions:
 
@@ -11,3 +11,4 @@ Configured URLs containing wildcards are considered during validation when <Inli
  * A query string value - A wildcard is allowed in place of a query string value. Partial wildcards are not allowed in this position. Wildcards are not allowed in query string names.
 
 See the OAuth 2.0 [URL Validation](/docs/lifecycle/authenticate-users/oauth/url-validation) page for more detail.
+</Aside>

--- a/astro/src/content/docs/_shared/_oauth-wildcard-usage.mdx
+++ b/astro/src/content/docs/_shared/_oauth-wildcard-usage.mdx
@@ -3,7 +3,7 @@ import InlineField from 'src/components/InlineField.astro';
 
 <Aside type="version" title="Available since 1.43.0">
 
-Configured URLs containing wildcards are considered during validation when <InlineField>{props.fieldName}</InlineField> is set to <code>{props.wildcard}</code>. Wildcards are allowed in the following positions:
+Configured URLs containing wildcards are considered during validation when <InlineField>{props.fieldName}</InlineField> is set to <code>{props.wildcard}</code>. Wildcards are allowed in the following positions:{/* eslint-disable-line */}
 
  * The left-most subdomain - A full or partial wildcard is allowed in the left-most subdomain. The replacement value cannot contain a `.`.
  * The port number - A wildcard is allowed in place of the port number. Partial wildcards are not allowed in this position.

--- a/astro/src/content/docs/apis/_application-oauth-configuration-response-body.mdx
+++ b/astro/src/content/docs/apis/_application-oauth-configuration-response-body.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 import ApplicationOauthconfigurationClientauthenticationpolicy from 'src/content/docs/apis/_application-oauthConfiguration-clientAuthenticationPolicy.mdx';
@@ -66,7 +67,7 @@ import JSON from 'src/components/JSON.astro';
     * `implicit`
     * `password`
     * `refresh_token`
-    * `urn:ietf:params:oauth:grant-type:device_code` <span class="text-green-600">Available since 1.11.0</span>
+    * `urn:ietf:params:oauth:grant-type:device_code` <AvailableSince since="1.11.0" />
   </APIField>
   <APIField name="oauthConfiguration.generateRefreshTokens" type="Boolean" since="1.3.0">
     Determines if the OAuth 2.0 Token endpoint will generate a refresh token when the `offline_access` scope is requested.

--- a/astro/src/content/docs/apis/_application-request-body.mdx
+++ b/astro/src/content/docs/apis/_application-request-body.mdx
@@ -300,7 +300,7 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
     * `implicit`
     * `password`
     * `refresh_token`
-    * `urn:ietf:params:oauth:grant-type:device_code` &nbsp; <AvailableSince since="1.11.0" />
+    * `urn:ietf:params:oauth:grant-type:device_code` <AvailableSince since="1.11.0" />
   </APIField>
   <APIField name="application.oauthConfiguration.generateRefreshTokens" type="Boolean" optional since="1.3.0">
     Determines if the OAuth 2.0 Token endpoint will generate a refresh token when the `offline_access` scope is requested.

--- a/astro/src/content/docs/apis/_application-request-body.mdx
+++ b/astro/src/content/docs/apis/_application-request-body.mdx
@@ -1,5 +1,6 @@
 import AdvancedPlanBlurbApi from 'src/content/docs/_shared/_advanced-plan-blurb-api.astro';
 import APIBlock from 'src/components/api/APIBlock.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import Aside from 'src/components/Aside.astro';
 import APIField from 'src/components/api/APIField.astro';
 import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
@@ -109,7 +110,7 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
 
     * `Fixed` - the expiration is calculated from the time the token is issued.
     * `SlidingWindow` - the expiration is calculated from the last time the token was used.
-    * `SlidingWindowWithMaximumLifetime` - the expiration is calculated from the last time the token was used, or until the <InlineField>maximumTimeToLiveInMinutes</InlineField> is reached. <span class="text-green-600">Available since 1.46.0</span>
+    * `SlidingWindowWithMaximumLifetime` - the expiration is calculated from the last time the token was used, or until the <InlineField>maximumTimeToLiveInMinutes</InlineField> is reached. <AvailableSince since="1.46.0" />
   </APIField>
 
   <APIField name="application.jwtConfiguration.refreshTokenOneTimeUseConfiguration.gracePeriodInSeconds" type="Integer" optional defaults="0" since="1.55.1">
@@ -196,9 +197,11 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
 
     * `Enabled` - Require a two-factor challenge during login when an eligible method is available.
     * `Disabled` - Do not require a two-factor challenge during login.
-    * `Required` - Require a two-factor challenge during login. A user will be required to configure 2FA if no eligible methods are available. <span class="text-green-600">Available since 1.42.0</span>
+    * `Required` - Require a two-factor challenge during login. A user will be required to configure 2FA if no eligible methods are available. <AvailableSince since="1.42.0" />
 
-    While this configuration requires a license, in version `1.49.0` or later it may be enabled for the FusionAuth admin application regardless of the license state.
+    <Aside title="Available since 1.49.0" type="version">
+      This value may be set for the FusionAuth admin UI application whether or not an instance is licensed. For other applications, a license is required.
+    </Aside>
   </APIField>
   <APIField name="application.multiFactorConfiguration.sms.templateId" type="UUID" optional since="1.26.0">
     The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.
@@ -228,9 +231,10 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
      * com.myApp://example
      * com.myApp:/example
 
-    <Aside type="version">Available since 1.32.0</Aside>
+    <Aside title="Available since 1.32.0" type="version">
+      You may now use URLs that do not begin with `http` to support native application origins. Prior to this version the value will be validated to begin with `http`. This also includes authorized origins that use a single slash to denote there is no naming authority for the scheme. Prior to this version a URL such as `com.myApp:/example` would fail validation as an invalid URL.
+    </Aside>
 
-    You may now use URLs that do not begin with `http` to support native application origins. Prior to this version the value will be validated to begin with `http`. This also includes authorized origins that use a single slash to denote there is no naming authority for the scheme. Prior to this version a URL such as `com.myApp:/example` would fail validation as an invalid URL.
 
     <OauthWildcardUsage fieldName="application.oauthConfiguration.authorizedURLValidationPolicy" wildcard="AllowWildcards" />
   </APIField>
@@ -243,13 +247,14 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
      * com.myApp://redirect
      * com.myApp:/redirect
 
-    <Aside type="version">Available since 1.7.0</Aside>
+    <Aside title="Available since 1.7.0" type="version">
+      You may now use URLs that do not begin with `http` to support native application redirect. Prior to this version the value will be validated to begin with `http`.
+</Aside>
 
-    You may now use URLs that do not begin with `http` to support native application redirect. Prior to this version the value will be validated to begin with `http`.
+    <Aside title="Available since 1.12.0" type="version">
+      You may now use URLs for application redirects that use a single slash to denote there is no naming authority for the scheme. Prior to this version a URL such as `com.myApp:/redirect` would fail validation as in invalid URL.
+    </Aside>
 
-    <Aside type="version">Available since 1.12.0</Aside>
-
-    You may now use URLs for application redirects that use a single slash to denote there is no naming authority for the scheme. Prior to this version a URL such as `com.myApp:/redirect` would fail validation as in invalid URL.
 
     <OauthWildcardUsage fieldName="application.oauthConfiguration.authorizedURLValidationPolicy" wildcard="AllowWildcards" />
   </APIField>
@@ -295,7 +300,7 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
     * `implicit`
     * `password`
     * `refresh_token`
-    * `urn:ietf:params:oauth:grant-type:device_code` &nbsp; <span class="text-green-600">Available since 1.11.0</span>
+    * `urn:ietf:params:oauth:grant-type:device_code` &nbsp; <AvailableSince since="1.11.0" />
   </APIField>
   <APIField name="application.oauthConfiguration.generateRefreshTokens" type="Boolean" optional since="1.3.0">
     Determines if the OAuth 2.0 Token endpoint will generate a refresh token when the `offline_access` scope is requested.
@@ -451,8 +456,8 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
 
     Supported values include:
 
-    * `basic` - the basic self registration options available prior to version `1.18.0`.
-    * `advanced` - advanced usage of custom forms, requires a paid plan.
+    * `basic` - basic self registration options.
+    * `advanced` - advanced usage of custom forms and requires a paid plan. <AvailableSince since="1.18.0"/>
   </APIField>
   <APIField name="application.registrationDeletePolicy.unverified.enabled" type="Boolean" optional since="1.13.0">
     Indicates that users without a verified registration for this application will have their registration permanently deleted after <InlineField>application.registrationDeletePolicy.unverified.numberOfDaysToRetain</InlineField> days.

--- a/astro/src/content/docs/apis/_application-request-body.mdx
+++ b/astro/src/content/docs/apis/_application-request-body.mdx
@@ -1,5 +1,6 @@
 import AdvancedPlanBlurbApi from 'src/content/docs/_shared/_advanced-plan-blurb-api.astro';
 import APIBlock from 'src/components/api/APIBlock.astro';
+import Aside from 'src/components/Aside.astro';
 import APIField from 'src/components/api/APIField.astro';
 import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import InlineField from 'src/components/InlineField.astro';
@@ -227,11 +228,11 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
      * com.myApp://example
      * com.myApp:/example
 
-    <span class="text-green-600">Available since 1.32.0</span>
+    <Aside type="version">Available since 1.32.0</Aside>
 
     You may now use URLs that do not begin with `http` to support native application origins. Prior to this version the value will be validated to begin with `http`. This also includes authorized origins that use a single slash to denote there is no naming authority for the scheme. Prior to this version a URL such as `com.myApp:/example` would fail validation as an invalid URL.
 
-    <OauthWildcardUsage validation_policy_field_name="application.oauthConfiguration.authorizedURLValidationPolicy" validation_policy_wildcard="AllowWildcards" />
+    <OauthWildcardUsage fieldName="application.oauthConfiguration.authorizedURLValidationPolicy" wildcard="AllowWildcards" />
   </APIField>
   <APIField name="application.oauthConfiguration.authorizedRedirectURLs" type="Array<String>" optional>
     An array of URLs that are the authorized redirect URLs for FusionAuth OAuth.
@@ -242,15 +243,15 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
      * com.myApp://redirect
      * com.myApp:/redirect
 
-    <span class="text-green-600">Available since 1.7.0</span>
+    <Aside type="version">Available since 1.7.0</Aside>
 
     You may now use URLs that do not begin with `http` to support native application redirect. Prior to this version the value will be validated to begin with `http`.
 
-    <span class="text-green-600">Available since 1.12.0</span>
+    <Aside type="version">Available since 1.12.0</Aside>
 
     You may now use URLs for application redirects that use a single slash to denote there is no naming authority for the scheme. Prior to this version a URL such as `com.myApp:/redirect` would fail validation as in invalid URL.
 
-    <OauthWildcardUsage validation_policy_field_name="application.oauthConfiguration.authorizedURLValidationPolicy" validation_policy_wildcard="AllowWildcards" />
+    <OauthWildcardUsage fieldName="application.oauthConfiguration.authorizedURLValidationPolicy" wildcard="AllowWildcards" />
   </APIField>
   <APIField name="application.oauthConfiguration.authorizedURLValidationPolicy" optional since="1.43.0">
     Controls the validation policy for <InlineField>application.oauthConfiguration.authorizedOriginURLs</InlineField> and <InlineField>application.oauthConfiguration.authorizedRedirectURLs</InlineField>.

--- a/astro/src/content/docs/apis/_application-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_application-response-body-base.mdx
@@ -291,7 +291,8 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
   <APIField name={ props.base_field_name + ".oauthConfiguration.requireClientAuthentication" } type="Boolean" since="1.3.0" deprecated>
     Determines if the OAuth 2.0 Token endpoint requires client authentication. If this is enabled, the client must provide client credentials when using the Token endpoint. The `client_id` and `client_secret` may be provided using a Basic Authorization HTTP header, or by sending these parameters in the request body using POST data.
 
-    <span class="text-red-700">Deprecated in version 1.28.0</span>
+    <DeprecatedSince version="1.28.0" />
+
     In version 1.28.0 and beyond, client authentication can be managed via <InlineField>{props.base_field_name}.oauthConfiguration.clientAuthenticationPolicy</InlineField>.
   </APIField>
   <APIField name={ props.base_field_name + ".oauthConfiguration.requireRegistration" } type="Boolean" since="1.28.0">
@@ -473,7 +474,8 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
   <APIField name={ props.base_field_name + ".samlv2Configuration.callbackURL" } type="String" since="1.6.0" deprecated>
     The URL of the callback (sometimes called the Assertion Consumer Service or ACS). This is where FusionAuth sends the browser after the user logs in via SAML.
 
-    <span class="text-red-700">Deprecated in version 1.20.0</span>
+    <DeprecatedSince version="1.20.0" />
+
     This field is preserved for backwards compatibility and may be removed in a future release. This is the first value found in the <InlineField>authorizedRedirectURLs</InlineField> parameter.
   </APIField>
   <APIField name={ props.base_field_name + ".samlv2Configuration.debug" } type="Boolean" since="1.6.0">

--- a/astro/src/content/docs/apis/_application-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_application-response-body-base.mdx
@@ -178,12 +178,12 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
     The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.
   </APIField>
   <APIField name={ props.base_field_name + ".oauthConfiguration.authorizedOriginURLs" } type="Array<String>">
-    An array of URLs that are the authorized origins for FusionAuth OAuth.
+    An array of URLs that are the authorized origins for this Application.
 
     When this configuration is omitted, all HTTP origins are allowed to use the browser based grants and the HTTP response header of `X-Frame-Options: DENY` will be added to each response to disallow iframe loading.
   </APIField>
   <APIField name={ props.base_field_name + ".oauthConfiguration.authorizedRedirectURLs" } type="Array<String>">
-    An array of URLs that are the authorized redirect URLs for FusionAuth OAuth.
+    An array of URLs that are the authorized redirect URLs for this Application.
   </APIField>
   <APIField name={ props.base_field_name + ".oauthConfiguration.authorizedURLValidationPolicy" } type="String" since="1.43.0">
     Controls the validation policy for <InlineField>{props.base_field_name}.oauthConfiguration.authorizedOriginURLs</InlineField> and <InlineField>{props.base_field_name}.oauthConfiguration.authorizedRedirectURLs</InlineField>.

--- a/astro/src/content/docs/apis/_application-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_application-response-body-base.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
@@ -101,7 +102,7 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
 
     * `Fixed` - the expiration is calculated from the time the token is issued.
     * `SlidingWindow` - the expiration is calculated from the last time the token was used.
-    * `SlidingWindowWithMaximumLifetime` - the expiration is calculated from the last time the token was used, or until the <InlineField>maximumTimeToLiveInMinutes</InlineField> is reached. <span class="text-green-600">Available since 1.46.0</span>
+    * `SlidingWindowWithMaximumLifetime` - the expiration is calculated from the last time the token was used, or until the <InlineField>maximumTimeToLiveInMinutes</InlineField> is reached. <AvailableSince since="1.46.0" />
   </APIField>
 
   <APIField name={ props.base_field_name + ".jwtConfiguration.refreshTokenOneTimeUseConfiguration.gracePeriodInSeconds" } type="Integer" since="1.55.1">
@@ -230,7 +231,7 @@ import Xmlsignaturec14nmethodValues from 'src/content/docs/_shared/_xmlSignature
     * `implicit`
     * `password`
     * `refresh_token`
-    * `urn:ietf:params:oauth:grant-type:device_code` <span class="text-green-600">Available since 1.11.0</span>
+    * `urn:ietf:params:oauth:grant-type:device_code` <AvailableSince since="1.11.0" />
   </APIField>
   <APIField name={ props.base_field_name + ".oauthConfiguration.generateRefreshTokens" } type="Boolean" since="1.3.0">
     Determines if the OAuth 2.0 Token endpoint will generate a refresh token when the `offline_access` scope is requested.

--- a/astro/src/content/docs/apis/_jwt_algorithm.mdx
+++ b/astro/src/content/docs/apis/_jwt_algorithm.mdx
@@ -1,8 +1,10 @@
+import AvailableSince from 'src/components/api/AvailableSince.astro';
+
 The algorithm used to sign the JSON Web Token (JWT). The following available JSON Web Algorithms (JWA) as described in [RFC 7518](https://tools.ietf.org/html/rfc7518) are available.
 
- * `ES256` - ECDSA using P-256 curve and SHA-256 <span class="text-green-600">Available since 1.4.0</span>
- * `ES384` - ECDSA using P-384 curve and SHA-384 <span class="text-green-600">Available since 1.4.0</span>
- * `ES512` - ECDSA using P-521 curve and SHA-512 <span class="text-green-600">Available since 1.4.0</span>
+ * `ES256` - ECDSA using P-256 curve and SHA-256 <AvailableSince since="1.4.0" />
+ * `ES384` - ECDSA using P-384 curve and SHA-384 <AvailableSince since="1.4.0" />
+ * `ES512` - ECDSA using P-521 curve and SHA-512 <AvailableSince since="1.4.0" />
  * `HS256` - HMAC using SHA-256
  * `HS384` - HMAC using SHA-384
  * `HS512` - HMAC using SHA-512

--- a/astro/src/content/docs/apis/_jwt_algorithm.mdx
+++ b/astro/src/content/docs/apis/_jwt_algorithm.mdx
@@ -2,12 +2,12 @@ import AvailableSince from 'src/components/api/AvailableSince.astro';
 
 The algorithm used to sign the JSON Web Token (JWT). The following available JSON Web Algorithms (JWA) as described in [RFC 7518](https://tools.ietf.org/html/rfc7518) are available.
 
- * `ES256` - ECDSA using P-256 curve and SHA-256 <AvailableSince since="1.4.0" />
- * `ES384` - ECDSA using P-384 curve and SHA-384 <AvailableSince since="1.4.0" />
- * `ES512` - ECDSA using P-521 curve and SHA-512 <AvailableSince since="1.4.0" />
- * `HS256` - HMAC using SHA-256
- * `HS384` - HMAC using SHA-384
- * `HS512` - HMAC using SHA-512
- * `RS256` - RSASSA-PKCS1-v1_5 using SHA-256
- * `RS384` - RSASSA-PKCS1-v1_5 using SHA-384
- * `RS512` - RSASSA-PKCS1-v1_5 using SHA-512
+* `ES256` - ECDSA using P-256 curve and SHA-256 <AvailableSince since="1.4.0" />
+* `ES384` - ECDSA using P-384 curve and SHA-384 <AvailableSince since="1.4.0" />
+* `ES512` - ECDSA using P-521 curve and SHA-512 <AvailableSince since="1.4.0" />
+* `HS256` - HMAC using SHA-256
+* `HS384` - HMAC using SHA-384
+* `HS512` - HMAC using SHA-512
+* `RS256` - RSASSA-PKCS1-v1_5 using SHA-256
+* `RS384` - RSASSA-PKCS1-v1_5 using SHA-384
+* `RS512` - RSASSA-PKCS1-v1_5 using SHA-512

--- a/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
@@ -41,9 +41,7 @@ This request requires that you specify both the User object and the User Registr
     The list of roles that the User has for this registration. The string is the role's `Name` not the role's `Id`, e.g. `admin` or `user-role`.
   </APIField>
   <APIField name="registration.timezone" type="String" optional>
-    The User's preferred timezone for this Application registration. The format is not enforced, however it is recommended to use a timezone in the TZ format such as
-
-    > `America/Denver` or `US/Mountain`
+    The User's preferred timezone for this Application registration. The format is not enforced, however it is recommended to use a timezone in the TZ format such as `America/Denver` or `US/Mountain`.
   </APIField>
   <APIField name="registration.username" type="String" optional>
     The username of the User for this Application. This username cannot be used to login. It is for display purposes only. The <InlineField>user.username</InlineField> field may be used to login.
@@ -135,7 +133,7 @@ This request requires that you specify both the User object and the User Registr
     The time-step size in seconds. With the current implementation, this must be `30` if provided. Any other value will be ignored.
   </APIField>
   <APIField name="user.twoFactor.methods[x].email" type="String" optional>
-    The value of the email address for this method. Only present if <InlineField>user.twoFactor.methods[x].method</InlineField> is `email`.
+    The value of the email address for this method. Only present if <InlineField>user.twoFactor.methods\[x].method</InlineField> is `email`.
   </APIField>
   <APIField name="user.twoFactor.methods[x].method" type="String" optional>
     The type of this method. There will also be an object with the same value containing additional information about this method.  The possible values are:
@@ -145,7 +143,7 @@ This request requires that you specify both the User object and the User Registr
     * `sms`
   </APIField>
   <APIField name="user.twoFactor.methods[x].mobilePhone" type="String" optional>
-    The value of the mobile phone for this method. Only present if <InlineField>user.twoFactor.methods[x].method</InlineField> is `sms`.
+    The value of the mobile phone for this method. Only present if <InlineField>user.twoFactor.methods\[x].method</InlineField> is `sms`.
   </APIField>
   <APIField name="user.twoFactor.methods[x].secret" type="String" optional>
     A base64 encoded secret.

--- a/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
 import UserSendSetPasswordEmail from 'src/content/docs/apis/_user-send-set-password-email.mdx';
@@ -75,10 +76,10 @@ This request requires that you specify both the User object and the User Registr
     * [salted-sha256](/docs/reference/password-hashes#salted-sha-256)
     * [salted-hmac-sha256](/docs/reference/password-hashes#salted-hmac-sha-256)
     * [salted-pbkdf2-hmac-sha256](/docs/reference/password-hashes#salted-pbkdf2-hmac-sha-256)
-    * [salted-pbkdf2-hmac-sha256-512](/docs/reference/password-hashes#salted-pbkdf2-hmac-sha-256)<span class="text-green-600 px-2">Available since 1.34.0</span>
+    * [salted-pbkdf2-hmac-sha256-512](/docs/reference/password-hashes#salted-pbkdf2-hmac-sha-256)<AvailableSince since="1.34.0" />
     * [bcrypt](/docs/reference/password-hashes#salted-bcrypt)
-    * [phpass-md5](/docs/reference/password-hashes#phpass-md5)<span class="text-green-600 px-2">Available since 1.45.0</span>
-    * [phpass-sha512](/docs/reference/password-hashes#phpass-sha-512)<span class="text-green-600 px-2">Available since 1.45.0</span>
+    * [phpass-md5](/docs/reference/password-hashes#phpass-md5)<AvailableSince since="1.45.0" />
+    * [phpass-sha512](/docs/reference/password-hashes#phpass-sha-512)<AvailableSince since="1.45.0" />
 
     You can also create your own password encryptor. See the [Custom Password Hashing](/docs/extend/code/password-hashes/custom-password-hashing) section for more information.
   </APIField>

--- a/astro/src/content/docs/apis/_user-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-request-body.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
@@ -57,10 +58,10 @@ You must specify either the **email** or the **username** or both for the User. 
         * [salted-sha256](/docs/reference/password-hashes#salted-sha-256)
         * [salted-hmac-sha256](/docs/reference/password-hashes#salted-hmac-sha-256)
         * [salted-pbkdf2-hmac-sha256](/docs/reference/password-hashes#salted-pbkdf2-hmac-sha-256)
-        * [salted-pbkdf2-hmac-sha256-512](/docs/reference/password-hashes#salted-pbkdf2-hmac-sha-256) <span class="text-green-600 px-2">Available since 1.34.0</span>
+        * [salted-pbkdf2-hmac-sha256-512](/docs/reference/password-hashes#salted-pbkdf2-hmac-sha-256) <AvailableSince since="1.34.0" />
         * [bcrypt](/docs/reference/password-hashes#salted-bcrypt)
-        * [phpass-md5](/docs/reference/password-hashes#phpass-md5) <span class="text-green-600 px-2">Available since 1.45.0</span>
-        * [phpass-sha512](/docs/reference/password-hashes#phpass-sha-512)<span class="text-green-600 px-2">Available since 1.45.0</span>
+        * [phpass-md5](/docs/reference/password-hashes#phpass-md5) <AvailableSince since="1.45.0" />
+        * [phpass-sha512](/docs/reference/password-hashes#phpass-sha-512)<AvailableSince since="1.45.0" />
 
     { props.http_method === 'PUT' &&
       <p>

--- a/astro/src/content/docs/apis/_user-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-request-body.mdx
@@ -162,11 +162,7 @@ You must specify either the **email** or the **username** or both for the User. 
   </APIField>
 
   <APIField name="user.timezone" type="String" optional>
-    The User's preferred timezone. The string must be in an [IANA](https://www.iana.org/time-zones) time zone format. For example:
-
-    <blockquote>
-      `America/Denver` or `US/Mountain`
-    </blockquote>
+    The User's preferred timezone. The string must be in an [IANA](https://www.iana.org/time-zones) time zone format. For example: `America/Denver` or `US/Mountain`.
   </APIField>
 
   <APIField name="user.twoFactor.methods[x].authenticator.algorithm" type="String" optional>

--- a/astro/src/content/docs/apis/_webhook-request-body.mdx
+++ b/astro/src/content/docs/apis/_webhook-request-body.mdx
@@ -1,6 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
-import BeforeVersion from 'src/components/api/BeforeVersion.astro';
+import Aside from 'src/components/Aside.astro';
 import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import EventTypes from 'src/content/docs/apis/_event-types.mdx';
 import InlineField from 'src/components/InlineField.astro';
@@ -44,9 +44,9 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   <APIField name="webhook.global" type="Boolean" optional defaults="false">
     Whether or not this Webhook is used for all Tenants or just for specific Tenants.
 
-    <BeforeVersion version="1.37.0">
-    Whether or not this Webhook is used for all events or just for specific Applications. In almost all cases you want to set this field to `true` and filter on the application Id when processing the webhook.
-    </BeforeVersion>
+    <Aside type="version" title="Before version 1.37.0">
+      Whether or not this Webhook is used for all events or just for specific Applications. In almost all cases you want to set this field to `true` and filter on the application Id when processing the webhook.
+    </Aside>
   </APIField>
   <APIField name="webhook.headers" type="Map<String, String>" optional>
     An object that contains headers that are sent as part of the HTTP request for the events.

--- a/astro/src/content/docs/apis/_webhook-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_webhook-response-body-base.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import BeforeVersion from 'src/components/api/BeforeVersion.astro';
 import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 import EventTypes from 'src/content/docs/apis/_event-types.mdx';
@@ -56,9 +57,8 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   <APIField name={`${props.base_field_name}.global`} type="Boolean">
     Whether or not this Webhook is used for all Tenants or just for specific Tenants.
 
-    <span class="text-green-600">
-    Before 1.37.0
-    </span>
+    <BeforeVersion version="1.37.0"/>
+
     Whether or not this Webhook is used for all events or just for specific Applications.
   </APIField>
 

--- a/astro/src/content/docs/apis/_webhook-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_webhook-response-body-base.mdx
@@ -1,6 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
-import BeforeVersion from 'src/components/api/BeforeVersion.astro';
+import Aside from 'src/components/Aside.astro';
 import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 import EventTypes from 'src/content/docs/apis/_event-types.mdx';
@@ -57,9 +57,9 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   <APIField name={`${props.base_field_name}.global`} type="Boolean">
     Whether or not this Webhook is used for all Tenants or just for specific Tenants.
 
-    <BeforeVersion version="1.37.0"/>
-
-    Whether or not this Webhook is used for all events or just for specific Applications.
+    <Aside type="version" title="Before version 1.37.0">
+      Whether or not this Webhook is used for all events or just for specific Applications.
+    </Aside>
   </APIField>
 
   <APIField name={`${props.base_field_name}.headers`} type="Map<String, String>">

--- a/astro/src/content/docs/apis/_webhook-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_webhook-response-body-base.mdx
@@ -17,9 +17,9 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
 
   <APIField name={`${props.base_field_name}.applicationIds`} type="Array<UUID>" optional deprecated>
     <>
-    <p>
+    <p>{/* eslint-disable-line */}
     The Ids of the Applications that this Webhook is associated with. If no Ids are returned and the <InlineField>global</InlineField> field is `false`, this Webhook is not used. Typically <InlineField>global</InlineField> should be set to `true`.
-    </p>
+    </p>{/* eslint-disable-line */}
 
     <RemovedSince since="1.37.0" >
       In version 1.37.0 and beyond, Webhooks are optionally associated with Tenants instead of Applications. See new field <InlineField>tenantIds</InlineField>.

--- a/astro/src/content/docs/apis/connectors/generic.mdx
+++ b/astro/src/content/docs/apis/connectors/generic.mdx
@@ -25,7 +25,6 @@ This API has been available since 1.18.0
 
 The following APIs are provided to manage Generic Connectors.
 
-
 ## Create the Generic Connector
 
 ### Request

--- a/astro/src/content/docs/apis/custom-forms/_form-field-key.mdx
+++ b/astro/src/content/docs/apis/custom-forms/_form-field-key.mdx
@@ -2,46 +2,46 @@ import AvailableSince from 'src/components/api/AvailableSince.astro';
 
 The key is the path to the value in the `user` or `registration` object.
 
-<br/>
+<br/>{/* eslint-disable-line */}
 
 **Predefined keys**
 
 Predefined keys are typed values managed by FusionAuth. When using a pre-defined key, the field data type and form control are not configurable.
 
- * `registration.preferredLanguages` <AvailableSince since="1.20.0" />
- * `registration.roles` <AvailableSince since="1.20.0" />
- * `registration.timezone` <AvailableSince since="1.20.0" />
- * `registration.username`
- * `user.birthDate`
- * `user.email`
- * `user.firstname`
- * `user.fullName`
- * `user.imageUrl` <AvailableSince since="1.20.0" />
- * `user.lastName`
- * `user.middleName`
- * `user.mobilePhone`
- * `user.password`
- * `user.preferredLanguages` <AvailableSince since="1.20.0" />
- * `user.timezone` <AvailableSince since="1.20.0" />
- * `user.username`
+* `registration.preferredLanguages` <AvailableSince since="1.20.0" />
+* `registration.roles` <AvailableSince since="1.20.0" />
+* `registration.timezone` <AvailableSince since="1.20.0" />
+* `registration.username`
+* `user.birthDate`
+* `user.email`
+* `user.firstname`
+* `user.fullName`
+* `user.imageUrl` <AvailableSince since="1.20.0" />
+* `user.lastName`
+* `user.middleName`
+* `user.mobilePhone`
+* `user.password`
+* `user.preferredLanguages` <AvailableSince since="1.20.0" />
+* `user.timezone` <AvailableSince since="1.20.0" />
+* `user.username`
 
-<br/>
+<br/>{/* eslint-disable-line */}
 
 **Custom Keys**
 
 When defining a key to store custom data, you may use one of the following prefixes:
 
- * `user.data.`
- * `registration.data`.
+* `user.data.`
+* `registration.data`.
 
 For example, in order to store a custom value on the user object to collect the User's favorite color, set the key value equal to `user.data.favoriteColor`.
 
 A valid key name must not contain spaces or special characters. An array may be specified by using the array syntax of `[0]` to indicate the first position in an array. Nested objects may be specified by using the object syntax of `['foo']` to indicate the named property of the object named `foo`. Consider the following examples:
 
- * `user.data.preferences[0]` would store the value in the first position of an array named `preferences`.
- * `user.data.preferences['color']` would store the value in an object named `preferences` with a key of `color`.
+* `user.data.preferences[0]` would store the value in the first position of an array named `preferences`.
+* `user.data.preferences['color']` would store the value in an object named `preferences` with a key of `color`.
 
-<br/>
+<br/>{/* eslint-disable-line */}
 
 **Localization**
 

--- a/astro/src/content/docs/apis/custom-forms/_form-field-key.mdx
+++ b/astro/src/content/docs/apis/custom-forms/_form-field-key.mdx
@@ -1,3 +1,5 @@
+import AvailableSince from 'src/components/api/AvailableSince.astro';
+
 The key is the path to the value in the `user` or `registration` object.
 
 <br/>
@@ -6,21 +8,21 @@ The key is the path to the value in the `user` or `registration` object.
 
 Predefined keys are typed values managed by FusionAuth. When using a pre-defined key, the field data type and form control are not configurable.
 
- * `registration.preferredLanguages` <span class="text-green-600">Available since 1.20.0</span>
- * `registration.roles` <span class="text-green-600">Available since 1.20.0</span>
- * `registration.timezone` <span class="text-green-600">Available since 1.20.0</span>
+ * `registration.preferredLanguages` <AvailableSince since="1.20.0" />
+ * `registration.roles` <AvailableSince since="1.20.0" />
+ * `registration.timezone` <AvailableSince since="1.20.0" />
  * `registration.username`
  * `user.birthDate`
  * `user.email`
  * `user.firstname`
  * `user.fullName`
- * `user.imageUrl` <span class="text-green-600">Available since 1.20.0</span>
+ * `user.imageUrl` <AvailableSince since="1.20.0" />
  * `user.lastName`
  * `user.middleName`
  * `user.mobilePhone`
  * `user.password`
- * `user.preferredLanguages` <span class="text-green-600">Available since 1.20.0</span>
- * `user.timezone` <span class="text-green-600">Available since 1.20.0</span>
+ * `user.preferredLanguages` <AvailableSince since="1.20.0" />
+ * `user.timezone` <AvailableSince since="1.20.0" />
  * `user.username`
 
 <br/>

--- a/astro/src/content/docs/apis/custom-forms/_form-request-body.mdx
+++ b/astro/src/content/docs/apis/custom-forms/_form-request-body.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
 

--- a/astro/src/content/docs/apis/custom-forms/_form-request-body.mdx
+++ b/astro/src/content/docs/apis/custom-forms/_form-request-body.mdx
@@ -46,10 +46,10 @@ import JSON from 'src/components/JSON.astro';
   <APIField name="form.type" type="String" optional defaults="registration" since="1.20.0">
     The type of form being created, a form type cannot be changed after the form has been created. This type will be used to identify how this form can be utilized by FusionAuth.
 
-      * `adminRegistration` - This form can be used to customize the add and edit User Registration form in the FusionAuth UI. <span class="text-green-600">Available since 1.20.0</span>
-      * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. <span class="text-green-600">Available since 1.20.0</span>
+      * `adminRegistration` - This form can be used to customize the add and edit User Registration form in the FusionAuth UI. <AvailableSince since="1.20.0" />
+      * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. <AvailableSince since="1.20.0" />
       * `registration` - This form can be used for self service registration.
-      * `selfServiceUser` - This form can be used for Self Service Account Management. <span class="text-green-600">Available since 1.26.0</span>
+      * `selfServiceUser` - This form can be used for Self Service Account Management. <AvailableSince since="1.26.0" />
 
     Prior to version `1.20.0`, the default form type was `registration`.
   </APIField>

--- a/astro/src/content/docs/apis/custom-forms/_form-response-body.mdx
+++ b/astro/src/content/docs/apis/custom-forms/_form-response-body.mdx
@@ -1,4 +1,5 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import APIField from 'src/components/api/APIField.astro';
 import JSON from 'src/components/JSON.astro';
 
@@ -29,10 +30,10 @@ import JSON from 'src/components/JSON.astro';
   <APIField name="form.type" type="String">
     The form type. The possible values are:
 
-    * `adminRegistration` - This form can be used to customize the add and edit User Registration form in the FusionAuth UI. <span class="text-green-600">Available since 1.20.0</span>
-     * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. <span class="text-green-600">Available since 1.20.0</span>
+    * `adminRegistration` - This form can be used to customize the add and edit User Registration form in the FusionAuth UI. <AvailableSince since="1.20.0" />
+     * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. <AvailableSince since="1.20.0" />
      * `registration` - This form can be used for self service registration.
-     * `selfServiceUser` - This form can be used for [Self Service Account Management](/docs/lifecycle/manage-users/account-management/). <span class="text-green-600">Available since 1.26.0</span>
+     * `selfServiceUser` - This form can be used for [Self Service Account Management](/docs/lifecycle/manage-users/account-management/). <AvailableSince since="1.26.0" />
   </APIField>
 </APIBlock>
 

--- a/astro/src/content/docs/apis/custom-forms/_forms-response-body.mdx
+++ b/astro/src/content/docs/apis/custom-forms/_forms-response-body.mdx
@@ -36,7 +36,7 @@ import JSON from 'src/components/JSON.astro';
      * `adminRegistration` - This form can be used to customize the add and edit User Registration form in the FusionAuth UI. <AvailableSince since="1.20.0" />
      * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. <AvailableSince since="1.20.0" />
      * `registration` - This form can be used for self service registration.
-    * `selfServiceUser` - This form can be used for Self Service Account Management. <span class="text-green-600">Available since 1.26.0#</span>
+    * `selfServiceUser` - This form can be used for Self Service Account Management. <AvailableSince since="1.26.0" />
   </APIField>
 </APIBlock>
 

--- a/astro/src/content/docs/apis/custom-forms/_forms-response-body.mdx
+++ b/astro/src/content/docs/apis/custom-forms/_forms-response-body.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import JSON from 'src/components/JSON.astro';
 
 #### Response Body
@@ -32,8 +33,8 @@ import JSON from 'src/components/JSON.astro';
   <APIField name="forms[x].type" type="String">
     The Form type. The possible values are:
 
-     * `adminRegistration` - This form can be used to customize the add and edit User Registration form in the FusionAuth UI. <span class="text-green-600">Available since 1.20.0</span>
-     * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. <span class="text-green-600">Available since 1.20.0</span>
+     * `adminRegistration` - This form can be used to customize the add and edit User Registration form in the FusionAuth UI. <AvailableSince since="1.20.0" />
+     * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI. <AvailableSince since="1.20.0" />
      * `registration` - This form can be used for self service registration.
     * `selfServiceUser` - This form can be used for Self Service Account Management. <span class="text-green-600">Available since 1.26.0#</span>
   </APIField>

--- a/astro/src/content/docs/apis/custom-forms/forms.mdx
+++ b/astro/src/content/docs/apis/custom-forms/forms.mdx
@@ -8,6 +8,7 @@ import PremiumPlanBlurb from 'src/content/docs/_shared/_premium-plan-blurb.astro
 import API from 'src/components/api/API.astro';
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import FormRequestBody from 'src/content/docs/apis/custom-forms/_form-request-body.mdx';
 import StandardPostResponseCodes from 'src/content/docs/apis/_standard-post-response-codes.astro';
 import FormResponseBody from 'src/content/docs/apis/custom-forms/_form-response-body.mdx';

--- a/astro/src/content/docs/apis/custom-forms/forms.mdx
+++ b/astro/src/content/docs/apis/custom-forms/forms.mdx
@@ -8,7 +8,6 @@ import PremiumPlanBlurb from 'src/content/docs/_shared/_premium-plan-blurb.astro
 import API from 'src/components/api/API.astro';
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
-import AvailableSince from 'src/components/api/AvailableSince.astro';
 import FormRequestBody from 'src/content/docs/apis/custom-forms/_form-request-body.mdx';
 import StandardPostResponseCodes from 'src/content/docs/apis/_standard-post-response-codes.astro';
 import FormResponseBody from 'src/content/docs/apis/custom-forms/_form-response-body.mdx';

--- a/astro/src/content/docs/apis/identity-providers/_facebook-post-request-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_facebook-post-request-body.mdx
@@ -1,4 +1,5 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
+import Aside from 'src/components/Aside.astro';
 import APIField from 'src/components/api/APIField.astro';
 import FacebookLoginMethodParameter from 'src/content/docs/apis/identity-providers/_facebook-login-method-parameter.mdx';
 import IdentityProviderDebugRequestParameter from 'src/content/docs/apis/identity-providers/_identity-provider-debug-request-parameter.mdx';
@@ -52,8 +53,9 @@ import JSON from 'src/components/JSON.astro';
   <APIField name="identityProvider.fields" type="String" optional defaults="email">
     The top-level fields that you are requesting from Facebook.
 
-    <p class="text-green-600">Available since 1.11.0</p>
-    The default value of `email` is now provided and stored in the database when this field is not specified.  This is a required `fields` value for retrieving the user's email address from the [Facebook Graph API](https://developers.facebook.com/docs/graph-api/using-graph-api/). Prior to this version, the value was defaulted at run-time.
+    <Aside type="version" title="Available since 1.11.0">
+      The default value of `email` is now provided and stored in the database when this field is not specified.  This is a required `fields` value for retrieving the user's email address from the [Facebook Graph API](https://developers.facebook.com/docs/graph-api/using-graph-api/). Prior to this version, the value was defaulted at run-time.
+    </Aside>
   </APIField>
   <APIField name="identityProvider.lambdaConfiguration.reconcileId" type="UUID" optional since="1.17.0">
     The unique Id of the lambda to used during the user reconcile process to map custom claims from the external identity provider to the FusionAuth user.
@@ -71,8 +73,9 @@ import JSON from 'src/components/JSON.astro';
   <APIField name="identityProvider.permissions" type="String" optional defaults="email">
     The top-level permissions that your application is asking of the user's Facebook account.
 
-    <p class="text-green-600">Available since 1.11.0</p>
-    The default value of `email` is now provided and stored in the database when this field is not specified.  This is a required `permissions` value for the [Facebook Login API](https://developers.facebook.com/docs/facebook-login/) to complete login. Prior to this version, the value not defaulted.
+    <Aside type="version" title="Available since 1.11.0">
+      The default value of `email` is now provided and stored in the database when this field is not specified.  This is a required `permissions` value for the [Facebook Login API](https://developers.facebook.com/docs/facebook-login/) to complete login. Prior to this version, the value not defaulted.
+    </Aside>
   </APIField>
 
   <IdentityProviderTenantConfiguration idp_since={props.idp_since} />

--- a/astro/src/content/docs/apis/identity-providers/_google-identity-provider-login-method-request-parameter.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_google-identity-provider-login-method-request-parameter.mdx
@@ -1,0 +1,5 @@
+import Aside from 'src/components/Aside.astro';
+
+<Aside type="version" title="Before version 1.44.0">
+If you are using a version of FusionAuth before version 1.44.0, `UsePopup` won't work. `UseRedirect` will continue to work. Please see [the 1.44.0 release notes](/docs/release-notes/#version-1-44-0) for more information. [This forum post](/community/forum/topic/2329/upcoming-google-identity-provider-changes) has more details on an available workaround and upgrade process.
+</Aside>

--- a/astro/src/content/docs/apis/identity-providers/_identity-provider-linking-strategy-request-parameter.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_identity-provider-linking-strategy-request-parameter.mdx
@@ -1,4 +1,5 @@
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 
 <APIField name="identityProvider.linkingStrategy" type="String" optional defaults={props.idp_linking_strategy} since={ props.idp_since < 12800 ?"1.28.0" : ''}>
@@ -7,6 +8,7 @@ import InlineField from 'src/components/InlineField.astro';
   The possible values are:
 
     * `CreatePendingLink` - Do not automatically link, instead return a pending link identifier that can be used to link to an existing user.
+    * `Disabled` - Disables linking automatically. You must use the API to create links. <AvailableSince since="1.37.0" />
     * `LinkAnonymously` - Always create a link based upon the unique Id returned by the identify provider. A username or email is not required and will not be used to link the user. A reconcile lambda will not be used in this configuration.
     * `LinkByEmail` - Link to an existing user based upon email. A user will be created with the email returned by the identity provider if one does not already exist.
     * `LinkByEmailForExistingUser` - Only link to an existing user based upon email. A user will not be created if one does not already exist with email returned by the identity provider.

--- a/astro/src/content/docs/apis/identity-providers/_identity-provider-linking-strategy-response-parameter.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_identity-provider-linking-strategy-response-parameter.mdx
@@ -1,4 +1,5 @@
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 import InlineField from 'src/components/InlineField.astro';
 
 <APIField name="identityProvider.linkingStrategy" type="String" optional defaults={props.idp_linking_strategy} since={ props.idp_since < 12800 ? "1.28.0" : '' }>
@@ -7,7 +8,7 @@ import InlineField from 'src/components/InlineField.astro';
   The possible values are:
 
     * `CreatePendingLink` - Create pending link.
-    * `Disabled` - Disables linking automatically. Available since `1.37.0`.
+    * `Disabled` - Disables linking automatically. <AvailableSince since="1.37.0" />
     * `LinkAnonymously` - Anonymous Link.
     * `LinkByEmail` - Link on email. Create the user if they do not exist.
     * `LinkByEmailForExistingUser` - Link on email. Do not create the user if they do not exist.

--- a/astro/src/content/docs/apis/identity-providers/_identity-provider-login-method-request-parameter.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_identity-provider-login-method-request-parameter.mdx
@@ -1,5 +1,5 @@
 import APIField from 'src/components/api/APIField.astro';
-import AvailableSince from 'src/components/api/AvailableSince.astro';
+import GoogleLoginMethodMessage from 'src/content/docs/apis/identity-providers/_google-identity-provider-login-method-request-parameter.mdx';
 
 <APIField name="identityProvider.loginMethod" type="String" optional defaults="UseRedirect" since={ props.idp_since < 12800 ? "1.28.0": ''}>
   The login method to use for this Identity Provider.
@@ -11,8 +11,6 @@ import AvailableSince from 'src/components/api/AvailableSince.astro';
    * `UseVendorJavaScript` - When logging in allow the {props.idp_display_name} JavaScript library to determine the login method.
 
   {props.idp_type === 'Google' && <>
-    <AvailableSince since="1.44.0" /><br/>
-
-    <strong>If you are using a version of FusionAuth older than 1.44.0</strong>, <code>UsePopup</code> won't work. <code>UseRedirect</code> will continue to work. Please see <a href="/docs/release-notes/#version-1-44-0">the 1.44.0 release notes</a> for more information. This <a href="/community/forum/topic/2329/upcoming-google-identity-provider-changes">forum post</a> has more details on an available workaround and upgrade process.
+    <GoogleLoginMethodMessage />
   </>}
 </APIField>

--- a/astro/src/content/docs/apis/identity-providers/_identity-provider-login-method-request-parameter.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_identity-provider-login-method-request-parameter.mdx
@@ -1,4 +1,5 @@
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 
 <APIField name="identityProvider.loginMethod" type="String" optional defaults="UseRedirect" since={ props.idp_since < 12800 ? "1.28.0": ''}>
   The login method to use for this Identity Provider.
@@ -10,7 +11,8 @@ import APIField from 'src/components/api/APIField.astro';
    * `UseVendorJavaScript` - When logging in allow the {props.idp_display_name} JavaScript library to determine the login method.
 
   {props.idp_type === 'Google' && <>
-    <span class="text-green-600">Since 1.44.0</span> <br/>
-    <strong>If you are using a version of FusionAuth older than 1.44.0</strong>, <code>UsePopup</code> won't work. <code>UseRedirect</code> will continue to work after this date. Please see [the 1.44.0 release notes](/docs/release-notes/#version-1-44-0) for more information. This [forum post](/community/forum/topic/2329/upcoming-google-identity-provider-changes) has more details on an available workaround and upgrade process.
+    <AvailableSince since="1.44.0" /><br/>
+
+    <strong>If you are using a version of FusionAuth older than 1.44.0</strong>, <code>UsePopup</code> won't work. <code>UseRedirect</code> will continue to work. Please see <a href="/docs/release-notes/#version-1-44-0">the 1.44.0 release notes</a> for more information. This <a href="/community/forum/topic/2329/upcoming-google-identity-provider-changes">forum post</a> has more details on an available workaround and upgrade process.
   </>}
 </APIField>

--- a/astro/src/content/docs/apis/identity-providers/_oauth-idp-request-body.mdx
+++ b/astro/src/content/docs/apis/identity-providers/_oauth-idp-request-body.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import Aside from 'src/components/Aside.astro';
 import InlineField from 'src/components/InlineField.astro';
 import JSON from 'src/components/JSON.astro';
 import IdentityProviderTenantConfiguration from 'src/content/docs/apis/identity-providers/_identity-provider-tenant-configuration.mdx';
@@ -21,8 +22,9 @@ import IdentityProviderLoginMethodRequestParameter from 'src/content/docs/apis/i
     This is an optional Application specific override for the top level <InlineField>buttonText</InlineField>.
 
     {props.idp_type === 'Google' && <>
-      <p class="text-green-600">Since 1.44.0</p>
-      The <InlineField>identityProvider.applicationConfiguration[applicationId].buttonText</InlineField> value may only be used when the <InlineField>identityProvider.loginMethod</InlineField> is set to <code>UseRedirect</code>. The button text is managed by Google for all other configurations. Google allows for minor adjustments using their API. You may specify any valid API parameter in the <InlineField>identityProvider.properties.button</InlineField> configuration.
+      <Aside type="version" title="Since 1.44.0">
+        The <InlineField>identityProvider.applicationConfiguration[applicationId].buttonText</InlineField> value may only be used when the <InlineField>identityProvider.loginMethod</InlineField> is set to <code>UseRedirect</code>. The button text is managed by Google for all other configurations. Google allows for minor adjustments using their API. You may specify any valid API parameter in the <InlineField>identityProvider.properties.button</InlineField> configuration.
+      </Aside>
     </>}
   </APIField>
   <APIField name="identityProvider.applicationConfiguration[applicationId].client_id" type="String" optional>
@@ -48,14 +50,16 @@ import IdentityProviderLoginMethodRequestParameter from 'src/content/docs/apis/i
 
     If this Application's <InlineField>loginMethod</InlineField> is set to <code>UsePopup</code>, or the Application configuration is unset and the top level <InlineField>loginMethod</InlineField> is set to <code>UsePopup</code>, and this value contains the conflicting <code>ux_mode=redirect</code> property, that single property will be replaced with <code>ux_mode=popup</code>.
 
-    <p class="text-green-600">Since 1.45.1</p>
-    The properties specified in this field will override individual properties on the top level <InlineField>properties.api</InlineField> rather than overriding the entire <InlineField>properties.api</InlineField> value.
+    <Aside type="version" title="Since 1.45.1">
+      The properties specified in this field will override individual properties on the top level <InlineField>properties.api</InlineField> rather than overriding the entire <InlineField>properties.api</InlineField> value.
+    </Aside>
   </APIField>
   <APIField name="identityProvider.applicationConfiguration[applicationId].properties.button" type="String" optional since="1.44.0">
     This is an optional Application specific override for the top level <InlineField>properties.button</InlineField>.
 
-    <p class="text-green-600">Since 1.45.1</p>
-    The properties specified in this field will override individual properties on the top level <InlineField>properties.button</InlineField> rather than overriding the entire <InlineField>properties.button</InlineField> value.
+    <Aside type="version" title="Since 1.45.1">
+      The properties specified in this field will override individual properties on the top level <InlineField>properties.button</InlineField> rather than overriding the entire <InlineField>properties.button</InlineField> value.
+    </Aside>
   </APIField>
 
   </>}
@@ -64,8 +68,9 @@ import IdentityProviderLoginMethodRequestParameter from 'src/content/docs/apis/i
     This is an optional Application specific override for the top level <InlineField>scope</InlineField>.
 
     { props.idp_type === 'Google' && <>
-      <p class="text-green-600">Since 1.44.0</p>
-      The <InlineField>identityProvider.applicationConfiguration[applicationId].scope</InlineField> value may only be used when the <InlineField>identityProvider.loginMethod</InlineField> is set to <code>UseRedirect</code>. The <code>email</code>, <code>profile</code>, and <code>openid</code> scopes will always be requested for all other configurations.
+      <Aside type="version" title="Since 1.44.0">
+        The <InlineField>identityProvider.applicationConfiguration[applicationId].scope</InlineField> value may only be used when the <InlineField>identityProvider.loginMethod</InlineField> is set to <code>UseRedirect</code>. The <code>email</code>, <code>profile</code>, and <code>openid</code> scopes will always be requested for all other configurations.
+      </Aside>
     </>}
   </APIField>
 
@@ -87,8 +92,9 @@ import IdentityProviderLoginMethodRequestParameter from 'src/content/docs/apis/i
     The top-level button text to use on the FusionAuth login page for this Identity Provider.
 
     { props.idp_type === 'Google' && <>
-      <p class="text-green-600">Since 1.44.0</p>
-      The <InlineField>identityProvider.buttonText</InlineField> value may only be used when the <InlineField>identityProvider.loginMethod</InlineField> is set to <code>UseRedirect</code>. The button text is managed by Google for all other configurations. Google allows for minor adjustments using their API. You may specify any valid API parameter in the <InlineField>identityProvider.properties.button</InlineField> configuration.
+      <Aside type="version" title="Since 1.44.0">
+        The <InlineField>identityProvider.buttonText</InlineField> value may only be used when the <InlineField>identityProvider.loginMethod</InlineField> is set to <code>UseRedirect</code>. The button text is managed by Google for all other configurations. Google allows for minor adjustments using their API. You may specify any valid API parameter in the <InlineField>identityProvider.properties.button</InlineField> configuration.
+      </Aside>
     </>}
   </APIField>
   <APIField name="identityProvider.client_id" type="String" required>
@@ -156,8 +162,9 @@ import IdentityProviderLoginMethodRequestParameter from 'src/content/docs/apis/i
     The top-level scope that you are requesting from {props.idp_display_name}.
 
     { props.idp_type === 'Google' && <>
-      <p class="text-green-600">Since 1.44.0</p>
-      The <InlineField>identityProvider.scope</InlineField> value may only be used when the <InlineField>identityProvider.loginMethod</InlineField> is set to <code>UseRedirect</code>. The <code>email</code>, <code>profile</code>, and <code>openid</code> scopes will always be requested for all other configurations.
+      <Aside type="version" title="Since 1.44.0">
+        The <InlineField>identityProvider.scope</InlineField> value may only be used when the <InlineField>identityProvider.loginMethod</InlineField> is set to <code>UseRedirect</code>. The <code>email</code>, <code>profile</code>, and <code>openid</code> scopes will always be requested for all other configurations.
+      </Aside>
     </>}
   </APIField>
 

--- a/astro/src/content/docs/apis/users.mdx
+++ b/astro/src/content/docs/apis/users.mdx
@@ -806,9 +806,9 @@ If FusionAuth sends an email to the user, it will either use the `email` top lev
   <APIField name="sendForgotPasswordEmail" type="Boolean" optional defaults="true">
     Whether or not calling this API should attempt to send the user an email using the configured Forgot Password email template. Setting this to `false` will begin the Forgot Password workflow without sending an email and only create the `changePasswordId`, this may be useful if you want to send an email outside of FusionAuth, or complete this workflow without the use of email.
 
-    <span class="text-green-800">Since 1.43.0</span>
-
-    Beginning in version `1.43.0`, when setting this to `false` you will not be required to have configured the Forgot Password email template in the FusionAuth tenant. Prior to this version, even when setting this to `false` the Tenant would be required to have configured the Forgot Password email template.
+    <Aside type="version" title="1.43.0">
+      When setting this to `false` you will not be required to have configured the Forgot Password email template in the FusionAuth tenant. Prior to `1.43.0`, even when setting this to `false`, the Tenant would be required to have configured the Forgot Password email template.
+    </Aside>
   </APIField>
   <APIField name="state" type="Object" optional>
     An optional object that will be returned un-modified when you complete the forgot password request. This may be useful to return the user to particular state once they complete the password change.

--- a/astro/src/content/docs/apis/users.mdx
+++ b/astro/src/content/docs/apis/users.mdx
@@ -806,7 +806,7 @@ If FusionAuth sends an email to the user, it will either use the `email` top lev
   <APIField name="sendForgotPasswordEmail" type="Boolean" optional defaults="true">
     Whether or not calling this API should attempt to send the user an email using the configured Forgot Password email template. Setting this to `false` will begin the Forgot Password workflow without sending an email and only create the `changePasswordId`, this may be useful if you want to send an email outside of FusionAuth, or complete this workflow without the use of email.
 
-    <Aside type="version" title="1.43.0">
+    <Aside type="version" title="Available since 1.43.0">
       When setting this to `false` you will not be required to have configured the Forgot Password email template in the FusionAuth tenant. Prior to `1.43.0`, even when setting this to `false`, the Tenant would be required to have configured the Forgot Password email template.
     </Aside>
   </APIField>


### PR DESCRIPTION
removed all span tags that were version related and replaced with Astro components.

documented suggestion here: https://github.com/FusionAuth/fusionauth-site/pull/3664#discussion_r2051037464 as standard for larger since paragraphs.

Superset of changes in https://github.com/FusionAuth/fusionauth-site/pull/3664
