### PR TITLE
fixed issue with identity provider sequence diagram

### DIFF
--- a/astro/src/diagrams/docs/get-started/core-concepts/integration-points/oauth-grant-with-federation.astro
+++ b/astro/src/diagrams/docs/get-started/core-concepts/integration-points/oauth-grant-with-federation.astro
@@ -22,6 +22,8 @@ sequenceDiagram
     FusionAuth ->> User : Return Login Page
     User ->> FusionAuth : Clicks On 'Login With ${idpName}'
     FusionAuth ->> User : Redirect To Identity Provider Authorization URL
+    User ->> IdentityProvider : Request Login Page
+    IdentityProvider ->> User : Return Login Page
     User ->> IdentityProvider : Enter Credentials
     IdentityProvider ->> IdentityProvider : Validate Credentials
     IdentityProvider ->> User : Redirect To FusionAuth With ${idpName} Authorization Code


### PR DESCRIPTION
we don't show the identity provider login page request/response.

This diagram is present on these pages:

http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/gaming/steam
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/gaming/nintendo
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/gaming/epic-games
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/gaming/sony
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/gaming/twitch
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/gaming/xbox
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/gaming/discord
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/enterprise/okta-oidc
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/enterprise/azure-ad-oidc
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/enterprise/cognito
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/social/github
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/social/facebook
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/social/google
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/social/twitter
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/social/linkedin
http://localhost:3000/docs/lifecycle/authenticate-users/identity-providers/social/apple
