### PR TITLE
docs: add trailing slash to canonical links

### DIFF
--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -42,9 +42,9 @@ if (canonical.endsWith('index.html')) {
   canonical = canonical.slice(0, canonical.indexOf('.html'));
 }
 
-// CloudFront redirects all extensionless URLs to their trailing-slash form,
+// CloudFront redirects /docs/ URLs to their trailing-slash form,
 // so the canonical must match the URL that actually gets served.
-if (!canonical.endsWith('/') && !/\.[a-z]{2,5}$/i.test(canonical.split('?')[0])) {
+if (!canonical.endsWith('/') && (canonical.includes('/docs/') || canonical.endsWith('/docs'))) {
   canonical += '/';
 }
 const slug = Astro.params.slug;

--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -41,6 +41,12 @@ if (canonical.endsWith('index.html')) {
 } else if (canonical.endsWith('.html')) {
   canonical = canonical.slice(0, canonical.indexOf('.html'));
 }
+
+// CloudFront redirects all extensionless URLs to their trailing-slash form,
+// so the canonical must match the URL that actually gets served.
+if (!canonical.endsWith('/') && !/\.[a-z]{2,5}$/i.test(canonical.split('?')[0])) {
+  canonical += '/';
+}
 const slug = Astro.params.slug;
 ---
 <head>


### PR DESCRIPTION
Scrapers currently get confused (including Algolia scraper that we need to test out new search solution) because 

- https://fusionauth.io/docs redirects to https://fusionauth.io/docs/ (with trailing slash)
- https://fusionauth.io/docs/ lists https://fusionauth.io/docs as canonical 

So the scraper follows the redirect and then gets directed back to where it came again.

Limiting the rule to just '/docs/ for now but we might want to expand it /blog /articles etc too.

- Tested the build and extracted all canconical links to a txt file and check that they all look correct, 

<img width="2760" height="1786" alt="CleanShot 2026-04-24 at 10 17 54@2x" src="https://github.com/user-attachments/assets/3cb27fed-f7f8-4a1e-bfd5-eeee7dce1531" />

