### PR TITLE
ENG-2760 - Account self service password change notes

### DIFF
--- a/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/upgrade.mdx
@@ -16,7 +16,13 @@ This page contains notes on changes in recent versions of FusionAuth that requir
 
 Version `1.99.9` does not *require* any theme changes. User passwords are optional in version `1.99.9` at the tenant level.
 
-For advanced registration forms, each application can decide, by including or omitting a password field in its advanced registration form, whether to require a password for a user (new or existing).
+<Aside type="caution">
+  Consider the security posture of your application when deciding whether to make passwords optional. There may be risk in communicating what channels are accepted.
+</Aside>
+
+For advanced registration and Self Service User forms, each application can decide, by including or omitting a password field in its advanced registration form, whether to require a password for a user (new or existing).
+
+### Registration
 
 Basic registration always requires a password. To accommodate the use case of an existing user, without a password, registering for an application with basic registration, there is a new field, `passwordSet`, that can be used on the `OAuth complete registration` page to display the password field with basic registrations.
 
@@ -46,9 +52,42 @@ For example, before:
 [/#if]
 ```
 
-<Aside type="caution">
-  Consider the security posture of your application when deciding whether to make passwords optional. There may be risk in communicating what channels are accepted.
-</Aside>
+### Self Service User
+
+To accommodate the use case of an existing user, without a password, setting a password for the first time, there is a new field, `passwordSet`, that can be used on the `Helpers` page to hide the "current password" field for users that do not have a password.
+
+```html title="Before"
+<form action="${request.contextPath}/account/edit" method="POST" class="full" id="user-form">
+  ...
+  [#list fieldValues as field]
+    [#if field.key == "user.password"]
+      [@helpers.passwordField field application.formConfiguration.selfServiceFormConfiguration.requireCurrentPasswordOnPasswordChange/]
+    [#else]
+      [@helpers.customField field=field key=field.key autofocus=false placeholder=field.key label=theme.optionalMessage(field.key) leftAddon="false"/]
+      [#if field.confirm]
+        [@helpers.customField field "confirm.${field.key}" false "[confirm]${field.key}" /]
+      [/#if]
+    [/#if]
+  [/#list]
+</form>
+```
+
+```html title="After"
+<form action="${request.contextPath}/account/edit" method="POST" class="full" id="user-form">
+  ...
+  [#list fieldValues as field]
+    [#if field.key == "user.password"]
+      [@helpers.passwordField field=field
+                              showCurrentPasswordField=(passwordSet && application.formConfiguration.selfServiceFormConfiguration.requireCurrentPasswordOnPasswordChange)/]
+    [#else]
+      [@helpers.customField field=field key=field.key autofocus=false placeholder=field.key label=theme.optionalMessage(field.key) leftAddon="false"/]
+      [#if field.confirm]
+        [@helpers.customField field "confirm.${field.key}" false "[confirm]${field.key}" /]
+      [/#if]
+    [/#if]
+  [/#list]
+</form>
+```
 
 ## Version 1.53.3
 

--- a/astro/src/content/json/themes/templates.json
+++ b/astro/src/content/json/themes/templates.json
@@ -41,6 +41,11 @@
         "description": "The User fields to display in the form. Each key maps to form fields by section within a Self-Service User form."
       },
       {
+        "name": "passwordSet",
+        "type": "Boolean",
+        "description": "A boolean that indicates if the user has a password set."
+      },
+      {
         "name": "user",
         "type": "User",
         "description": "The User object corresponding to the authenticated user."
@@ -532,7 +537,29 @@
     "displayName": "OAuth complete registration",
     "fieldName": "oauth2CompleteRegistration",
     "description": "This page contains a form that is used for users that have accounts but might be missing required fields.",
-    "path": "/oauth2/complete-registration"
+    "path": "/oauth2/complete-registration",
+    "variables": [
+      {
+        "name": "fields",
+        "type": "Map<Integer, List<FormField>>",
+        "description": "The User fields to display in the form. Each key maps to form fields by section within a Self-Service User form."
+      },
+      {
+        "name": "passwordSet",
+        "type": "Boolean",
+        "description": "A boolean that indicates if the user has a password set."
+      },
+      {
+        "name": "step",
+        "type": "Integer",
+        "description": "(for Advanced Registration Forms only) The step in the registration process according to the form in use. The value will be `1` for the first step, `2` for the second step, and so on."
+      },
+      {
+        "name": "totalSteps",
+        "type": "Integer",
+        "description": "(for Advanced Registration Forms only) The total number of steps in the registration form."
+      }
+    ]
   },
   {
     "displayName": "OAuth consent prompt",
@@ -543,7 +570,7 @@
     "variables": [
       {
         "name": "action",
-        "type":"String",
+        "type": "String",
         "description": "The action the user selected on the consent prompt. The value should be `allow` if the user made consent selections and wants to continue or `cancel` if they have decided not to continue."
       },
       {


### PR DESCRIPTION
Targeting `wied03/ENG-2790/password-toggle` since we base this branch off those changes. https://github.com/FusionAuth/fusionauth-site/pull/3821 should be merged first.

Clarify how to do upgrade that accommodate account self service, setting a password for a user, for the first time.

Also go back and add new theme template variable for complete registration.