### PR TITLE
rename identity.verified event to user.identity.verified

### DIFF
--- a/astro/src/content/docs/apis/_event-types.mdx
+++ b/astro/src/content/docs/apis/_event-types.mdx
@@ -4,7 +4,6 @@ import AvailableSince from 'src/components/api/AvailableSince.astro';
 
 * `audit-log.create` - When an audit log is created <AvailableSince since="1.30.0" />
 * `event-log.create` - When an event log is created  <AvailableSince since="1.30.0" />
-* `identity.verified` - When a user's identity is verified <AvailableSince since="1.99.9" />
 * `jwt.public-key.update` - When a JWT RSA Public / Private keypair may have been changed
 * `jwt.refresh` - When an access token is refreshed using a refresh token  <AvailableSince since="1.16.0" />
 * `jwt.refresh-token.revoke` - When a JWT Refresh Token is revoked
@@ -20,6 +19,7 @@ import AvailableSince from 'src/components/api/AvailableSince.astro';
 * `user.email.verified` - When a user verifies their email address  <AvailableSince since="1.8.0" />
 * `user.identity-provider.link` - When a link is created from a user to an Identity Provider  <AvailableSince since="1.36.0" />
 * `user.identity-provider.unlink` - When an existing Identity Provider link is removed from a User  <AvailableSince since="1.36.0" />
+* `user.identity.verified` - When a user's identity is verified <AvailableSince since="1.99.9" />
 * `user.loginId.duplicate.create` - When a request to create a user with a login Id (email or username) which is already in use has been received  <AvailableSince since="1.30.0" />  <EnterprisePlanBlurbApi> the `user.loginId.duplicate.create` event </EnterprisePlanBlurbApi>
 * `user.loginId.duplicate.update` - When a request to update a user and change their login Id (email or username) to one that is already in use has been received  <AvailableSince since="1.30.0" /> <EnterprisePlanBlurbApi> the `user.loginId.duplicate.update` event </EnterprisePlanBlurbApi>
 * `user.login.failed` - When a user fails a login request  <AvailableSince since="1.6.0" />

--- a/astro/src/content/docs/extend/events-and-webhooks/events/index.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/index.mdx
@@ -36,7 +36,6 @@ These are the events that FusionAuth generates that can be optionally consumed b
 * [Group Member Remove Complete](/docs/extend/events-and-webhooks/events/group-member-remove-complete) - when a user remove transaction has completed
 * [Group Member Update](/docs/extend/events-and-webhooks/events/group-member-update) - when a group membership is updated
 * [Group Member Update Complete](/docs/extend/events-and-webhooks/events/group-member-update-complete) - when a group membership update transaction has completed
-* [Identity Verified](/docs/extend/events-and-webhooks/events/identity-verified) - when a user identity is verified
 * [User Actions](/docs/extend/events-and-webhooks/events/user-actions) - when a moderator takes an action on a user
 * [User Bulk Create](/docs/extend/events-and-webhooks/events/user-bulk-create) - when multiple users are created as the result of the Import API
 * [User Create](/docs/extend/events-and-webhooks/events/user-create) - when a user is created
@@ -48,6 +47,7 @@ These are the events that FusionAuth generates that can be optionally consumed b
 * [User Email Verified](/docs/extend/events-and-webhooks/events/user-email-verified) - when a user verifies their email address
 * [User Identity Provider Link](/docs/extend/events-and-webhooks/events/user-identity-provider-link) - when a link with an Identity Provider is created
 * [User Identity Provider Unlink](/docs/extend/events-and-webhooks/events/user-identity-provider-unlink) - when a link with an Identity Provider is removed
+* [User Identity Verified](/docs/extend/events-and-webhooks/events/user-identity-verified) - when a user identity is verified
 * [User Login Failed](/docs/extend/events-and-webhooks/events/user-login-failed) - when a user fails to complete login
 * [User Login Success](/docs/extend/events-and-webhooks/events/user-login-success) - when a user successfully completes login
 * [User Reactivate](/docs/extend/events-and-webhooks/events/user-reactivate) - when a user is reactivated

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-email-verified.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-email-verified.mdx
@@ -22,7 +22,7 @@ export const eventType = 'user.email.verified';
        version="1.8.0"/>
 
 <Aside>
-  The [Identity Verified](/docs/extend/events-and-webhooks/events/identity-verified) event is also created when email identities are verified and also includes phone number identities.
+  The [User Identity Verified](/docs/extend/events-and-webhooks/events/user-identity-verified) event is also created when email identities are verified and also includes phone number identities.
   <AvailableSince since="1.99.9" />
 </Aside>
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-identity-verified.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-identity-verified.mdx
@@ -1,6 +1,6 @@
 ---
-title: Identity Verified
-description: Learn about the Identity Verified event.
+title: User Identity Verified
+description: Learn about the User Identity Verified event.
 section: extend
 subcategory: events and webhooks
 tertcategory: events
@@ -11,11 +11,11 @@ import Event from 'src/content/docs/extend/events-and-webhooks/events/_event.ast
 import EventBody from 'src/content/docs/extend/events-and-webhooks/events/_event-body.astro';
 import InlineField from 'src/components/InlineField.astro';
 
-export const eventType = 'identity.verified';
+export const eventType = 'user.identity.verified';
 
 <Event description="This event is generated when a user verifies an identity, which could be an email address or phone number."
        eventType={eventType}
-       name="Identity Verified"
+       name="User Identity Verified"
        scope="tenant"
        transactional="true"
        version="1.99.9"/>
@@ -25,7 +25,7 @@ export const eventType = 'identity.verified';
 </Aside>
 
 <EventBody eventType={eventType}
-           jsonFile="identity-verified.json">
+           jsonFile="user-identity-verified.json">
 
   <APIField slot="leading-fields" name="event.createInstant" type="Long">
     The [instant](/docs/reference/data-types#instants) that the event was generated.

--- a/astro/src/content/json/events/user-identity-verified.json
+++ b/astro/src/content/json/events/user-identity-verified.json
@@ -15,7 +15,7 @@
       "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"
     },
     "tenantId": "e872a880-b14f-6d62-c312-cb40f22af465",
-    "type": "identity.verified",
+    "type": "user.identity.verified",
     "loginId": "example@fusionauth.io",
     "loginIdType": "email",
     "user": {


### PR DESCRIPTION
### Issue:
- https://linear.app/fusionauth/issue/ENG-2047/identityverifiedevent-needs-to-be-named-correctly-emailed-or-sent-via

### Problem:
- IdentityVerifiedEvent should be UserIdentityVerifiedEvent b/c it is a BaseUserEvent

### Solution:
- rename in docs

### Linked PR:
- https://github.com/fusionauth-eng/fusionauth-app/pull/909
