### PR TITLE
Document `samlResponse.assertions` in SAML reconcile lambda

### DIFF
--- a/astro/src/content/docs/extend/code/lambdas/_saml-response-fields.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/_saml-response-fields.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import InlineField from 'src/components/InlineField.astro';
 import RemovedSince from 'src/components/api/RemovedSince.astro';
 
 ### SAML Response Fields
@@ -59,6 +60,9 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
   </APIField>
   <APIField name="samlResponse.assertion.subject.confirmation.recipient" type="String">
     The recipient of the subject. This defaults to the callback URL (ACS).
+  </APIField>
+  <APIField name="samlResponse.assertions" type="Array" since="1.60.0">
+    An array containing all assertions on the SAML response. You can use this array to inspect the original assertions on the response instead of the combined <InlineField>assertion</InlineField>.
   </APIField>
   <APIField name="samlResponse.destination" type="String">
     The destination of the SAML response. This defaults to the callback URL (ACS).


### PR DESCRIPTION
Release notes for 1.60.0 indicated that the SAML reconcile lambda contains a new `samlResponse.assertions` field, but it was not included in the lambda documentation.