### PR TITLE
Update role for user being searched in user search doc.

### DIFF
--- a/astro/src/content/docs/get-started/core-concepts/users.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/users.mdx
@@ -712,7 +712,7 @@ The following screenshot shows a query string being constructed to search for us
 
 When searching for users by application or any fields on an application, it is necessary to construct a JSON query due to the way the Elasticsearch mapping is defined.
 
-The following screenshot shows an Elasticsearch JSON query being constructed to search for users that match the email pattern `*@fusionauth.io`, are registered to the `Pied Piper` application, and are assigned the `CEO` role:
+The screenshot shows an Elasticsearch JSON query for the registered users of the `Pied Piper` application assigned to the `CEO` role that have an email that matches the pattern `*@fusionauth.io`:
 
 ![User Search with JSON Query.](/img/docs/get-started/core-concepts/user-search-json-query.png)
 


### PR DESCRIPTION
## Why

There was a discordance between the descriptive text and the screenshot. This PR corrects the text.

## URLS

http://localhost:3000/docs/get-started/core-concepts/users#elasticsearch-search-engine