### PR TITLE
Add missing doc for basic auth using an API key

### DIFF
--- a/astro/src/components/api/API.astro
+++ b/astro/src/components/api/API.astro
@@ -60,11 +60,20 @@ if (uri) {
 
 const authenticationTypes = {
   'api-key': '/docs/apis/authentication#api-key-authentication',
-  'none': '/docs/apis/authentication#no-authentication-required',
-  'jwt': '/docs/apis/authentication#jwt-authentication',
   'basic': '/docs/apis/authentication#basic-authentication-using-an-api-key',
   'client-credentials': '/docs/apis/authentication#client-credentials',
-  'local-bypass': '/docs/apis/authentication#localhost-authentication-bypass'
+  'jwt': '/docs/apis/authentication#jwt-authentication',
+  'local-bypass': '/docs/apis/authentication#localhost-authentication-bypass',
+  'none': '/docs/apis/authentication#no-authentication-required'
+}
+
+const authenticationTypeName = {
+  'api-key': 'API Key Authentication',
+  'basic': 'Basic Authentication using an API Key',
+  'client-credentials': 'Client Credentials',
+  'jwt': 'JWT Authentication',
+  'local-bypass': 'Localhost Authentication Bypass',
+  'none': 'No Authentication Required'
 }
 ---
 
@@ -73,7 +82,7 @@ const authenticationTypes = {
   { authentication &&
     <div class="not-prose flex mb-2 flex-row mx-1">
       { authentication.map(auth =>
-          <a class="no-underline flex" href={authenticationTypes[auth]}>
+          <a class="no-underline flex" href={authenticationTypes[auth]} title={authenticationTypeName[auth]}>
             <APIAuthenticationIcon type={auth}/>
           </a>
       )}

--- a/astro/src/content/docs/apis/system.mdx
+++ b/astro/src/content/docs/apis/system.mdx
@@ -235,11 +235,7 @@ FusionAuth also supports a system status check [using Prometheus](/docs/operate/
 
 ### Request
 
-<API method="GET" uri="/api/status" authentication={["none"]} title="Return the system status without an API key"/>
-
-<API method="GET" uri="/api/status" authentication={["api-key", "basic"]} title="Return the system status with an API key"/>
-
-<API method="GET" uri="/api/status" authentication={["local-bypass"]} title="Return the system status without an API key with local bypass configured"/>
+<API method="GET" uri="/api/status" authentication={["api-key", "basic", "local-bypass", "none"]} title="Return the system status"/>
 
 ### Response
 
@@ -311,7 +307,7 @@ The Version API is used to retrieve the current version of FusionAuth.
 
 ### Request
 
-<API method="GET" uri="/api/system/version" authentication={["api-key"]} title="Return the FusionAuth system version with an API key"/>
+<API method="GET" uri="/api/system/version" authentication={["api-key", "basic"]} title="Return the FusionAuth system version"/>
 
 ### Response
 
@@ -338,7 +334,7 @@ This page contains the API that is used for retrieving FusionAuth application me
 
 By default, this API requires authentication. If you prefer to allow unauthenticated access to this endpoint from local scrapers, you may set `fusionauth-app.local-metrics.enabled=true`. See the  [configuration reference](/docs/reference/configuration) for more info.
 
-<API method="GET" uri="/api/prometheus/metrics" authentication={["api-key", "basic"]} title="Retrieve FusionAuth application metrics to use with Prometheus"/>
+<API method="GET" uri="/api/prometheus/metrics" authentication={["api-key", "basic", "local-bypass"]} title="Retrieve FusionAuth application metrics to use with Prometheus"/>
 
 ### Request Parameters
 There are no request parameters required with this API.


### PR DESCRIPTION
Add missing API auth for the System Status API. 

### Related
- https://github.com/FusionAuth/fusionauth-site/issues/3919