### PR TITLE
Update RT revocation

### DIFF
--- a/astro/src/content/docs/apis/_tenant-request-body.mdx
+++ b/astro/src/content/docs/apis/_tenant-request-body.mdx
@@ -473,11 +473,11 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
   </APIField>
 
   <APIField name="tenant.jwtConfiguration.refreshTokenRevocationPolicy.onLoginPrevented" type="Boolean" optional defaults="true" since="1.17.0">
-    When enabled, all refresh tokens will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
+    When enabled, all of a user's refresh tokens will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
   </APIField>
 
   <APIField name="tenant.jwtConfiguration.refreshTokenRevocationPolicy.onMultiFactorEnable" type="Boolean" optional defaults="false" since="1.42.0">
-    When enabled, all refresh tokens will be revoked when a user enables multi-factor authentication for the first time. This policy will not be applied when adding subsequent multi-factor methods to the user.
+    When enabled, all of a user's refresh tokens will be revoked when a user enables multi-factor authentication for the first time. This policy will not be applied when adding subsequent multi-factor methods to the user.
   </APIField>
 
   <APIField name="tenant.jwtConfiguration.refreshTokenRevocationPolicy.onOneTimeTokenReuse" type="Boolean" optional defaults="false" since="1.55.1">
@@ -485,7 +485,7 @@ import TransactionTypes from 'src/content/docs/apis/_transaction-types.mdx';
   </APIField>
 
   <APIField name="tenant.jwtConfiguration.refreshTokenRevocationPolicy.onPasswordChanged" type="Boolean" optional defaults="true" since="1.17.0">
-    When enabled, all refresh tokens will be revoked when a user changes their password.
+    When enabled, all of a user's refresh tokens will be revoked when a user changes their password.
   </APIField>
 
   <APIField name="tenant.jwtConfiguration.refreshTokenSlidingWindowConfiguration.maximumTimeToLiveInMinutes" type="Integer" optional since="1.46.0">

--- a/astro/src/content/docs/apis/_tenant-response-body-base.mdx
+++ b/astro/src/content/docs/apis/_tenant-response-body-base.mdx
@@ -385,11 +385,11 @@ import JSON from 'src/components/JSON.astro';
   </APIField>
 
   <APIField name={props.base_field_name + '.jwtConfiguration.refreshTokenRevocationPolicy.onLoginPrevented'} type="Boolean" since="1.17.0">
-    When enabled, all refresh tokens will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
+    When enabled, all of a user's refresh tokens will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
   </APIField>
 
   <APIField name={props.base_field_name + '.jwtConfiguration.refreshTokenRevocationPolicy.onMultiFactorEnable'} type="Boolean" since="1.42.0">
-    When enabled, all refresh tokens will be revoked when a user enables multi-factor authentication for the first time. This policy will not be applied when adding subsequent multi-factor methods to the user.
+    When enabled, all of a user's refresh tokens will be revoked when the user enables multi-factor authentication for the first time. This policy will not be applied when adding subsequent multi-factor methods to the user.
   </APIField>
 
   <APIField name={props.base_field_name + '.jwtConfiguration.refreshTokenRevocationPolicy.onOneTimeTokenReuse'} type="Boolean" since="1.55.1">
@@ -397,7 +397,7 @@ import JSON from 'src/components/JSON.astro';
   </APIField>
 
   <APIField name={props.base_field_name + '.jwtConfiguration.refreshTokenRevocationPolicy.onPasswordChanged'} type="Boolean" since="1.17.0">
-    When enabled, all refresh tokens will be revoked when a user changes their password.
+    When enabled, all of a user's refresh tokens will be revoked when a user changes their password.
   </APIField>
 
   <APIField name={props.base_field_name + '.jwtConfiguration.refreshTokenSlidingWindowConfiguration.maximumTimeToLiveInMinutes'} type="Integer" since="1.46.0">

--- a/astro/src/content/docs/get-started/core-concepts/_refresh-token-settings.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/_refresh-token-settings.mdx
@@ -26,9 +26,9 @@ import InlineField from 'src/components/InlineField.astro';
   <APIField name="Refresh token revocation" optional renderif={props.page === "tenant"}>
     The events that will cause refresh tokens to be revoked. The possible values are:
 
-    * `On action preventing login`, which revokes all of a user's tokens when a [user action](/docs/lifecycle/manage-users/user-actions) prevents login.
-    * `On multi-factor enable`, which revokes all of a user's tokens when a user enables [multi-factor authentication](/docs/lifecycle/authenticate-users/multi-factor-authentication) for the first time.
-    * `On password change`, which revokes all of a user's tokens when a user changes their password.
+    * `On action preventing login`, which revokes all of a user's refresh tokens when a [user action](/docs/lifecycle/manage-users/user-actions) prevents login.
+    * `On multi-factor enable`, which revokes all of a user's refresh tokens when a user enables [multi-factor authentication](/docs/lifecycle/authenticate-users/multi-factor-authentication) for the first time.
+    * `On password change`, which revokes all of a user's refresh tokens when a user changes their password.
     * `On reuse of a one-time use token`, if and when a one-time use refresh token is reused, the token will be revoked. Only the reused token is revoked.
   </APIField>
 </APIBlock>

--- a/astro/src/content/docs/get-started/core-concepts/_refresh-token-settings.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/_refresh-token-settings.mdx
@@ -24,11 +24,11 @@ import InlineField from 'src/components/InlineField.astro';
     Note that one-time use tokens refreshed within a grace period are not considered for revocation when the Tenant Refresh Token Revocation Policy is configured to revoke a one-time use refresh token on reuse. When a token is reused within the grace period the current token will be returned on the API response and the token will not be rotated.
   </APIField>
   <APIField name="Refresh token revocation" optional renderif={props.page === "tenant"}>
-    The events that will cause refresh tokens to be revoked. The possible values are:
+    The events that cause refresh tokens to be revoked. The possible values are:
 
-    * `On action preventing login`, which revokes all of a user's refresh tokens when a [user action](/docs/lifecycle/manage-users/user-actions) prevents login.
-    * `On multi-factor enable`, which revokes all of a user's refresh tokens when a user enables [multi-factor authentication](/docs/lifecycle/authenticate-users/multi-factor-authentication) for the first time.
-    * `On password change`, which revokes all of a user's refresh tokens when a user changes their password.
-    * `On reuse of a one-time use token`, if and when a one-time use refresh token is reused outside of any configured grace period, the token will be revoked. Only the reused token is revoked.
+    * <InlineField>On action preventing login</InlineField> revokes all of a user's refresh tokens when a [user action](/docs/lifecycle/manage-users/user-actions) prevents login.
+    * <InlineField>On multi-factor enable</InlineField> revokes all of a user's refresh tokens when a user enables [multi-factor authentication](/docs/lifecycle/authenticate-users/multi-factor-authentication) for the first time.
+    * <InlineField>On password change</InlineField> revokes all of a user's refresh tokens when a user changes their password.
+    * <InlineField>On reuse of a one-time use token</InlineField> which revokes the token, if and when a one-time use refresh token is reused outside of any configured grace period. Only the reused token is revoked; the rest of the user's tokens remain valid.
   </APIField>
 </APIBlock>

--- a/astro/src/content/docs/get-started/core-concepts/_refresh-token-settings.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/_refresh-token-settings.mdx
@@ -24,6 +24,11 @@ import InlineField from 'src/components/InlineField.astro';
     Note that one-time use tokens refreshed within a grace period are not considered for revocation when the Tenant Refresh Token Revocation Policy is configured to revoke a one-time use refresh token on reuse. When a token is reused within the grace period the current token will be returned on the API response and the token will not be rotated.
   </APIField>
   <APIField name="Refresh token revocation" optional renderif={props.page === "tenant"}>
-    The events that will cause refresh tokens to be revoked.
+    The events that will cause refresh tokens to be revoked. The possible values are:
+
+    * `On action preventing login`, which revokes all of a user's tokens when a [user action](/docs/lifecycle/manage-users/user-actions) prevents login.
+    * `On multi-factor enable`, which revokes all of a user's tokens when a user enables [multi-factor authentication](/docs/lifecycle/authenticate-users/multi-factor-authentication) for the first time.
+    * `On password change`, which revokes all of a user's tokens when a user changes their password.
+    * `On reuse of a one-time use token`, if and when a one-time use refresh token is reused, the token will be revoked. Only the reused token is revoked.
   </APIField>
 </APIBlock>

--- a/astro/src/content/docs/get-started/core-concepts/_refresh-token-settings.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/_refresh-token-settings.mdx
@@ -29,6 +29,6 @@ import InlineField from 'src/components/InlineField.astro';
     * `On action preventing login`, which revokes all of a user's refresh tokens when a [user action](/docs/lifecycle/manage-users/user-actions) prevents login.
     * `On multi-factor enable`, which revokes all of a user's refresh tokens when a user enables [multi-factor authentication](/docs/lifecycle/authenticate-users/multi-factor-authentication) for the first time.
     * `On password change`, which revokes all of a user's refresh tokens when a user changes their password.
-    * `On reuse of a one-time use token`, if and when a one-time use refresh token is reused, the token will be revoked. Only the reused token is revoked.
+    * `On reuse of a one-time use token`, if and when a one-time use refresh token is reused outside of any configured grace period, the token will be revoked. Only the reused token is revoked.
   </APIField>
 </APIBlock>


### PR DESCRIPTION
The RT (refresh token) revocation policies were not as clear as they could be, nor were they listed on the core-concepts tenant doc page.

This PR fixes that.