### PR TITLE
Fix typos in prompt.mdx "descriotion"

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/prompt.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/prompt.mdx
@@ -83,13 +83,13 @@ For example, when you request `prompt=none` and the user doesn't have an active 
 
 - `error=login_required`
 - `error_reason=authentication_required`
-- `error_descriotion=The user is required to complete authentication.`
+- `error_description=The user is required to complete authentication.`
 
 Another example is when the user is required to provide consent even when there's an active SSO session (`prompt=consent`). The returned error contains:
 
 - `error=consent_required`
 - `error_reason=consent_required`
-- `error_descriotion=The user is required to consent to one or more scopes in order to complete authentication.`
+- `error_description=The user is required to consent to one or more scopes in order to complete authentication.`
 
 See [OAuth2 Error Redirect parameters](/docs/lifecycle/authenticate-users/oauth/endpoints#redirect-parameters-2) for additional information.
 


### PR DESCRIPTION
`error_descriotion` -> `error_description`