### PR TITLE
ENG-1677 - Passwordless send phone rate limiting

### DIFF
--- a/astro/src/content/docs/apis/_tenant-request-body.mdx
+++ b/astro/src/content/docs/apis/_tenant-request-body.mdx
@@ -938,7 +938,7 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
   </APIField>
 
   <APIField name="tenant.rateLimitConfiguration.sendPasswordlessPhone.timePeriodInSeconds" type="Integer" optional defaults="60" since="1.99.9">
-    The duration for the number of times a user can request a passwordless login message before being rate limited.
+    The duration for the number of times a user can request a passwordless login SMS message before being rate limited.
 
     Required when `enabled` is set to `true`.
 

--- a/astro/src/content/docs/apis/_tenant-request-body.mdx
+++ b/astro/src/content/docs/apis/_tenant-request-body.mdx
@@ -897,7 +897,7 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
   </APIField>
 
   <APIField name="tenant.rateLimitConfiguration.sendPasswordless.enabled" type="Boolean" optional defaults="false" since="1.30.0">
-    Whether rate limiting is enabled for send passwordless via email.
+    Whether rate limiting is enabled for sending passwordless login links/codes via email.
 
     <EnterprisePlanBlurbApi feature="rate limiting" />
 
@@ -922,7 +922,7 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
   </APIField>
 
   <APIField name="tenant.rateLimitConfiguration.sendPasswordlessPhone.enabled" type="Boolean" optional defaults="false" since="1.99.9">
-    Whether rate limiting is enabled for send passwordless via phone.
+    Whether rate limiting is enabled for sending passwordless login links/codes via SMS.
 
     <EnterprisePlanBlurbApi feature="rate limiting" />
 

--- a/astro/src/content/docs/apis/_tenant-request-body.mdx
+++ b/astro/src/content/docs/apis/_tenant-request-body.mdx
@@ -929,7 +929,7 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
   </APIField>
 
   <APIField name="tenant.rateLimitConfiguration.sendPasswordlessPhone.limit" type="Integer" optional defaults="5" since="1.99.9">
-    The number of times a user can request a passwordless login message within the configured <InlineField>timePeriodInSeconds</InlineField> duration.
+    The number of times a user can request a passwordless login SMS message within the configured <InlineField>timePeriodInSeconds</InlineField> duration.
 
     Required when `enabled` is set to `true`.
 

--- a/astro/src/content/docs/apis/_tenant-request-body.mdx
+++ b/astro/src/content/docs/apis/_tenant-request-body.mdx
@@ -897,7 +897,7 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
   </APIField>
 
   <APIField name="tenant.rateLimitConfiguration.sendPasswordless.enabled" type="Boolean" optional defaults="false" since="1.30.0">
-    Whether rate limiting is enabled for send passwordless.
+    Whether rate limiting is enabled for send passwordless via email.
 
     <EnterprisePlanBlurbApi feature="rate limiting" />
 
@@ -920,6 +920,32 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
     <EnterprisePlanBlurbApi feature="rate limiting" />
 
   </APIField>
+
+  <APIField name="tenant.rateLimitConfiguration.sendPasswordlessPhone.enabled" type="Boolean" optional defaults="false" since="1.99.9">
+    Whether rate limiting is enabled for send passwordless via phone.
+
+    <EnterprisePlanBlurbApi feature="rate limiting" />
+
+  </APIField>
+
+  <APIField name="tenant.rateLimitConfiguration.sendPasswordlessPhone.limit" type="Integer" optional defaults="5" since="1.99.9">
+    The number of times a user can request a passwordless login message within the configured <InlineField>timePeriodInSeconds</InlineField> duration.
+
+    Required when `enabled` is set to `true`.
+
+    <EnterprisePlanBlurbApi feature="rate limiting" />
+
+  </APIField>
+
+  <APIField name="tenant.rateLimitConfiguration.sendPasswordlessPhone.timePeriodInSeconds" type="Integer" optional defaults="60" since="1.99.9">
+    The duration for the number of times a user can request a passwordless login message before being rate limited.
+
+    Required when `enabled` is set to `true`.
+
+    <EnterprisePlanBlurbApi feature="rate limiting" />
+
+  </APIField>
+
 
   <APIField name="tenant.rateLimitConfiguration.sendPhoneVerification.enabled" type="Boolean" optional defaults="false" since="1.99.9">
     Whether rate limiting is enabled for send phone verification.

--- a/astro/src/content/docs/apis/_tenant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_tenant-response-body-base.mdx
@@ -722,6 +722,14 @@ import JSON from 'src/components/JSON.astro';
     The duration for the number of times a user can request a passwordless login email before being rate limited.
   </APIField>
 
+  <APIField name={props.base_field_name + '.rateLimitConfiguration.sendPasswordlessPhone.limit'} type="Integer" since="1.99.9">
+    The number of times a user can request a passwordless login message within the configured <InlineField>timePeriodInSeconds</InlineField> duration.
+  </APIField>
+
+  <APIField name={props.base_field_name + '.rateLimitConfiguration.sendPasswordlessPhone.timePeriodInSeconds'} type="Integer" since="1.99.9">
+    The duration for the number of times a user can request a passwordless login message before being rate limited.
+  </APIField>
+
   <APIField name={props.base_field_name + '.rateLimitConfiguration.sendPhoneVerification.limit'} type="Integer" since="1.99.9">
     The number of times a user can request a phone verification message within the configured <InlineField>timePeriodInSeconds</InlineField> duration.
   </APIField>

--- a/astro/src/content/docs/apis/_tenant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_tenant-response-body-base.mdx
@@ -727,7 +727,7 @@ import JSON from 'src/components/JSON.astro';
   </APIField>
 
   <APIField name={props.base_field_name + '.rateLimitConfiguration.sendPasswordlessPhone.timePeriodInSeconds'} type="Integer" since="1.99.9">
-    The duration for the number of times a user can request a passwordless login message before being rate limited.
+    The duration for the number of times a user can request a passwordless login SMS message before being rate limited.
   </APIField>
 
   <APIField name={props.base_field_name + '.rateLimitConfiguration.sendPhoneVerification.limit'} type="Integer" since="1.99.9">

--- a/astro/src/content/docs/apis/_tenant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_tenant-response-body-base.mdx
@@ -723,7 +723,7 @@ import JSON from 'src/components/JSON.astro';
   </APIField>
 
   <APIField name={props.base_field_name + '.rateLimitConfiguration.sendPasswordlessPhone.limit'} type="Integer" since="1.99.9">
-    The number of times a user can request a passwordless login message within the configured <InlineField>timePeriodInSeconds</InlineField> duration.
+    The number of times a user can request a passwordless login SMS message within the configured <InlineField>timePeriodInSeconds</InlineField> duration.
   </APIField>
 
   <APIField name={props.base_field_name + '.rateLimitConfiguration.sendPasswordlessPhone.timePeriodInSeconds'} type="Integer" since="1.99.9">

--- a/astro/src/content/json/tenants/request.json
+++ b/astro/src/content/json/tenants/request.json
@@ -354,6 +354,11 @@
         "limit": 5,
         "timePeriodInSeconds": 60
       },
+      "sendPasswordlessPhone": {
+        "enabled": false,
+        "limit": 5,
+        "timePeriodInSeconds": 60
+      },
       "sendPhoneVerification": {
         "enabled": false,
         "limit": 5,

--- a/astro/src/content/json/tenants/response.json
+++ b/astro/src/content/json/tenants/response.json
@@ -364,6 +364,11 @@
         "limit": 5,
         "timePeriodInSeconds": 60
       },
+      "sendPasswordlessPhone": {
+        "enabled": false,
+        "limit": 5,
+        "timePeriodInSeconds": 60
+      },
       "sendPhoneVerification": {
         "enabled": false,
         "limit": 5,

--- a/astro/src/content/json/tenants/responses.json
+++ b/astro/src/content/json/tenants/responses.json
@@ -362,6 +362,11 @@
           "limit": 5,
           "timePeriodInSeconds": 60
         },
+        "sendPasswordlessPhone": {
+          "enabled": false,
+          "limit": 5,
+          "timePeriodInSeconds": 60
+        },
         "sendPhoneVerification": {
           "enabled": false,
           "limit": 5,


### PR DESCRIPTION
13a5d122e131eafba2aa4da5c4f6266b6f11ae71 covered the screenshots already. Used the PR for that as a baseline.

Author notes: We did not include any of these settings in the tenant search response. Was that intentional?