### PR TITLE
remove warning limit on custom domains to certain plans

### DIFF
--- a/astro/src/content/docs/_shared/_hosted-backend-warning.md
+++ b/astro/src/content/docs/_shared/_hosted-backend-warning.md
@@ -8,6 +8,6 @@ If this configuration is not possible, use one of these alternative methods:
 
 * Develop using a local FusionAuth instance, so both your webapp and FusionAuth are running on `localhost`.
 * Do not use the FusionAuth hosted backend, and instead write your own backend with a cross origin cookie policy: [here's an example](https://github.com/FusionAuth/fusionauth-javascript-sdk-express/tree/main).
-* Configure a [custom domain name for the FusionAuth Cloud instance](/docs/get-started/run-in-the-cloud/cloud#updating-with-existing-custom-domains) (limited to certain plans).
+* Configure a [custom domain name for the FusionAuth Cloud instance](/docs/get-started/run-in-the-cloud/cloud#updating-with-existing-custom-domains).
 
 Modifying FusionAuth CORS configuration options does not fix this issue because the cookies that FusionAuth writes will not be accessible cross domain.


### PR DESCRIPTION
up until the new platform was the default, basic deployments were not allowed to have a domain name.

now they are. See https://fusionauth.io/pricing?step=hosting

Support is equipped to migrate users to the new hosting platform, so we can remove this warning.