### PR TITLE
fixed issue with web browser as storage option

### DIFF
--- a/astro/src/content/docs/_shared/_recommended-token-storage-options.mdx
+++ b/astro/src/content/docs/_shared/_recommended-token-storage-options.mdx
@@ -14,7 +14,7 @@ Here is a table of characteristics of recommended JWT storage options.
 | Sticky sessions or session datastore required        | No                                                   | Yes                            | No  |
 | Token sent on HTTP API requests automatically        | Yes (you may need to tweak the `credentials` option) | No                             | No  |
 | Token can be presented to APIs on other domains      | No                                                   | Yes (via server-side requests) | Yes |
-| Works in a web browser                               | No                                                   | Yes                            | No  |
+| Works in a web browser                               | Yes                                                  | Yes                            | No  |
 
 The proper JWT storage choice is based on your threat modeling and how much risk a particular service can tolerate. You can also configure your JWTs to be short lived, which minimizes the amount of time a stolen JWT can be used.
 


### PR DESCRIPTION
We had cookies marked as not working in a web browser when they really really do.

See the last line of the Cookies column here: https://fusionauth.io/articles/oauth/oauth-token-storage#storage-options

<img width="533" height="419" alt="Screenshot 2025-08-18 at 2 23 49 PM" src="https://github.com/user-attachments/assets/37bda41b-ca6e-4091-ad42-580ecab1551a" />
