### PR TITLE
Add scopes to the example authorization code grant

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
@@ -586,7 +586,7 @@ Ensure you are sending these parameters as form encoded data in the request body
     This parameter may contain multiple scopes space separated.
     For example, the value of `openid offline_access` provides two scopes on the request.
 
-    Available grant types:
+    Available scopes:
 
     * `openid` - This scope is used to request an `id_token` be returned in the response
     * `offline_access` - This scope scope is used to request a `refresh_token` be returned in the response

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
@@ -48,7 +48,7 @@ This is an implementation of the Authorization endpoint as defined by the [IETF 
 
 To begin the Authorization Code Grant you will redirect to the Authorization endpoint from your application.
 
-<API method="GET" uri="/oauth2/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type=code&tenantId={tenantId}"/>
+<API method="GET" uri="/oauth2/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type=code&tenantId={tenantId}&scope=openid%20offline_access%20profile%20email"/>
 
 #### Request Parameters
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
@@ -118,7 +118,7 @@ To begin the Authorization Code Grant you will redirect to the Authorization end
   </APIField>
   <APIField name="scope" type="String" optional>
     If you are using OpenID Connect, the request must contain this parameter and at minimum it must contain `openid`.
-    This parameter may contain multiple scopes space separated.
+    This parameter may contain multiple space separated scopes.
     For example, the value of `openid offline_access` provides two scopes on the request.
 
     Example scopes which modify the behavior of the endpoint:
@@ -583,7 +583,7 @@ Ensure you are sending these parameters as form encoded data in the request body
   </APIField>
   <APIField name="scope" type="String" optional>
     The optional scope you are requesting during this grant.
-    This parameter may contain multiple scopes space separated.
+    This parameter may contain multiple space separated scopes.
     For example, the value of `openid offline_access` provides two scopes on the request.
 
     Available scopes:

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/endpoints.mdx
@@ -121,10 +121,12 @@ To begin the Authorization Code Grant you will redirect to the Authorization end
     This parameter may contain multiple scopes space separated.
     For example, the value of `openid offline_access` provides two scopes on the request.
 
-    These scopes modify the behavior of the endpoint:
+    Example scopes which modify the behavior of the endpoint:
 
     * `openid` - This scope is used to request an `id_token` be returned in the response
     * `offline_access` - This scope is used to request a `refresh_token` be returned in the response
+
+    [Learn more about scopes, including custom scopes.](/docs/lifecycle/authenticate-users/oauth/scopes)
   </APIField>
   <APIField name="state" type="String" optional>
     The optional state parameter. This is generally used as a Cross Site Request Forgery (CSRF) token or to provide deeplinking support.

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/scopes.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/scopes.mdx
@@ -57,7 +57,7 @@ The following table describes the differences between the two options in more de
 The `Strict` policy uses the requested and consented OAuth scopes to determine which claims to add to the Id token and UserInfo response. The `address`, `email`, `profile`, and `phone` scopes are [provided by FusionAuth](#provided-scopes) and are used to populate claims according to available user data and [Section 5.4 of the OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims).
 
 * `address` - FusionAuth does not include physical addresses in its user data model. A lambda could be used to populate the `address` claim based on custom user data.
-* `email` - populates the `email` and `email_verified` claims
+* `email` - Populates the `email` and `email_verified` claims.
 * `phone` - Populates the `phone_number` claim based on the user's `mobilePhone` value. FusionAuth does not verify phone numbers, so the `phone_number_verified` claim is not included.
 * `profile` - Populates various profile-related data. The following describes how each claim maps to FusionAuth user data.
 


### PR DESCRIPTION
Added some more details and links to the scopes section of the authorization code grant, also fixed a typo or two.