### PR TITLE
clarify saml populate lambda doc

### DIFF
--- a/astro/src/content/docs/extend/code/lambdas/samlv2-response-populate.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/samlv2-response-populate.mdx
@@ -8,7 +8,7 @@ tertcategory: lambdas
 ---
 import SamlResponseFields from 'src/content/docs/extend/code/lambdas/_saml-response-fields.mdx';
 
-In order to handle complex integrations with SAML service providers, you can specify a lambda to be used by the FusionAuth SAML identity provider. This lambda will be invoked prior to the SAML response being sent back to the service provider.
+In order to handle complex integrations with SAML service providers, you can specify a lambda to be used by a FusionAuth application acting as SAML identity provider (IdP). This lambda will be invoked prior to the SAML response being sent back to the service provider.
 
 When you create a new lambda using the FusionAuth UI we will provide you an empty function for you to implement.
 


### PR DESCRIPTION
It was unclear if we were talking about the SAML identity provider/IdP or the fusionauth Identity Provider concept, so I made it more clear.