### PR TITLE
removing google analytics

### DIFF
--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -89,14 +89,6 @@ const slug = Astro.params.slug;
   {searchFilters && <SearchFilter filters={searchFilters} />}
 
   {isProd && enableGTM &&
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MZ9FDPFDF0"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-MZ9FDPFDF0');
-    </script>
     <!-- Google tag manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
we'll add this to GTM

Per https://support.google.com/analytics/answer/9304153?hl=en the gtag stuff is for installing GA4 directly, not using GTM.