### PR TITLE
chore: add Algolia site verification meta tag

### DIFF
--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -48,6 +48,7 @@ const slug = Astro.params.slug;
   <meta name="viewport" content="width=device-width"/>
   <link rel="icon" type="image/png" href="/img/favicon.png"/>
   { canonical && <link rel="canonical" href={canonical} /> }
+  <meta name="algolia-site-verification" content="857638C054AD182F" />
   <link rel="sitemap" href="/sitemap-index.xml">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="/css/brands.min.css"/>


### PR DESCRIPTION
Adds an algolia verification tag to allow us to experiment with / use the free Algolia DocsSearch product.

I checked that the tag actually appears on the /docs page locally

<img width="2546" height="628" alt="image" src="https://github.com/user-attachments/assets/7524fb00-3a4d-4c04-9c9c-13f73ce19066" />
