### PR TITLE
fix: prevent double scroll bars

### DIFF
--- a/astro/src/components/Sidebar.astro
+++ b/astro/src/components/Sidebar.astro
@@ -139,7 +139,7 @@ function getSortedArray(nodeChildren: Record<string, any>) {
 const treeArray = getSortedArray(treeRoot.children);
 ---
 
-<aside class="w-64 flex-shrink-0 h-[calc(100vh-4rem)] sticky top-16 overflow-y-auto border-r border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 pt-2 pr-2 pl-0">
+<aside class="w-64 flex-shrink-0 h-[calc(100vh-4rem)] sticky top-16 border-r border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 pt-2 pr-2 pl-0">
   <nav class="flex flex-col gap-1">
     {treeArray.map(node => (
       <SidebarItem node={node} />

--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -113,7 +113,7 @@ const mainStyles = [
 const sideNavStyles = [
   "lg:bg-opacity-0 hidden dark:bg-slate-900 bg-white absolute top-[110px] py-4 w-64 -left-0 z-10",
   // spacing
-  "lg:block lg:max-w-[270px] lg:w-full lg:pr-4 lg:mr-6 lg:py-0 lg:sticky lg:top-24 lg:self-start overflow-y-auto lg:max-h-[calc(100vh-100px)]"
+  "lg:block lg:max-w-[270px] lg:w-full lg:pr-4 lg:mr-6 lg:py-0 lg:sticky lg:top-[calc(--spacing(24)+1px)] lg:self-start overflow-y-auto lg:max-h-[calc(100vh-100px)]"
 ];
 
 const tocStyles = [


### PR DESCRIPTION
Currently there are two scrollbars in the side navigation:
<img width="287" height="614" alt="grafik" src="https://github.com/user-attachments/assets/c5d44da5-014f-457a-a411-ce5bb28d32bf" />

This change removes the inner scrollbar, and restores the behavior pre PR #4200 

Also when scrolling the page, the navigation shifts by one pixel.