### PR TITLE
ENG-2853: OAuth redirect `userState`

### DIFF
--- a/astro/src/content/docs/_shared/_oauth-authorize-redirect-parameters.mdx
+++ b/astro/src/content/docs/_shared/_oauth-authorize-redirect-parameters.mdx
@@ -11,12 +11,12 @@ import APIField from 'src/components/api/APIField.astro';
     The state that was provided on the Authorization request. This parameter will be omitted if the <InlineField>state</InlineField> request parameter was not provided.
   </APIField>
   <APIField name="userState" type="String" optional>
-    The FusionAuth user state.
+    The FusionAuth user state. This value serves as a hint for the user's registration and verification status suitable for message customization and similar uses. <InlineField>userState</InlineField> should _not_ be used to make any security decisions for the user.
 
     The possible values are:
       * `Authenticated` - The user is successfully authenticated for the requested application.
       * `AuthenticatedNotRegistered` - The user is successfully authenticated, but not registered for the requested application.
-      * `AuthenticatedNotVerified` - The user is successfully authenticated, but the user's email address has not been verified.
+      * `AuthenticatedNotVerified` - The user is successfully authenticated, but the user's email address and/or phone number have not been verified.
       * `AuthenticatedRegistrationNotVerified` - The user is successfully authenticated and registered, but the registration has not been verified for the requested application.
   </APIField>
 </APIBlock>


### PR DESCRIPTION
Update the documentation for the `userState` redirect parameter to include phone. Call out that the value should not be used for security decisions.