### PR TITLE
Uncomment Part 2 link in BFF article series section

### DIFF
--- a/astro/src/content/blog/backend-for-frontend-security-architecture.mdx
+++ b/astro/src/content/blog/backend-for-frontend-security-architecture.mdx
@@ -504,10 +504,10 @@ Although BFF isn't necessary for every application, it's strongly recommended if
 2. Evaluate whether your current auth provider's default pattern is secure.
 
 
-{/* TODO: Uncomment when parts 2 and 3 are published.
 ## Next in this series
 
 Part 2 examines the [Token-Mediating Backend (TMB) architecture pattern](/blog/auth-architecture-part2-tmb) - the middle-ground approach that many auth providers use by default. Learn why it's better than storing all tokens in the browser but still falls short of BFF's security guarantees, explore real implementations of TMB, and discover when using TMB is acceptable despite its limitations.
 
+{/* TODO: Uncomment when part 3 is published.
 Part 3 covers the [Browser-Based OAuth Client (BBOC) architecture](/blog/browser-based-oauth-client-security-architecture) - the least secure pattern, which the draft specifically recommends against using for sensitive applications. Learn why some providers still default to this pattern and what you absolutely must do if you're stuck with it.
 */}


### PR DESCRIPTION
Part 1 had the "Next in this series" section commented out pending Part 2's publication. Part 2 is now up for review in https://github.com/FusionAuth/fusionauth-site/pull/3949, so this uncomments the Part 2 link. The Part 3 link stays commented out until Part 3 ships.