### PR TITLE
generates markdown page for all docs

### DIFF
--- a/astro/astro.config.ts
+++ b/astro/astro.config.ts
@@ -6,6 +6,7 @@ import tailwind from "@astrojs/tailwind";
 import indexPages from "astro-index-pages/index.js";
 import {rehypeTasklistEnhancer} from './src/plugins/rehype-tasklist-enhancer';
 import {codeTitleRemark} from './src/plugins/code-title-remark';
+import * as markdownExtract from './src/plugins/markdown-extract.js';
 import remarkMdx from 'remark-mdx';
 
 const optionalIntegrations = [];
@@ -35,6 +36,8 @@ const config = defineConfig({
       applyBaseStyles: true,
       nesting: true,
     })
+    ,
+    markdownExtract.default()
   ],
   markdown: {
     remarkPlugins: [

--- a/astro/public/js/CopyMarkdownToClipboard-0.0.1.js
+++ b/astro/public/js/CopyMarkdownToClipboard-0.0.1.js
@@ -1,0 +1,38 @@
+'use strict';
+
+class CopyMarkdownToClipboard {
+  constructor() {
+    console.log("in constructor");
+    document.addEventListener('click', event => this.#handleClick(event));
+  }
+
+  async #handleClick(event) {
+    console.log("in click");
+    const button = event.target;
+    const href = button.getAttribute('data-href');
+    console.log(href);
+
+    try {
+      const response = await fetch(href);
+      if (!response.ok) throw new Error('Failed to fetch file');
+  
+      const text = await response.text();
+  
+      await navigator.clipboard.writeText(text);
+      button.textContent = 'Copied';
+  
+      // Optionally reset button text after 2 seconds
+      setTimeout(() => {
+        button.textContent = 'Copy File Contents';
+      }, 2000);
+    } catch (err) {
+      console.error('Error copying file contents:', err);
+      button.textContent = 'Failed';
+      setTimeout(() => {
+        button.textContent = 'Copy File Contents';
+      }, 2000);
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => new CopyMarkdownToClipboard());

--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -70,6 +70,7 @@ const slug = Astro.params.slug;
     </>
   }
   <script src="/js/CopyToClipboard-0.2.4.js" type="text/javascript"></script>
+  <script src="/js/CopyMarkdownToClipboard-0.0.1.js" type="text/javascript"></script>
   <script src="/js/Search-0.2.3.js" type="text/javascript"></script>
   <script src="/js/ScrollSpy-0.1.0.js" type="text/javascript"></script>
   <script src="/js/Tabs-0.1.0.js" type="text/javascript"></script>

--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -18,6 +18,7 @@ interface Props {
   author?: string;
   date?: string;
   description?: string;
+  copyMarkdown?: boolean;
   disableTOC?: boolean;
   excludeFromSearchIndex?: boolean,
   frontmatter?: Record<string, any>,
@@ -38,6 +39,7 @@ interface Props {
 
 let {
   author,
+  copyMarkdown = false,
   date,
   description = "Looks like the developers forgot to include a description for this page. Sorry about that.",
   disableTOC,
@@ -120,6 +122,11 @@ const sideNavStyles = [
 const tocStyles = [
   "bottom-0 hidden overflow-y-auto pb-10 pt-0 xl:block w-full max-w-[240px] ml-6 sticky top-24 self-start overflow-y-auto lg:max-h-[calc(100vh-100px)] z-10"
 ];
+
+// used for copying markdown only
+const path = Astro.url.pathname;
+const fullMarkdownPath = path.replace(/.html$/,'.mdx');
+
 ---
 
 <!DOCTYPE html>
@@ -180,6 +187,10 @@ const tocStyles = [
 
           {breadcrumbs.length === 0 && section && <p class="font-semibold mb-4 mt-0 text-indigo-700 text-lg dark:text-indigo-500">{ specialCaps(section) }</p>}
           <h1 data-pagefind-meta="title" class:list={["text-3xl", image ? "mt-16" : "", author ? "mb-0" : ""]}>{title}</h1>
+          {copyMarkdown &&
+            <button class="bg-orange-500 font-bold hover:bg-orange-600 ml-3 px-3 py-2 rounded text-white text-xs tracking-tighter transition-colors uppercase lg:font-extrabold" id="copyBtn" data-href={fullMarkdownPath}>Copy File Contents</button>
+          }
+
           {author &&
             <p class="m-0 text-sm">By {author} {date && <span>- {new Date(date).toDateString()}</span>}</p>
           }

--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -188,7 +188,7 @@ const fullMarkdownPath = path.replace(/.html$/,'.mdx');
           {breadcrumbs.length === 0 && section && <p class="font-semibold mb-4 mt-0 text-indigo-700 text-lg dark:text-indigo-500">{ specialCaps(section) }</p>}
           <h1 data-pagefind-meta="title" class:list={["text-3xl", image ? "mt-16" : "", author ? "mb-0" : ""]}>{title}</h1>
           {copyMarkdown &&
-            <button class="bg-orange-500 font-bold hover:bg-orange-600 ml-3 px-3 py-2 rounded text-white text-xs tracking-tighter transition-colors uppercase lg:font-extrabold" id="copyBtn" data-href={fullMarkdownPath}>Copy File Contents</button>
+            <button class="bg-orange-500 font-bold hover:bg-orange-600 ml-3 px-3 py-2 rounded text-white text-xs tracking-tighter transition-colors uppercase lg:font-extrabold" id="copyBtn" data-href={fullMarkdownPath}>Copy as Markdown for LLMs</button>
           }
 
           {author &&

--- a/astro/src/layouts/Docs.astro
+++ b/astro/src/layouts/Docs.astro
@@ -34,6 +34,7 @@ if (frontmatter.subcategory) {
 <Default {frontmatter}
          {headings}
          cta="NONE"
+         copyMarkdown=true
          contribute={false}
          {breadcrumbs}
          {openGraphImage}

--- a/astro/src/plugins/markdown-extract.js
+++ b/astro/src/plugins/markdown-extract.js
@@ -1,0 +1,96 @@
+// src/plugins/markdown-extract.ts
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function walk(dir, extFilter = ['.md', '.mdx']) {
+  const results = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    // console.log('processing: '+entry.name);
+
+    if (entry.isDirectory()) {
+      results.push(...walk(fullPath, extFilter));
+    } else if (!entry.name.startsWith('_') && extFilter.includes(path.extname(entry.name))) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+async function renderAstroComponent(filePath) {
+  const content = await fs.readFile(filePath, "utf8");
+  return content.replace(/^---[\s\S]*?---/, "").trim();
+}
+
+function shouldInline(importPath) {
+  return (
+    importPath.startsWith("src/content") ||
+    importPath.startsWith("src/diagrams")
+  );
+}
+
+const importRegex = /^\s*import\s+.*?['"](.+?\.mdx?)['"]\s*;?\s*$/gm;
+
+/**
+ * Recursively inlines imports from .md/.mdx files
+ * @param {string} filePath - Absolute path to the initial file
+ * @param {Set<string>} seen - Tracks files already inlined to avoid cycles
+ * @returns {string} - Final inlined content
+ */
+function inlineMarkdownImports(filePath, seen = new Set()) {
+  if (seen.has(filePath)) {
+    console.warn(`Skipping already inlined file: ${filePath}`);
+    return '';
+  }
+
+  seen.add(filePath);
+
+  let content = fs.readFileSync(filePath, 'utf-8');
+
+  content = content.replace(importRegex, (match, importPath) => {
+    const baseDir = "";
+    const resolvedPath = path.resolve(baseDir, importPath);
+    console.log(resolvedPath);
+
+    if (!fs.existsSync(resolvedPath)) {
+      console.warn(`Import not found: ${resolvedPath}`);
+      return `<!-- Missing import: ${importPath} -->`;
+    }
+
+    const inlined = inlineMarkdownImports(resolvedPath, seen);
+    return `<!-- Inlined from ${importPath} -->\n${inlined}`;
+  });
+
+  return content;
+}
+
+
+export default function markdownExtractIntegration() {
+  const pageMap = new Map(); // Map pathname -> file path
+  return {
+    name: 'markdown-extract',
+    hooks: {
+      'astro:build:done': async ({ dir }) => {
+        console.log('Copying content collection entries...');
+        const contentDir = path.resolve('./src/content/docs');
+        const contentFiles = walk(contentDir);
+
+        for (const file of contentFiles) {
+          // console.log(file);
+          const relPath = path.relative(contentDir, file);
+          const outPath = path.join(dir.pathname || dir,'docs', relPath);
+          const inlinedContent = inlineMarkdownImports(file);
+
+          fs.mkdirSync(path.dirname(outPath), { recursive: true });
+          fs.writeFileSync(outPath, inlinedContent, 'utf-8');
+          // fs.copyFileSync(file, outPath);
+          console.log(`Wrote content: ${relPath}`);
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
It is really nice to be able to copy markdown into an LLM and ask for a summary or otherwise manipulate it.

This does a couple of things:

* post build, copies over doc files (inlining components under src/content and src/diagrams) to the same file with the suffix mdx
* adds a copy button to all docs pages
* adds a new js file with the copy javascript. It didn't feel appropriate to put it into our existing copytoclipboard object as they do different things (could be wrong though)

I checked the publish workflows and they copy everything under dist so we should be good with that. The content won't get indexed because it isn't linked anywhere.


### TODO

I'm sure the copy button is too orange, so will ask Sean to weigh in on the design aspect

I want to add a google analytics event so we know if this is being used.