### PR TITLE
update closed github issues handling

### DIFF
--- a/.github/workflows/closedissues.yml
+++ b/.github/workflows/closedissues.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # check on PR
+  pull_request:
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check_closed_github_issues:


### PR DESCRIPTION
This does two things:

- run with -v every time so we can see the problematic issues on the failing github action
- changes this to run on every pull request so that we fix the issues closer to when they happen