### PR TITLE
updated to work with safari

### DIFF
--- a/astro/src/tools/docs/copyMarkdownToClipboard.js
+++ b/astro/src/tools/docs/copyMarkdownToClipboard.js
@@ -1,21 +1,20 @@
-document.querySelector('#copy-docs-markdown-llm-button').addEventListener('click',async event => {
+document.querySelector('#copy-docs-markdown-llm-button').addEventListener('click', async event => {
   const button = event.currentTarget;
   const href = button.dataset.href;
   const resetTextMS = 2000;
-
-  // if you change this, change the initial value in the astro component as well
   const btnText = 'Copy as Markdown for LLMs';
 
   try {
-    const response = await fetch(href);
-    if (!response.ok) throw new Error('Failed to fetch file');
+    // Create the clipboard item immediately within the user gesture
+    const clipboardItem = new ClipboardItem({
+      'text/plain': fetch(href).then(async response => {
+        if (!response.ok) throw new Error('Failed to fetch file');
+        return response.text();
+      })
+    });
 
-    const text = await response.text();
-
-    await navigator.clipboard.writeText(text);
+    await navigator.clipboard.write([clipboardItem]);
     button.textContent = 'Copied';
-
-    // Optionally reset button text after 2 seconds
     setTimeout(() => {
       button.textContent = btnText;
     }, resetTextMS);


### PR DESCRIPTION
When using the copy to markdown button on the live site with safari, it was failing.

Was getting the console error message "NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission." And the button changes to a value of "failed".

<img width="274" alt="Screenshot 2025-06-09 at 4 01 10 PM" src="https://github.com/user-attachments/assets/a55ede5e-9efd-4e2a-99c2-e5f529635030" />

Apparently restructuring this JS to have the fetch inside the clipboard item create satisfies safari.

Testing locally with:
- FF
- chrome
- safari