### PR TITLE
Add breachedPasswordStatus to response examples and api doc

### DIFF
--- a/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
@@ -79,7 +79,7 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
     The [instant](/docs/reference/data-types#instants) this user's password was last checked for inclusion in the set of known breached credentials.
   </APIField>
   <APIField name="user.breachedPasswordStatus" type="String">
-    If a user has been compromised, this field shows the level of compromise from the following options:
+    Shows whether or not a user's password has been compromised, based on a comparison with a list of known breached passwords. May have any of the following values:
 
     * `None`: this password does not exist in the set of known breached passwords
     * `CommonPassword`: this account currently uses a commonly used password that exists repeatedly in the set of known breached passwords (e.g. `12345`)

--- a/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-response-body.mdx
@@ -76,7 +76,16 @@ import RemovedSince from 'src/components/api/RemovedSince.astro';
     The User's birthdate formatted as `YYYY-MM-DD`
   </APIField>
   <APIField name="user.breachedPasswordLastCheckedInstant" type="Long">
-    The [instant](/docs/reference/data-types#instants) this user's password was last checked to determine if is compromised.
+    The [instant](/docs/reference/data-types#instants) this user's password was last checked for inclusion in the set of known breached credentials.
+  </APIField>
+  <APIField name="user.breachedPasswordStatus" type="String">
+    If a user has been compromised, this field shows the level of compromise from the following options:
+
+    * `None`: this password does not exist in the set of known breached passwords
+    * `CommonPassword`: this account currently uses a commonly used password that exists repeatedly in the set of known breached passwords (e.g. `12345`)
+    * `PasswordOnly`: this password exists in the set of known breached passwords, but the username does not
+    * `ExactMatch`: this precise username and password combination exists in the set of known breached credentials
+    * `SubAddressMatch`: some combination of an [subaddress](https://www.rfc-editor.org/rfc/rfc5233) of the user's email (e.g `myemail+subaddress@example.org`) and this password exists in the set of known breached credentials
   </APIField>
   <APIField name="user.cleanSpeakId" type="UUID">
     This Id is used by FusionAuth when the User's username is sent to CleanSpeak to be moderated (filtered and potentially sent to the approval queue). It is the **content Id** of the username inside CleanSpeak.

--- a/astro/src/content/json/users/create-response.json
+++ b/astro/src/content/json/users/create-response.json
@@ -3,6 +3,7 @@
   "user": {
     "active": true,
     "breachedPasswordLastCheckedInstant": 1471786483322,
+    "breachedPasswordStatus": "None",
     "birthDate": "1976-05-30",
     "connectorId": "e3306678-a53a-4964-9040-1c96f36dda72",
     "data": {

--- a/astro/src/content/json/users/login-response.json
+++ b/astro/src/content/json/users/login-response.json
@@ -3,6 +3,8 @@
   "user": {
     "active": true,
     "birthDate": "1976-05-30",
+    "breachedPasswordLastCheckedInstant": 1471786483322,
+    "breachedPasswordStatus": "None",
     "connectorId": "e3306678-a53a-4964-9040-1c96f36dda72",
     "data": {
       "displayName": "Johnny Boy",

--- a/astro/src/content/json/users/passwordless-login-response.json
+++ b/astro/src/content/json/users/passwordless-login-response.json
@@ -9,6 +9,8 @@
   },
   "user": {
     "active": true,
+    "breachedPasswordLastCheckedInstant": 1471786483322,
+    "breachedPasswordStatus": "None",
     "birthDate": "1976-05-30",
     "connectorId": "e3306678-a53a-4964-9040-1c96f36dda72",
     "data": {

--- a/astro/src/content/json/users/response.json
+++ b/astro/src/content/json/users/response.json
@@ -2,6 +2,7 @@
   "user": {
     "active": true,
     "breachedPasswordLastCheckedInstant": 1471786483322,
+    "breachedPasswordStatus": "None",
     "birthDate": "1976-05-30",
     "connectorId": "e3306678-a53a-4964-9040-1c96f36dda72",
     "data": {

--- a/astro/src/content/json/users/users-response.json
+++ b/astro/src/content/json/users/users-response.json
@@ -4,6 +4,7 @@
       "active": true,
       "birthDate": "1976-05-30",
       "breachedPasswordLastCheckedInstant": 1471786483322,
+      "breachedPasswordStatus": "None",
       "data": {
         "displayName": "Johnny Boy",
         "favoriteColors": [

--- a/astro/src/content/json/users/users-search-response.json
+++ b/astro/src/content/json/users/users-search-response.json
@@ -7,6 +7,7 @@
       "active": true,
       "birthDate": "1976-05-30",
       "breachedPasswordLastCheckedInstant": 1471786483322,
+      "breachedPasswordStatus": "None",
       "data": {
         "displayName": "Johnny Boy",
         "favoriteColors": [


### PR DESCRIPTION
Loosely inspired by the definitions here: https://github.com/FusionAuth/fusionauth-java-client/blob/develop/src/main/java/io/fusionauth/domain/BreachedPasswordStatus.java


Fixes https://github.com/FusionAuth/fusionauth-site/issues/4076