### PR TITLE
fixing the framework-specific broken link.

### DIFF
--- a/src/redirects.json
+++ b/src/redirects.json
@@ -581,6 +581,7 @@
     "/docs/lifecycle/migrate-users/": true,
     "/docs/lifecycle/migrate-users/provider-specific/": true,
     "/docs/lifecycle/migrate-users/connectors/": true,
+    "/docs/lifecycle/migrate-users/framework-specific/": true,
     "/docs/lifecycle/migrate-users/scim/": true,
     "/docs/lifecycle/register-users/": true,
     "/docs/operate/": true,


### PR DESCRIPTION
I am looking at the broken links and have run across a problem. For sub sections of the menu, we have what looks like an auto generated page with boxes for each of the subcategories. i.e. https://fusionauth.io/docs/lifecycle/manage-users/search/  .  We have created a new category and this is not happening. https://fusionauth.io/docs/lifecycle/migrate-users/framework-specific. It looks like this is handled in the redirect.json.