### PR TITLE
parseContent is now async, so we need to wait for it

### DIFF
--- a/astro/src/layouts/Blog.astro
+++ b/astro/src/layouts/Blog.astro
@@ -34,8 +34,8 @@ const featuredCategory = frontmatter.featured_category ? frontmatter.featured_ca
 
 const collection = await getCollection<BlogContent>('blog');
 
-const relatedPosts = mapRelated(collection, 'categories', featuredCategory, slug);
-const relatedTags = mapRelated(collection, 'tags', featuredTag, slug);
+const relatedPosts = await mapRelated(collection, 'categories', featuredCategory, slug);
+const relatedTags = await mapRelated(collection, 'tags', featuredTag, slug);
 
 const searchFilters = {
   author: authors,

--- a/astro/src/tools/blog/mapRelated.ts
+++ b/astro/src/tools/blog/mapRelated.ts
@@ -12,12 +12,12 @@ type MetaSection = "categories" | "authors" | "tags";
  * @param target the target metaSection value to filter for
  * @param currentSlug the current post to exclude from the results
  */
-export const mapRelated = (collection: BlogContent[], metaSection: MetaSection, target: string, currentSlug: string): ParsedBlog[] =>
-    collection ? collection
+export const mapRelated = async (collection: BlogContent[], metaSection: MetaSection, target: string, currentSlug: string): Promise<ParsedBlog[]> =>
+    collection ? Promise.all(collection
         .filter(blog => blog.data
             && blog.data[metaSection]
             && blog.data[metaSection].split(',').includes(target)
             && blog.slug !== currentSlug)
         .sort(sortByDate)
         .slice(0, 3)
-        .map(parseContent) : [];
+        .map(parseContent)) : [];


### PR DESCRIPTION
This caused an issue for our related tags on our blog posts.

https://inversoft.slack.com/archives/C02H35R1Q6N/p1745347825985119 has more details.