### PR TITLE
Update FusionAuth Cloud section of the proxy docs 

### DIFF
--- a/astro/src/content/docs/operate/deploy/proxy-setup.mdx
+++ b/astro/src/content/docs/operate/deploy/proxy-setup.mdx
@@ -147,7 +147,7 @@ If you are self-hosting, you can also proxy requests *from* FusionAuth, such as 
 
 ## FusionAuth Cloud Instances
 
-The latest FusionAuth Cloud Instances will use [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) to negotiate a TLS connection. If you are using a proxy in front of your FusionAuth instance, ensure it supports the use of SNI for TLS connections. Additionally, to allow for proper TLS certificate handling, the `Host` header should be set to the domain name of your FusionAuth instance (e.g. `example.fusionauth.io`).
+The latest FusionAuth Cloud Instances will use [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to negotiate a TLS connection. If you are using a proxy in front of your FusionAuth instance, ensure it supports the use of SNI for TLS connections. Additionally, to allow for proper TLS certificate handling, the `Host` header should be set to the domain name of your FusionAuth instance (e.g. `example.fusionauth.io`).
 
 ## Limits
 


### PR DESCRIPTION
### Changes made: 

Update the FusionAuth Cloud section of the proxy docs to mention the need for setting the `Host` header when using a proxy in front of a FusionAuth Cloud instance. 