### PR TITLE
support canonical url in our blog posts

### DIFF
--- a/astro/src/content/config.js
+++ b/astro/src/content/config.js
@@ -3,6 +3,7 @@ import { defineCollection, z } from 'astro:content';
 const articlesCollection = defineCollection({
   schema: z.object({
     author: z.string().optional(),
+    canonicalUrl: z.string().optional(),
     cta: z.string().optional(),
     description: z.string(),
     disableTOC: z.boolean().default(false),
@@ -93,6 +94,7 @@ const blogCollection = defineCollection({
     featured_tag: z.string().optional(),
     featured_category: z.string().optional(),
     excerpt_separator: z.string().optional(),
+    canonicalUrl: z.string().optional(),
     blurb: z.string().optional(),
   }),
 });

--- a/astro/src/layouts/Blog.astro
+++ b/astro/src/layouts/Blog.astro
@@ -23,6 +23,7 @@ let { slug } = Astro.params;
 title = frontmatter.title ? frontmatter.title : title;
 const htmlTitle = frontmatter.htmlTitle ? frontmatter.htmlTitle : title;
 const description = frontmatter.description ? frontmatter.description : '';
+const canonicalUrl = frontmatter.canonicalUrl ? frontmatter.canonicalUrl : '';
 const categories = frontmatter.categories ? frontmatter.categories.split(',').map(cat => cat.trim()) : [];
 const image = frontmatter.image ? frontmatter.image : '/img/blogs/header-example.svg';
 const authors = frontmatter.authors ? frontmatter.authors.split(',').map(author => author.trim()) : [];
@@ -74,7 +75,7 @@ const markdownStyles = [
 ---
 <!DOCTYPE html>
 <html class="antialiased" lang="en">
-<HeadComponent title={ htmlTitle } description={description} openGraphImage={image} {searchFilters}></HeadComponent>
+<HeadComponent title={ htmlTitle } canonicalUrl={canonicalUrl} description={description} openGraphImage={image} {searchFilters}></HeadComponent>
 <body class="antialiased leading-tight">
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5P7VLHG"


### PR DESCRIPTION
This adds the ability (already supported in the component) to customize the canonical URL tag in blog posts.

You can exercise this by adding `canonicalUrl: /test-value` to any blog post front matter and then visiting it in the browser, and looking for this tag. This will result in an update of the value like so:

```
<link rel="canonical" href="http://localhost:3001/test-value">
```

If you do not add this to the frontmatter, we default to a normal value (the host of the astro server, the /blog subdirectory and the slug of the post).

I also added canonicalUrl to the articles collection (already supported) and the blog collection schema definitions.