### PR TITLE
handle case where an issue is closed but not yet released.

### DIFF
--- a/src/scripts/check-for-closed-github-issues-in-docs.sh
+++ b/src/scripts/check-for-closed-github-issues-in-docs.sh
@@ -1,24 +1,34 @@
 #!/bin/bash
-
 VERBOSE=""
 if [ "$1" == "-v" ]; then
   VERBOSE="true"
 fi
-
 rm -f numbers
-
 # find all the issue numbers in the docs
 for i in `grep -ilR https://github.com/fusionauth/fusionauth-issues/issue astro/src/content/docs|grep -v 'release-notes'`; do
   grep -i github.com/FusionAuth/fusionauth-issues/issues/ $i|grep -v new/choose |sed 's!.*https://!!'|sed 's!).*!!' |sed 's!".*!!'|sed 's! .*!!'|sed 's!.*-issues/issues/!!' |sed 's![^0-9]*!!g'  >> numbers
 done
-
 # Repository in the format owner/repo
 repo="fusionauth/fusionauth-issues"
-
 CLOSED_COUNT=0
-
 # Loop through the issue numbers and check if they are closed
 for issue in `sort -un numbers`; do
+  # Check if issue has an open milestone
+  milestone_number=$(gh issue view "$issue" --repo "$repo" --json milestone --jq '.milestone.number // empty')
+  if [ -z $milestone_number ]; then 
+    milestone_state="na"
+  else 
+    milestone_state=$(gh api repos/fusionauth/fusionauth-issues/milestones/$milestone_number | jq -r '.state')
+  fi
+
+  # Skip issues that are associated with an open milestone
+  if [ "$milestone_state" == "open" ]; then
+    if [ "$VERBOSE" == "true" ]; then
+      echo "Issue #$issue has an OPEN milestone - skipping"
+    fi
+    continue
+  fi
+
   status=$(gh issue view "$issue" --repo "$repo" --json state --jq '.state')
   
   if [ "$status" == "CLOSED" ]; then
@@ -28,6 +38,4 @@ for issue in `sort -un numbers`; do
     CLOSED_COUNT=$((CLOSED_COUNT + 1)) # Increment the closed issue count
   fi
 done
-
 echo -n $CLOSED_COUNT
-


### PR DESCRIPTION
This check makes sure we don't reference any closed issues in our docs. This is important because it signals that doc needs to be updated to be correct (if an GH issue is referenced and closed, there has been some kind of fix to the underlying product issue).

The engineering team changed their process and now closes an issue and adds it to an open milestone when done. When a release happens, the milestone is closed.

This means this check can safely ignore issues that are closed and assigned to an open milestone. 

The change I made to this script does that.

You can test with issue 2982, which is closed but in a future milestone. The script should give a count of 0 on this branch, but 1 on main.

You can also test by adding a reference to issue 3013 to a doc somewhere and running this script. It should give a count of 1 on this branch and on main. This is because 3013 is closed and belongs to a closed milestone.
