### PR TITLE
add missing identity related fields

### DIFF
--- a/astro/src/content/docs/apis/_tenant-application-phone-configuration.mdx
+++ b/astro/src/content/docs/apis/_tenant-application-phone-configuration.mdx
@@ -11,6 +11,10 @@ import InlineField from 'src/components/InlineField.astro';
     The Id of the Message Template used to send a message to a user when their phone number has been updated. The message will be sent to both their new and old phone numbers. {props.application_phone_config_override_text}
   </APIField>
 
+  <APIField name={ props.base_field_name + ".phoneConfiguration.implicitPhoneVerificationAllowed" } optional type="Boolean" defaults="true" since="1.59.0" renderif={props.is_tenant}>
+    When set to true, this allows a phone number to be verified as a result of completing a similar phone based workflow such as change password. When set to false, the user must explicitly complete the phone verification workflow even if the user has already completed a similar phone workflow such as change password.
+  </APIField>
+
   <APIField name={props.base_field_name + '.phoneConfiguration.loginIdInUseOnCreateTemplateId'} type="UUID" since="1.59.0">
     The Id of the Message Template used to send a message to a user when another user attempts to create an account with their login Id. {props.application_phone_config_override_text}
 

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-create.mdx
@@ -34,6 +34,14 @@ export const eventType = 'user.loginId.duplicate.create';
     The email address that is already in-use.
   </APIField>
 
+  <APIField slot="leading-fields" name="event.duplicateIdentities" type="Array<Object>" since="1.59.0">
+    List of identities that are already in-use. Identity objects contain a <InlineField>type</InlineField> and a <InlineField>value</InlineField> property. The <InlineField>type</InlineField> is the type of identity (e.g., email, phoneNumber, username) and the <InlineField>value</InlineField> is the actual value of that identity.
+  </APIField>
+
+  <APIField slot="leading-fields" name="event.duplicatePhone" type="String" since="1.59.0">
+    The phone number that is already in-use.
+  </APIField>
+
   <APIField slot="leading-fields" name="event.duplicateUsername" type="String">
     The username that is already in-use.
   </APIField>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-create.mdx
@@ -38,7 +38,7 @@ export const eventType = 'user.loginId.duplicate.create';
     List of identities that are already in-use. Identity objects contain a <InlineField>type</InlineField> and a <InlineField>value</InlineField> property. The <InlineField>type</InlineField> is the type of identity (e.g., email, phoneNumber, username) and the <InlineField>value</InlineField> is the actual value of that identity.
   </APIField>
 
-  <APIField slot="leading-fields" name="event.duplicatePhone" type="String" since="1.59.0">
+  <APIField slot="leading-fields" name="event.duplicatePhoneNumber" type="String" since="1.59.0">
     The phone number that is already in-use.
   </APIField>
 
@@ -59,7 +59,7 @@ export const eventType = 'user.loginId.duplicate.create';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be <code>{eventType}</code>.
+    The event type, this value will always be <InlineField>{eventType}</InlineField>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-update.mdx
@@ -34,6 +34,14 @@ export const eventType = 'user.loginId.duplicate.update';
     The email address that is already in-use.
   </APIField>
 
+  <APIField slot="leading-fields" name="event.duplicateIdentities" type="Array<Object>" since="1.59.0">
+    List of identities that are already in-use. Identity objects contain a <InlineField>type</InlineField> and a <InlineField>value</InlineField> property. The <InlineField>type</InlineField> is the type of identity (e.g., email, phoneNumber, username) and the <InlineField>value</InlineField> is the actual value of that identity.
+  </APIField>
+
+  <APIField slot="leading-fields" name="event.duplicatePhone" type="String" since="1.59.0">
+    The phone number that is already in-use.
+  </APIField>
+
   <APIField slot="leading-fields" name="event.duplicateUsername" type="String">
     The username that is already in-use.
   </APIField>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-update.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/user-login-id-duplicate-update.mdx
@@ -38,7 +38,7 @@ export const eventType = 'user.loginId.duplicate.update';
     List of identities that are already in-use. Identity objects contain a <InlineField>type</InlineField> and a <InlineField>value</InlineField> property. The <InlineField>type</InlineField> is the type of identity (e.g., email, phoneNumber, username) and the <InlineField>value</InlineField> is the actual value of that identity.
   </APIField>
 
-  <APIField slot="leading-fields" name="event.duplicatePhone" type="String" since="1.59.0">
+  <APIField slot="leading-fields" name="event.duplicatePhoneNumber" type="String" since="1.59.0">
     The phone number that is already in-use.
   </APIField>
 
@@ -59,7 +59,7 @@ export const eventType = 'user.loginId.duplicate.update';
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">
-    The event type, this value will always be <code>{eventType}</code>.
+    The event type, this value will always be <InlineField>{eventType}</InlineField>.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.user" type="Object">


### PR DESCRIPTION
### Problem:
A few new fields in the 1.59.0 release were missing documentation. Thanks `src/check-apis-against-client-json.rb`!

### Solution:
Document them.