### PR TITLE
add message template vars to table

### DIFF
--- a/astro/src/content/docs/customize/email-and-messages/message-templates-replacement-variables.mdx
+++ b/astro/src/content/docs/customize/email-and-messages/message-templates-replacement-variables.mdx
@@ -37,6 +37,8 @@ FusionAuth provides the capability to preview message templates via the [Message
 | `${application}`             | `{ "name": "My Application", "oauthConfiguration": { "clientId": "123456" } }` | Application name, `oauthConfiguration.clientId` for themed message links |
 | `${changePasswordId}`        | `1234567890`                                                                | Embedded in change password and set password URLs                          |
 | `${code}`                    | `123456`                                                                    | Embedded in MFA/Two Factor messages                                         |
+| `${event}`                   | `{ "type": "UserLoginSuspicious", "info": {...} }`                          | Embedded in User Event messages                                             |
+| `${method}`                  | `{ "id" : "FQLM", "method" : "email" }`                                     | Embedded in Two Factor Add/Remove event messages                            |
 | `${oneTimeCode}`             | `88888`                                                                     | Embedded in passwordless login messages                                     |
 | `${tenant}`                  | `{ "name": "My Tenant", "id": "78910" }`                                    | `tenant.id` allows links embedded in messages to render using the correct theme for that tenant. |
 | `${user}`                    | `{ "firstName": "John", "lastName": "Doe" }`                                | User information and `user.tenantId` for themed message links          |


### PR DESCRIPTION
### Issue:
- https://linear.app/fusionauth/issue/ENG-3047/fix-message-template-previewing-again

### Problem:
Message template variables table didn't include vars for threat detection and two factor add/remove (interleaved PRs race condition)

### Solution:
Add them
