### PR TITLE
Remove Copy Markdown for LLMs button

### DIFF
--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -13,7 +13,7 @@ import ArticleNav from '../components/nav/ArticleNav.astro';
 import Icon from '../components/icon/Icon.astro';
 import { specialCaps } from '../tools/string';
 import IndexableBody from '../components/search/IndexableBody.astro';
-import CopyMdButton from '../components/docs/CopyMdButton.astro';
+// import CopyMdButton from '../components/docs/CopyMdButton.astro';
 
 interface Props {
   author?: string;
@@ -188,7 +188,7 @@ const fullMarkdownPath = path.replace(/.html$/,'.mdx');
 
           {breadcrumbs.length === 0 && section && <p class="font-semibold mb-4 mt-0 text-indigo-700 text-lg dark:text-indigo-500">{ specialCaps(section) }</p>}
           <h1 data-pagefind-meta="title" class:list={["text-3xl", image ? "mt-16" : "", author ? "mb-0" : ""]}>{title}</h1>
-          {copyMarkdown && <CopyMdButton mdpath={fullMarkdownPath} />}
+<!--          {copyMarkdown && <CopyMdButton mdpath={fullMarkdownPath} />}  -->
 
           {author &&
             <p class="m-0 text-sm">By {author} {date && <span>- {new Date(date).toDateString()}</span>}</p>


### PR DESCRIPTION
Commented out the display of this button but did not remove either the component or JavaScript that implements it in case we want similar functionality later.