### PR TITLE
fix: canonical links again

### DIFF
--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -9,6 +9,7 @@ interface Props {
   title?: string;
   openGraphImage?: string;
   canonicalUrl?: string;
+  isIndexPage?: boolean;
   searchFilters?: { [key: string]: string[] };
 }
 
@@ -19,6 +20,7 @@ const {
   enableKapa = true,
   title, openGraphImage,
   canonicalUrl,
+  isIndexPage = false,
   searchFilters = {}
 } = Astro.props;
 const openGraphImageUrl = openGraphImage ? new URL(openGraphImage, Astro.url): new URL("/img/og/articles-developers-v1.png", Astro.url);
@@ -42,9 +44,9 @@ if (canonical.endsWith('index.html')) {
   canonical = canonical.slice(0, canonical.indexOf('.html'));
 }
 
-// CloudFront redirects /docs/ URLs to their trailing-slash form,
-// so the canonical must match the URL that actually gets served.
-if (!canonical.endsWith('/') && (canonical.includes('/docs/') || canonical.endsWith('/docs'))) {
+// Pages built from index.mdx are served as a directory (with trailing slash);
+// standalone .mdx files are served without one. Match whichever URL is served.
+if (isIndexPage && !canonical.endsWith('/')) {
   canonical += '/';
 }
 const slug = Astro.params.slug;

--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -33,6 +33,7 @@ interface Props {
   breadcrumbs?: any[];
   maxTocDepth?: number;
   noBreadcrumb: boolean;
+  isIndexPage?: boolean;
 }
 
 let {
@@ -56,6 +57,7 @@ let {
   breadcrumbs = [],
   searchFilters = {},
   maxTocDepth,
+  isIndexPage = false,
 }: Props = Astro.props;
 
 author = frontmatter.author ? frontmatter.author : author;
@@ -133,7 +135,7 @@ const cleanedHtmlTitle = htmlTitle
 
 <!DOCTYPE html>
 <html class="antialiased min-h-full" lang="en">
-<Head title=`${cleanedHtmlTitle} | FusionAuth Docs` description={description} canonicalUrl={frontmatter.canonicalUrl} {openGraphImage} {searchFilters} />
+<Head title=`${cleanedHtmlTitle} | FusionAuth Docs` description={description} canonicalUrl={frontmatter.canonicalUrl} {isIndexPage} {openGraphImage} {searchFilters} />
 <IndexableBody {excludeFromSearchIndex}>
   <slot name="nav"/>
   <main class:list={mainStyles}>

--- a/astro/src/pages/docs/[...slug].astro
+++ b/astro/src/pages/docs/[...slug].astro
@@ -25,7 +25,8 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content, headings } = await render(entry);
+const isIndexPage = entry.id === 'index' || entry.id.endsWith('/index');
 ---
-<Layout frontmatter={entry.data} {headings} disableTOC={entry.data.disableTOC || headings.length ===0}>
+<Layout frontmatter={entry.data} {headings} {isIndexPage} disableTOC={entry.data.disableTOC || headings.length ===0}>
   <Content />
 </Layout>


### PR DESCRIPTION
I did not realize from previous fix that not _all_ pages have trailing slash. Folders have an 'index.md' file which creates a page that gets a slash. "leaf" pages with unique names do not get a slash

<img width="1440" height="746" alt="image" src="https://github.com/user-attachments/assets/b833a471-64ec-4718-936d-40bc89a5f3cd" />

<img width="1840" height="860" alt="image" src="https://github.com/user-attachments/assets/32728e2a-ba03-491b-ac20-730e11e18f07" />


So the previous fix was partially successful and allowed us to scrape 50 pages from Algolia, but this one includes logic ot pass through whether or not a file is an index file, and only add the slash if it is.

<img width="1384" height="584" alt="image" src="https://github.com/user-attachments/assets/732ed786-8411-4ecc-a945-a9b6fb014cea" />

I checked the build folder and spot checked ten links of each category to make sure the logic works.
