### PR TITLE
Update download widget to support modifying kickstart files

### DIFF
--- a/astro/src/components/download/DownloadWidget.astro
+++ b/astro/src/components/download/DownloadWidget.astro
@@ -198,7 +198,7 @@ var step = 1;
           <strong>Step { step++ }:</strong> Customize the Kickstart
         </p>
         <p class="mb-6">
-          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+          Update your <code>kickstart.json</code> file to correctly configure your instance:
         </p>
         <p class="mb-6">
         <ul>
@@ -238,7 +238,7 @@ var step = 1;
           <strong>Step { step++ }:</strong> Customize the Kickstart
         </p>
         <p class="mb-6">
-          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+          Update your <code>kickstart.json</code> file to correctly configure your instance:
         </p>
         <p class="mb-6">
         <ul>
@@ -292,7 +292,7 @@ var step = 1;
           <strong>Step { step++ }:</strong> Customize the Kickstart
         </p>
         <p class="mb-6">
-          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+          Update your <code>kickstart.json</code> file to correctly configure your instance:
         </p>
         <p class="mb-6">
         <ul>
@@ -339,7 +339,7 @@ var step = 1;
           <strong>Step { step++ }:</strong> Customize the Kickstart
         </p>
         <p class="mb-6">
-          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+          Update your <code>kickstart.json</code> file to correctly configure your instance:
         </p>
         <p class="mb-6">
         <ul>
@@ -391,7 +391,7 @@ var step = 1;
           <strong>Step { step++ }:</strong> Customize the Kickstart
         </p>
         <p class="mb-6">
-          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+          Update your <code>kickstart.json</code> file to correctly configure your instance:
         </p>
         <p class="mb-6">
         <ul>

--- a/astro/src/components/download/DownloadWidget.astro
+++ b/astro/src/components/download/DownloadWidget.astro
@@ -2,7 +2,7 @@
 import Code from 'src/components/Code.astro';
 import Kickstart from 'src/components/download/Kickstart.astro';
 
-const {kickstartEnabled, kickstartName, includeDocker = true, includeFastPath = true, includeHostedOptions, includeKubernetes, includePackages, includeSandbox, showDockerCompose = true} = Astro.props;
+const {kickstartEnabled, kickstartName, includeDocker = true, includeFastPath = true, includeHostedOptions, includeKubernetes, includePackages, includeSandbox, kickstartCustomizationInstructions = new Array()} = Astro.props;
 
 var tabs = [];
 
@@ -193,17 +193,28 @@ var step = 1;
           </p>
           <Kickstart env={false} includeNix={true} includeWindows={true} name={kickstartName} section="docker-compose-kickstart"/>
       }
-      { showDockerCompose &&
+      { kickstartCustomizationInstructions.length > 0 &&
         <p class="mb-6 mt-12">
-          <strong>Step { step++ }:</strong> Start the Docker Compose containers
+          <strong>Step { step++ }:</strong> Customize the Kickstart
         </p>
-        <Code>
-          docker compose up
-        </Code>
         <p class="mb-6">
-          Then open <a href="http://localhost:9011" class={anchorClass}>http://localhost:9011</a> in your browser.
+          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+        </p>
+        <p class="mb-6">
+        <ul>
+          {kickstartCustomizationInstructions.map(customizationInstruction => <li>{customizationInstruction}</li>)}
+        </ul>
         </p>
       }
+      <p class="mb-6 mt-12">
+        <strong>Step { step++ }:</strong> Start the Docker Compose containers
+      </p>
+      <Code>
+        docker compose up
+      </Code>
+      <p class="mb-6">
+        Then open <a href="http://localhost:9011" class={anchorClass}>http://localhost:9011</a> in your browser.
+      </p>
     </div>
     <div data-tab-content id="docker-vanilla" class="hidden m-8" data-reset={step = 1}>
       <h2 class="mb-4 text-2xl">Docker Vanilla</h2>

--- a/astro/src/components/download/DownloadWidget.astro
+++ b/astro/src/components/download/DownloadWidget.astro
@@ -233,6 +233,19 @@ var step = 1;
           </p>
           <Kickstart env={false} includeNix={true} includeWindows={true} name={kickstartName} section="docker-vanilla"/>
       }
+      { kickstartCustomizationInstructions.length > 0 &&
+        <p class="mb-6 mt-12">
+          <strong>Step { step++ }:</strong> Customize the Kickstart
+        </p>
+        <p class="mb-6">
+          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+        </p>
+        <p class="mb-6">
+        <ul>
+          {kickstartCustomizationInstructions.map(customizationInstruction => <li>{customizationInstruction}</li>)}
+        </ul>
+        </p>
+      }
       <p class="mb-6 mt-12">
         <strong>Step { step++ }:</strong> Start the Docker container
       </p>
@@ -273,6 +286,19 @@ var step = 1;
             <strong>Step { step++ }:</strong> Download the Kickstart files needed for this project
           </p>
           <Kickstart env={true} includeNix={true} includeWindows={false} name={kickstartName}/>
+      }
+      { kickstartCustomizationInstructions.length > 0 &&
+        <p class="mb-6 mt-12">
+          <strong>Step { step++ }:</strong> Customize the Kickstart
+        </p>
+        <p class="mb-6">
+          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+        </p>
+        <p class="mb-6">
+        <ul>
+          {kickstartCustomizationInstructions.map(customizationInstruction => <li>{customizationInstruction}</li>)}
+        </ul>
+        </p>
       }
       <p class="mb-6 mt-12">
         <strong>Step { step++ }:</strong> Start FusionAuth

--- a/astro/src/components/download/DownloadWidget.astro
+++ b/astro/src/components/download/DownloadWidget.astro
@@ -334,6 +334,19 @@ var step = 1;
           </p>
           <Kickstart env={true} includeNix={true} includeWindows={false} name={kickstartName}/>
       }
+      { kickstartCustomizationInstructions.length > 0 &&
+        <p class="mb-6 mt-12">
+          <strong>Step { step++ }:</strong> Customize the Kickstart
+        </p>
+        <p class="mb-6">
+          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+        </p>
+        <p class="mb-6">
+        <ul>
+          {kickstartCustomizationInstructions.map(customizationInstruction => <li>{customizationInstruction}</li>)}
+        </ul>
+        </p>
+      }
       <p class="mb-6 mt-12">
         <strong>Step { step++ }:</strong> Start FusionAuth
       </p>
@@ -372,6 +385,19 @@ var step = 1;
             <strong>Step { step++ }:</strong> Download the Kickstart files needed for this project
           </p>
           <Kickstart env={true} includeNix={false} includeWindows={true} name={kickstartName}/>
+      }
+      { kickstartCustomizationInstructions.length > 0 &&
+        <p class="mb-6 mt-12">
+          <strong>Step { step++ }:</strong> Customize the Kickstart
+        </p>
+        <p class="mb-6">
+          Update your <code>kickstart/kickstart.json</code> file to correctly configure your instance:
+        </p>
+        <p class="mb-6">
+        <ul>
+          {kickstartCustomizationInstructions.map(customizationInstruction => <li>{customizationInstruction}</li>)}
+        </ul>
+        </p>
       }
       <p class="mb-6 mt-12">
         <strong>Step { step++ }:</strong> Start FusionAuth

--- a/astro/src/components/download/DownloadWidget.astro
+++ b/astro/src/components/download/DownloadWidget.astro
@@ -2,7 +2,7 @@
 import Code from 'src/components/Code.astro';
 import Kickstart from 'src/components/download/Kickstart.astro';
 
-const {kickstartEnabled, kickstartName, includeDocker = true, includeFastPath = true, includeHostedOptions, includeKubernetes, includePackages, includeSandbox} = Astro.props;
+const {kickstartEnabled, kickstartName, includeDocker = true, includeFastPath = true, includeHostedOptions, includeKubernetes, includePackages, includeSandbox, showDockerCompose = true} = Astro.props;
 
 var tabs = [];
 
@@ -193,15 +193,17 @@ var step = 1;
           </p>
           <Kickstart env={false} includeNix={true} includeWindows={true} name={kickstartName} section="docker-compose-kickstart"/>
       }
-      <p class="mb-6 mt-12">
-        <strong>Step { step++ }:</strong> Start the Docker Compose containers
-      </p>
-      <Code>
-        docker compose up
-      </Code>
-      <p class="mb-6">
-        Then open <a href="http://localhost:9011" class={anchorClass}>http://localhost:9011</a> in your browser.
-      </p>
+      { showDockerCompose &&
+        <p class="mb-6 mt-12">
+          <strong>Step { step++ }:</strong> Start the Docker Compose containers
+        </p>
+        <Code>
+          docker compose up
+        </Code>
+        <p class="mb-6">
+          Then open <a href="http://localhost:9011" class={anchorClass}>http://localhost:9011</a> in your browser.
+        </p>
+      }
     </div>
     <div data-tab-content id="docker-vanilla" class="hidden m-8" data-reset={step = 1}>
       <h2 class="mb-4 text-2xl">Docker Vanilla</h2>


### PR DESCRIPTION
## Why

Sometimes you want to modify a kickstart file that has been downloaded for an example app. This might be to add a license key or some other small variable injection.

## What

Added an optional array to this component. If this array is present and non-zero length, the contents of the array will be displayed in a list in order under the caption "change your kickstart/kickstart.json file as shown below".

## Files changed

Just the download widget component, no changes visible in URLs.