### PR TITLE
Add workaround for text files imported into kickstart with Unicode code point notation in them

### DIFF
--- a/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
@@ -444,7 +444,7 @@ In this example you are creating an email template and reading in the values for
 
 Newlines are preserved in included text files, whereas they are not in the kickstart file. If you are, for example, including a lambda function definition, it may lead to better readability if you include the body from a text file.
 
-If using Unicode code point notation in a text file, ensure the string is properly escaped. For example, to add `\u2026` to a `messages.properties` file included by KickStart into a theme, use the string `\\\\u2026`. There is an [open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1947) with more discussion.
+If using Unicode code point notation in a text file, ensure the string is properly escaped. For example, to add `\u2026` to a file, use the string `\\\\u2026`. There is an [open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1947) with more discussion.
 
 ### Include JSON files
 

--- a/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
@@ -444,7 +444,13 @@ In this example you are creating an email template and reading in the values for
 
 Newlines are preserved in included text files, whereas they are not in the kickstart file. If you are, for example, including a lambda function definition, it may lead to better readability if you include the body from a text file.
 
-If using Unicode code point notation in a text file, ensure the string is properly escaped. For example, to add `\u2026` to a file, use the string `\\\\u2026`. There is an [open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1947) with more discussion.
+If using Unicode code point notation in a text file, ensure the string is properly escaped, due to a complexity in Kickstart parsing. You can also use the actual character instead of the code point notation or the HTML escape sequence. All of these will render correctly for `\u2026`:
+
+* `\\\\u2026`
+* `…`
+* `&#x2026;`
+
+There is an [open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1947) with more discussion.
 
 ### Include JSON files
 

--- a/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
@@ -444,13 +444,13 @@ In this example you are creating an email template and reading in the values for
 
 Newlines are preserved in included text files, whereas they are not in the kickstart file. If you are, for example, including a lambda function definition, it may lead to better readability if you include the body from a text file.
 
-If using Unicode code point notation in a text file, ensure the string is properly escaped, due to a complexity in Kickstart parsing. You can also use the actual character instead of the code point notation or the HTML escape sequence. All of these will render correctly for `\u2026`:
+Unicode characters in a Kickstart file can be included directly, using Unicode code point notation, or an HTML escape sequence. Unicode code point notation must be escaped with three prepended backslashes. For example, the three ways to include the horizontal ellipses character, `…`, are:
 
-* `\\\\u2026`
 * `…`
+* `\\\\u2026`
 * `&#x2026;`
 
-There is an [open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1947) with more discussion.
+For more information, see the [open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1947).
 
 ### Include JSON files
 

--- a/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
@@ -444,6 +444,8 @@ In this example you are creating an email template and reading in the values for
 
 Newlines are preserved in included text files, whereas they are not in the kickstart file. If you are, for example, including a lambda function definition, it may lead to better readability if you include the body from a text file.
 
+If using Unicode code point notation in a text file, ensure the string is properly escaped. For example, to add `\u2026` to a `messages.properties` file included by KickStart into a theme, use the string `\\\\u2026`. There is an [open GitHub issue](https://github.com/FusionAuth/fusionauth-issues/issues/1947) with more discussion.
+
 ### Include JSON files
 
 If you're making a lot of API requests, or simply want to manage each API request body separately it may be helpful to read in external JSON files. The directories shown here are just examples, and you can use your own convention.


### PR DESCRIPTION
## Why

I ran across [a bug](https://github.com/FusionAuth/fusionauth-issues/issues/1947) when writing an example app and wanted to document the workaround.

## What

This change adds a workaround and a link to an open GitHub issue for a known parsing issue for Kickstart, our tool to quickly bootstrap development instances.

## URIs

- http://localhost:3000/docs/get-started/download-and-install/development/kickstart#include-text-files