### PR TITLE
fix: update headings to start with h2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ vendor
 # VS Code
 .vscode/
 *.code-workspace
+/.idea/

--- a/astro/src/content/docs/apis/errors.mdx
+++ b/astro/src/content/docs/apis/errors.mdx
@@ -9,7 +9,7 @@ import InlineField from 'src/components/InlineField.astro';
 
 When FusionAuth encounters an error or finds validation errors in your request, an Errors object is returned in the response body. The Errors object is defined as follows, where <InlineField>fieldName</InlineField> indicates the field in the request body the message is describing and <InlineField>[x]</InlineField> indicates the value is part of an array of one or more values.
 
-### Error Fields
+## Error Fields
 
 <APIBlock>
   <APIField name="generalErrors" type="Array">

--- a/astro/src/content/docs/customize/email-and-messages/twilio-messenger.mdx
+++ b/astro/src/content/docs/customize/email-and-messages/twilio-messenger.mdx
@@ -18,13 +18,13 @@ This page explains how to connect your FusionAuth instance to Twilio messenger t
 
 To create a new Twilio messenger, navigate to <Breadcrumb>Settings -> Messengers</Breadcrumb>. Click <InlineUIElement>Add Twilio Messenger</InlineUIElement> from the dropdown in the upper right.
 
-### Add Twilio Messenger
+## Add Twilio Messenger
 
 ![Add Messenger Twilio](/img/docs/customize/email-and-messages/add-messenger-twilio.png)
 
 Complete the following fields:
 
-#### Form Fields
+### Form Fields
 
 <APIBlock>
   <APIField name="Id" optional>
@@ -53,7 +53,7 @@ Complete the following fields:
   </APIField>
 </APIBlock>
 
-### Testing Your Configuration
+## Testing Your Configuration
 
 ![Test Configuration Twilio](/img/docs/customize/email-and-messages/configuration-test-twilio.png)
 

--- a/astro/src/content/docs/customize/look-and-feel/advanced-themes/examples.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/advanced-themes/examples.mdx
@@ -7,7 +7,7 @@ import InlineField from 'src/components/InlineField.astro';
 
 Want to show off your FusionAuth theming skills? Feel free to send us a few screenshots and you may show up on this page!
 
-### Celery Payroll
+## Celery Payroll
 https://www.celerypayroll.com
 
 The left image is the login page rendered in English, the right example is the same page in Dutch using FusionAuth localization.
@@ -16,12 +16,12 @@ The left image is the login page rendered in English, the right example is the s
 
 ![Celery Login Dutch](/img/docs/customize/look-and-feel/celery-login_nl.png)
 
-### Gmork Tech
+## Gmork Tech
 
 https://dagger.gmork.tech/
 
 ![Gmork Tech](/img/docs/customize/look-and-feel/gmork-tech-login.png)
 
-### Oryx Software
+## Oryx Software
 
 ![Oryx Software](/img/docs/customize/look-and-feel/oryx-login.png)

--- a/astro/src/content/docs/extend/events-and-webhooks/events/index.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/index.mdx
@@ -54,7 +54,7 @@ These are the events that FusionAuth generates that can be optionally consumed b
 * [User Update](/docs/extend/events-and-webhooks/events/user/user-update) - when a user is updated
 * [User Update Complete](/docs/extend/events-and-webhooks/events/user/user-update-complete) - when a user update transaction has completed
 
-### Breached Password Events
+## Breached Password Events
 
 These are the Breached Password licensed events that may FusionAuth generates that can be optionally consumed by your registered Webhook.
 
@@ -62,7 +62,7 @@ These are the Breached Password licensed events that may FusionAuth generates th
 
 * [User Password Breach](/docs/extend/events-and-webhooks/events/user/password/user-password-breach) - when Reactor detects a user is using a potentially breached password
 
-### Threat Detection Events
+## Threat Detection Events
 
 These are the Threat Detection licensed events that may FusionAuth generates that can be optionally consumed by your registered Webhook.
 
@@ -70,7 +70,7 @@ These are the Threat Detection licensed events that may FusionAuth generates tha
 
 <ListAdvancedThreatDetectionWebhooks />
 
-### Tenant Scoped Events
+## Tenant Scoped Events
 
 Tenant scoped events are generated for all applications in a tenant or for none of them.
 
@@ -78,11 +78,11 @@ All user events are tenant scoped because a user is a tenant scoped entity. For 
 
 A tenant scoped event can, however contain an `applicationId` which can be used to filter events when received. One example is `user.registration.create`.
 
-### Application Scoped Events
+## Application Scoped Events
 
 <ApplicationWebhooksWarning />
 
-### Transaction Compatibility
+## Transaction Compatibility
 
 Events can be either transactional or non-transactional. The final state of the operation which caused a transaction event is not persisted to FusionAuth until after the configured webhook finishes. Non-transactional events do not require any webhooks to succeed.
 

--- a/astro/src/content/docs/extend/events-and-webhooks/signing.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/signing.mdx
@@ -15,7 +15,7 @@ Signing Webhook events allows you to verify each event was sent by FusionAuth. W
 
 This document covers configuring webhook signatures, verifying signatures in your webhook listener, and key rotation.
 
-### Configuration
+## Configuration
 
 Configuring webhook signatures in FusionAuth consists of generating a key and configuring your webhook to sign using that key.
 
@@ -36,7 +36,7 @@ Next, you configure your webhook to sign the event with this key. From <Breadcru
 
 ![Webhook Settings Signature](/img/docs/extend/events-and-webhooks/webhook-settings-signature.png)
 
-### Signature Verification
+## Signature Verification
 
 The webhook signature is provided in the HTTP header `X-FusionAuth-Signature-JWT` as a signed JWT with a claim of `request_body_sha256` containing the SHA-256 hash of the webhook event payload.
 
@@ -69,17 +69,17 @@ The JWT decodes with:
 
 The `kid` identifies the Id of the key used to sign the JWT. JWT libraries can look the key up from the JWKS endpoint, or a locally stored key can be used. After verifying the JWT signature, the JWT's `request_body_sha256` payload claim is compared against your own calculated SHA-256 hash of the event body
 
-### Example Webhook Listener Code
+## Example Webhook Listener Code
 
 The following code ([available on GitHub](https://github.com/FusionAuth/fusionauth-example-javascript-webhooks/blob/main/signature-verify/app.js)) demonstrates webhook signature verification with a simple Node server.
 
 <RemoteCode title="Example Node.js Webhook Signature Verifier" lang="javascript" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-javascript-webhooks/main/signature-verify/app.js" />
 
-### Testing
+## Testing
 
 The [Webhook Testing](/docs/extend/events-and-webhooks#test-a-webhook) page provides a quick way to test your webhook signature configuration and signature verification on your webhook listener.
 
-### Key Rotation
+## Key Rotation
 
 [Rotating keys](/docs/operate/secure/key-rotation) regularly is an important part of a defense-in-depth strategy. The type of key used for signing webhook events and the method used for fetching that key determines the process for rotating keys.
 

--- a/astro/src/content/docs/get-started/core-concepts/authentication-authorization.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/authentication-authorization.mdx
@@ -15,7 +15,7 @@ Authentication and authorization are two fundamental concepts in FusionAuth. The
 
 Authentication is sometimes referred to as `authn` or `AuthN` and authorization is sometimes referred to as `authz` or `AuthZ`.
 
-### Authentication in FusionAuth
+## Authentication in FusionAuth
 
 Authentication means that a user has provided credentials which the system has accepted. This is often a username and password, but could be a code from a magic link, a token from a social auth provider, or a JWT from an external identity provider.
 
@@ -29,7 +29,7 @@ The JWT will contain information about the user. Here's an example of the payloa
 
 <JSON title="Example JWT For an Authenticated But Not Authorized User" src="login/jwt-unauthorized.json" />
 
-### Authorization in FusionAuth
+## Authorization in FusionAuth
 
 Authorization means that the user has been registered with an application. Authentication is a necessary prerequisite to authorization; if FusionAuth doesn't know who the user is, it can't know what resources the user is allowed to access.
 
@@ -39,7 +39,7 @@ In either case, the end result of the request will be a JWT containing informati
 
 <JSON title="Example JWT For an Authorized User" src="login/jwt.json" />
 
-### Authorization and Securing Your Application
+## Authorization and Securing Your Application
 
 These concepts are critical to application security.
 
@@ -55,7 +55,7 @@ If you enable <InlineField>Require registration</InlineField> on an application,
 
 The `aud` claim identifies the context of the request, in other words who is this JWT for: a Payroll application, a mobile application, etc. The presence of the `applicationId` and `roles` claims identifies the User's registration (authorization) and access (roles) to the requested resource identified by the `aud` claim.
 
-### An Example
+## An Example
 
 Say you have three people trying to log in:
 

--- a/astro/src/content/docs/get-started/core-concepts/premium-features.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/premium-features.mdx
@@ -7,21 +7,21 @@ import Features from 'src/content/docs/_features.astro';
 
 FusionAuth has a full-featured Community plan, but some features are reserved for customer with a license key. This section outlines the features and how to use them.
 
-### Licensed Community Features
+## Licensed Community Features
 
 <Features plan="licensed" />
 
-### Premium Features
+## Premium Features
 
 {/*  Don't add a new feature here. Add it to the src/content/json/features.json file and the list will be generated. */}
 <Features plan="premium" />
 
-### Advanced Features
+## Advanced Features
 
 {/*  Don't add a new feature here. Add it to the src/content/json/features.json file and the list will be generated. */}
 <Features plan="advanced" />
 
-### Enterprise Features
+## Enterprise Features
 
 {/*  Don't add a new feature here. Add it to the src/content/json/features.json file and the list will be generated. */}
 <Features plan="enterprise" />

--- a/astro/src/content/docs/get-started/core-concepts/types-and-relationships.mdx
+++ b/astro/src/content/docs/get-started/core-concepts/types-and-relationships.mdx
@@ -11,7 +11,7 @@ The first set of FusionAuth types are **Tenants**, **Applications**, **Groups**,
 
 The second set of types are **Entity Types**, **Entities**, **Permissions**, and **Entity Grants**. These types were added to FusionAuth in 2021, after the original set of types in the previous paragraph. These types are used for machine-to-machine authentication, and provide a case-specific way to model things (entities), rather than organizations. 
 
-### Applications And Users
+## Applications And Users
 
 A tenant in FusionAuth is a completely isolated environment, with its own set of users, applications, and configurations, independent of other tenants, even if they share the same FusionAuth instance.
 
@@ -41,7 +41,7 @@ In the meantime, there are two workarounds you can implement:
 - Manage permissions in your website code. Keep the user and role associations in FusionAuth, but link roles to permissions in your website database, not in FusionAuth. When a user logs in with FusionAuth, your website queries the database to retrieve all permissions associated with their roles and applies them to the user. This treats FusionAuth more as an authentication system than an authorization system.
 </Aside>
 
-### Entities And Permissions
+## Entities And Permissions
 
 An entity in FusionAuth is just a name, and can represent anything — a company, document, or refrigerator. The only functional aspect to an entity is that it can be used for machine-to-machine authentication with the client credentials OAuth flow. In this case, an entity usually represents a service. Entities are only available with a paid FusionAuth license.
 
@@ -53,7 +53,7 @@ For example, you could make an entity type called "Company", with entities like 
 
 As with roles, permissions in FusionAuth have no functional meaning. They are merely strings passed to your website when a user logs in, and your website can use them in any way.
 
-### A Diagram Of All FusionAuth Types
+## A Diagram Of All FusionAuth Types
 
 The diagram below illustrates the relationships between FusionAuth types as described in the previous sections, pairing each type name with its corresponding example object. Read the diagram from bottom to top to see who is a member of what, or who has what attributes.
 

--- a/astro/src/content/docs/get-started/download-and-install/reference/server-layout.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/reference/server-layout.mdx
@@ -15,7 +15,7 @@ After you have selected a desired server layout, see the installation links belo
 * [Install FusionAuth Search](/docs/get-started/download-and-install/search)
 * [Install FusionAuth App](/docs/get-started/download-and-install/fusionauth-app)
 
-### Single server
+## Single server
 
 ![One server](/img/docs/get-started/download-and-install/single-server.png)
 
@@ -25,7 +25,7 @@ This configuration uses a single server to host all of the components for Fusion
 * QA / Staging environments
 * Small production deployments
 
-### Two servers with external database
+## Two servers with external database
 
 ![Two servers with an external database](/img/docs/get-started/download-and-install/two-servers-external-db.png)
 
@@ -40,7 +40,7 @@ In this scenario FusionAuth should be placed behind a load balancer to utilize b
 * Staging environments
 * Production deployments
 
-### Horizontally Scaled with external database
+## Horizontally Scaled with external database
 
 ![Horizontally scaled with an external database](/img/docs/get-started/download-and-install/n-servers-external-db.png)
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/application-authentication-tokens.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/application-authentication-tokens.mdx
@@ -19,7 +19,7 @@ token for you which is highly recommended, the token is built using a secure ran
 While 128 bites of entropy is generally considered to be sufficiently secure , the generated Authentication Token provides 256 bites of entropy. This value is calculated
 by multiplying the number of characters by the entropy per character, and because a Base64 encoded character provides a entropy of 5.954 bits, a 43 character string will have 256 bits of entropy.
 
-### Enabling Authentication Tokens
+## Enabling Authentication Tokens
 
 To enable Authentication Tokens, open the FusionAuth web interface and navigate to <Breadcrumb>Applications</Breadcrumb> from the main menu. Edit the Application you want to use Authentication Tokens for and click the Security tab. You'll see an option like this:
 
@@ -27,7 +27,7 @@ To enable Authentication Tokens, open the FusionAuth web interface and navigate 
 
 Enable this option and save the change to your Application.
 
-### Generating Authentication Tokens
+## Generating Authentication Tokens
 
 Once the Authentication Tokens are enabled for a specific Application, you can ask FusionAuth to generate one for a User by creating or
 updating a User Registration. To accomplish this, you will set the request parameter named `generateAuthenticationToken` to true in
@@ -43,7 +43,7 @@ This request will result in a response that includes an Authentication Token lik
 
 For more information, review the [User Registration APIs](/docs/apis/registrations).
 
-### Authenticating Using a Token
+## Authenticating Using a Token
 
 Once a User has been given an Application specific Authentication Token, you can supply it on the [Login API](/docs/apis/login) as long as
 you include the Application Id in the request as well.

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/enterprise/azure-ad-oidc.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/enterprise/azure-ad-oidc.mdx
@@ -18,7 +18,7 @@ Once you have completed this configuration you may enable an OpenID Connect <Inl
 
 <AzureAside />
 
-### Register a New Azure Active Directory Application
+## Register a New Azure Active Directory Application
 
 You will first need to login to the [Azure Portal](https://azure.microsoft.com/en-us/features/azure-portal/).
 
@@ -32,7 +32,7 @@ Here we have configured our application `Redirect URI`.  If FusionAuth is runnin
 
 Once the application has been created, note the `Application (client) ID` and the `Directory (tenant) ID`.  These will be used respectively as the <InlineField>Client Id</InlineField> value and to construct the <InlineField>Issuer</InlineField> value in your FusionAuth OpenID Connect Identity Provider configuration.
 
-### Create a New Azure Active Directory Application Secret
+## Create a New Azure Active Directory Application Secret
 
 Navigate to <Breadcrumb>Azure Active Directory -> App Registrations -> Your Application -> Certificates & secrets -> New client secret</Breadcrumb> to create a new Azure Active Directory Application Client Secret.
 
@@ -40,7 +40,7 @@ Navigate to <Breadcrumb>Azure Active Directory -> App Registrations -> Your Appl
 
 Note the `VALUE` of the created client secret.  This will be used as the <InlineField>Client secret</InlineField> value in your FusionAuth OpenID Connect Identity Provider configuration.
 
-### Configure a New FusionAuth OpenID Connect Identity Provider
+## Configure a New FusionAuth OpenID Connect Identity Provider
 
 To create an Azure AD Identity Provider return to FusionAuth and navigate to <Breadcrumb>Settings -> Identity Providers</Breadcrumb> and click <InlineUIElement>Add provider</InlineUIElement> and select <InlineUIElement>OpenID Connect</InlineUIElement> from the dialog.
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/external-jwt/example.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/external-jwt/example.mdx
@@ -11,7 +11,7 @@ The [Identity Providers](/docs/apis/identity-providers/) APIs allow you to confi
 
 A typical use case for federated login is when you have users that wish to log into your application but their password is stored and managed in another identity provider.
 
-### Overview
+## Overview
 
 A concrete example of this scenario is when you have implemented FusionAuth as your primary identity
 provider and you have a subset of users that may exist in Active Directory that you need to authenticate to your application.

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/gaming/discord.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/gaming/discord.mdx
@@ -13,7 +13,7 @@ Once you have completed this configuration you may enable an OpenID Connect <Inl
 
 <IdentityProviderOverviewDiagram identity_provider_name="Discord" />
 
-### Register a Discord OAuth2 Application
+## Register a Discord OAuth2 Application
 
 First, log in to [Discord](https://discord.com/developers/applications/). Then, navigate to [https://discord.com/developers/applications/](https://discord.com/developers/applications/) and create a new application.
 
@@ -27,7 +27,7 @@ To configure the callback URL for your application, add `/oauth2/callback` to th
 
 Note the `CLIENT ID` and the `CLIENT SECRET` after the application is created. You'll use these to configure the <InlineField>Client Id</InlineField> and <InlineField>Client secret</InlineField> values for your FusionAuth OpenID Connected Identity Provider.
 
-### Configure a New FusionAuth OpenID Connect Identity Provider
+## Configure a New FusionAuth OpenID Connect Identity Provider
 
 To create a Discord Identity Provider, open FusionAuth, navigate to <Breadcrumb>Settings -> Identity Providers</Breadcrumb>, and click <InlineUIElement>Add OpenID Connect</InlineUIElement>.
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/integrations/saml/zendesk.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/integrations/saml/zendesk.mdx
@@ -12,7 +12,7 @@ We'll also set up roles in FusionAuth to automatically grant agent dashboard acc
 
 <YouTube id="QYuTOD8wjZU" />
 
-### Prerequisites
+## Prerequisites
 
 This document assumes you have a running instance of FusionAuth and a working Zendesk application. You will also need admin accounts for both to configure them correctly.
 
@@ -20,7 +20,7 @@ Additionally, you'll need to know your Zendesk URL. It may be something like: `h
 
 Finally, you'll need a FusionAuth user that you will use to sign into Zendesk. You can use an existing user or create a new user for this purpose.
 
-### Configure FusionAuth
+## Configure FusionAuth
 
 First, we want to create a new application named, `Zendesk`, in FusionAuth. Navigate to <Breadcrumb>Applications</Breadcrumb> and create an application with the following two roles:
 
@@ -80,7 +80,7 @@ Finally, go to <Breadcrumb>Settings -> Key Master</Breadcrumb> and view the `Sig
 
 ![The required certificate fingerprint.](/img/docs/lifecycle/authenticate-users/integrations/saml/fingerprint-for-zendesk.png)
 
-### Configure Zendesk
+## Configure Zendesk
 
 The [general Zendesk SSO instructions](https://support.zendesk.com/hc/en-us/articles/203663676) are worth reading.
 
@@ -102,7 +102,7 @@ Navigate to the `End users` section. Check `External authentication`. You should
 
 You can also uncheck `Zendesk Authentication` in these two sections to ensure that users are managed only in FusionAuth. 
 
-### Log in
+## Log in
 
 Open a different browser and go to your Zendesk URL: `https://fusionauth-example.zendesk.com/`.
 
@@ -110,7 +110,7 @@ Enter the user credentials previously configured in FusionAuth.
 
 You should arrive at a screen appropriate to the role of the user (Help Center for end users, the Zendesk dashboard for others).
 
-### Troubleshooting
+## Troubleshooting
 
 Admin users will be able to access their dashboard at `https://fusionauth-example.zendesk.com/access/normal` should FusionAuth be unavailable for any reason. There's more information at the [Zendesk help center](https://support.zendesk.com/hc/en-us/articles/115006925348-Accessing-your-Zendesk-account-when-your-SSO-service-is-down).
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/prompt.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/prompt.mdx
@@ -11,17 +11,17 @@ import Aside from 'src/components/Aside.astro';
 
 The OpenID Connect prompt parameter provides additional flexibility to control the login workflow.
 
-### Supported values
+## Supported values
 
 - `none` - No user interface is displayed. An error is returned if the user is not already authenticated.
 - `login` - The user will be prompted for authentication when there's an existing SSO session.
 - `consent` - Always prompt for consent from the user.
 
-### Example use cases
+## Example use cases
 
 The following examples use a single consent value. A request may contain more than one consent value unless one of the values is `none`. For example, adding `prompt=login none` to the request will result in a validation error.
 
-#### Silent authentication
+### Silent authentication
 
 This is usually used when an application would like obtain a new authorization code grant without any user interaction. The application will receive an error user interaction is required. The application can then decide how and when to ask the user to authenticate.
 
@@ -29,17 +29,17 @@ Add `prompt=none` to the request.
 
 For an authorization code grant response that contains `code`, complete the code exchange to finish a silent authentication. If the response contains `error` then the user will require some sort of interaction to complete authentication. See [Error handling](#error-handling) below for some examples.
 
-#### Require reauthentication
+### Require reauthentication
 Require the user to authenticate even if they have an active SSO session.
 
 Add `prompt=login` to the request.
 
-#### Require reauthentication for a session older than 120 seconds
+### Require reauthentication for a session older than 120 seconds
 Authenticate a user if the session was created less than `120` seconds ago, otherwise require the user to authenticate again.
 
 Add `max_age=120` to the request.
 
-#### Force consent
+### Force consent
 Force prompting the user for consent for the requested scopes even if the scopes were previously accepted or rejected.
 
 Add `prompt=consent` to the request.
@@ -63,7 +63,7 @@ The following table shows the expected behavior for different consent configurat
 
 The table shows that the only time adding `prompt=consent` changes display of the consent prompt to the end user is when the application is configured as third party, and the consent mode is set to Remember decision.
 
-#### Error handling
+### Error handling
 
 An error will be returned when the request containing a supported prompt value cannot be completed.
 
@@ -85,7 +85,7 @@ Another example is when the user is required to provide consent even when there'
 
 See [OAuth2 Error Redirect parameters](/docs/lifecycle/authenticate-users/oauth/endpoints#redirect-parameters-2) for additional information.
 
-### Identity providers
+## Identity providers
 
 <Aside type="version">
   In version 1.61.0 and beyond the following rules will apply as it relates to third party identity providers.
@@ -97,7 +97,7 @@ For all other identity provider types, the `prompt` parameter will not be forwar
 
 When `max_age` is specified and the value is `0` or the FusionAuth SSO session age is greater than the specified value, this parameter will be converted to `prompt=login` and the above rules will then be applied to an OpenID Connect or SAML v2 identity provider. The `max_age` parameter is never forwarded.
 
-### Security considerations
+## Security considerations
 Use `prompt=login` or `max_age` with the correct expectations. Don't rely on these parameters for either a security guarantee or that the user is reauthenticated. This is because request parameters can be removed easily.
 
 For example, if a user with an existing SSO session removes the `prompt=login` parameter, an authorization code is generated and redirected back to the authorized redirect.
@@ -114,19 +114,19 @@ For example, when using `login=prompt` or `max_age`, after completing the author
 
 If `auth_time` is the same as your current access token, or isn't recent enough, reject the token and end the users session. Alternatively, don't allow the user to perform the requested task that initiated the login request.
 
-### Limitations and constraints
+## Limitations and constraints
 
 Before using this parameter make sure you understand the following limitations and constraints.
 
-#### Unsupported values
+### Unsupported values
 
 The `select_account` parameter is currently unsupported. Using this value in `prompt` is ignored.
 
-##### Identity providers
+#### Identity providers
 
 In versions prior to 1.6.1, the `prompt` parameter was never forwarded to a third party identity provider.
 
-#### Edge cases
+### Edge cases
 
 When using the `idp_hint` request parameter and including `prompt=login`, FusionAuth redirects to the identity provider resolved by request parameter.
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/setting-up-user-account-lockout.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/setting-up-user-account-lockout.mdx
@@ -20,7 +20,7 @@ To accomplish this rules based account lockout, you need to take two steps:
 If you are interested in rate limiting other actions, such as forgot password requests or two-factor messages, you can use [advanced threat detection](/docs/operate/secure/advanced-threat-detection) to do so.
 </Aside>
 
-### Creating the User Action
+## Creating the User Action
 
 The first step is to create a user action, under <Breadcrumb>Settings -> User Actions</Breadcrumb>. Give it a name of "Account Lock". Check the <InlineField>Time-based</InlineField> and <InlineField>Prevent login</InlineField> checkboxes.
 
@@ -28,7 +28,7 @@ The first step is to create a user action, under <Breadcrumb>Settings -> User Ac
 
 There are other configuration options available, including localization and user notification options; check out the [User Action APIs](/docs/apis/user-actions) for more information.
 
-### Tenant Configuration
+## Tenant Configuration
 
 Next, configure your tenant, under <Breadcrumb>Tenants -> Default</Breadcrumb>. Then navigate to the <Breadcrumb>Password</Breadcrumb> tab. Under the <InlineUIElement>Failed authentication settings</InlineUIElement> section, change the <InlineField>User action</InlineField> to your newly created user action, `Account Lock`.
 
@@ -38,7 +38,7 @@ For example, the below settings will allow five failed attempts in sixty seconds
 
 ![Configuring user account lockout settings](/img/docs/lifecycle/authenticate-users/account-lock-tenant-settings.png)
 
-### What Happens When The Account is Locked
+## What Happens When The Account is Locked
 
 When a user account has been locked by this mechanism, they'll be able to sign in after the duration has elapsed. All login paths will be locked. This user will not be able to log in using the FusionAuth login pages, and any login API access will return a 4xx error, as specified in the [Login API docs](/docs/apis/login).
 
@@ -52,7 +52,7 @@ An administrator can manually remove or extend this lock. You can also modify th
 
 ![What an admin sees when viewing a locked out user's account](/img/docs/lifecycle/authenticate-users/account-lock-admin-view.png)
 
-### Webhooks
+## Webhooks
 
 If you are interested in analytics around the number of lockout actions that are taken, you may want to listen for these [webhooks](/docs/extend/events-and-webhooks/events/) and ingest the data into a reporting tool.
 

--- a/astro/src/content/docs/lifecycle/manage-users/account-management/add-webauthn.mdx
+++ b/astro/src/content/docs/lifecycle/manage-users/account-management/add-webauthn.mdx
@@ -16,7 +16,7 @@ Available since version `1.41.0`
 
 WebAuthn is disabled by default on a tenant. To toggle navigate to <Breadcrumb>Tenants -> Edit Tenant -> WebAuthn</Breadcrumb>. In order for the user to use the registered passkey, at least one WebAuthn workflow must be enabled for the tenant.
 
-### Enable WebAuthn on Tenant (Admin Facing)
+## Enable WebAuthn on Tenant (Admin Facing)
 
 WebAuthn is disabled by default at the tenant level. It can be toggled on and off as needed.
 
@@ -24,7 +24,7 @@ WebAuthn is disabled by default at the tenant level. It can be toggled on and of
 
 In order for a user to use a passkey, one or more WebAuthn workflows must be enabled at the tenant or application level. See the [WebAuthn Admin Guide](/docs/lifecycle/authenticate-users/passwordless/webauthn) for more details on configuration.
 
-### Add a Passkey from Account Management (User Facing)
+## Add a Passkey from Account Management (User Facing)
 
 ![Account Management Index](/img/docs/lifecycle/manage-users/account-management/account-management-index-crop.png)
 
@@ -41,7 +41,7 @@ Next,
 2. Click the <InlineUIElement>Submit</InlineUIElement> button.
 3. Complete the WebAuthn registration with your authenticator of choice.
 
-### See It in Action (User Facing)
+## See It in Action (User Facing)
 
 You can use a registered passkey to complete enabled WebAuthn workflows. This example uses the bootstrap authentication workflow by clicking the <InlineUIElement>Fingerprint, device or key</InlineUIElement> button on the login screen.
 

--- a/astro/src/content/docs/lifecycle/manage-users/account-management/bootstrapping-login.mdx
+++ b/astro/src/content/docs/lifecycle/manage-users/account-management/bootstrapping-login.mdx
@@ -13,7 +13,7 @@ Available since version `1.45.0`
 
 In some scenarios you may want to allow users to access the self-service account management pages when it is impractical to use a normal login flow. One such scenario is with native mobile applications where the user is logged in to FusionAuth and the application is in possession of the access token. The following procedure will allow you to access these pages without requiring the user to log in again.
 
-### Opening the Self-Service Account Pages With an Access Token
+## Opening the Self-Service Account Pages With an Access Token
 
 In order to access the self-service account management pages in this manner you will need to meet the following criteria:
 

--- a/astro/src/content/docs/lifecycle/manage-users/account-management/customizing-account-management.mdx
+++ b/astro/src/content/docs/lifecycle/manage-users/account-management/customizing-account-management.mdx
@@ -18,7 +18,7 @@ FusionAuth ships with a default template for each Account Management page. Howev
 
 Below we will walk you through updating account management forms and theme templates.
 
-### Add a Form Field (Admin Facing)
+## Add a Form Field (Admin Facing)
 
 <Aside type="note">
 Forms allow you to collect any data you want. More information can be found in our [Advanced Registration Forms](/docs/lifecycle/register-users/advanced-registration-forms) page.
@@ -33,7 +33,7 @@ To change a form:
 
 ![Form Home](/img/docs/lifecycle/manage-users/account-management/forms-home-self-serve-crop.png)
 
-#### Edit Form (Admin Facing)
+### Edit Form (Admin Facing)
 
 In this example, we are going to add a `birthDate` field on our account management self service form.
 
@@ -45,7 +45,7 @@ Even though we are adding `birthDate` below, FusionAuth forms allow custom form 
 
 Remember, you can move each field around with up and down arrows
 
-#### Adding a birthDate (Admin Facing)
+### Adding a birthDate (Admin Facing)
 
 To add a `birthDate`, click <InlineUIElement>Add field</InlineUIElement>
 
@@ -53,7 +53,7 @@ To add a `birthDate`, click <InlineUIElement>Add field</InlineUIElement>
 
 Select `Birthdate` and click submit. Now we have a custom form available on our self-service account management page.  Please note we are using a built-in field, but FusionAuth lets you define any number of custom fields. More information can be found in our [Advanced Registration Forms](/docs/lifecycle/register-users/advanced-registration-forms) page.
 
-### See It in Action - Forms (User Facing)
+## See It in Action - Forms (User Facing)
 
 Take the following steps to see the changes:
 
@@ -75,7 +75,7 @@ With FusionAuth forms you can achieve more complex workflows such as:
 
 Below, we will show you how to make this editable `birthDate` field show up on the account management home screen.
 
-### Update Your Theme and Template (Admin Facing)
+## Update Your Theme and Template (Admin Facing)
 
 <Aside type="note">
 For more information on themes please reference the documentation found [here](/docs/customize/look-and-feel/).
@@ -100,7 +100,7 @@ With self service account management, there are several templates that are used:
 
 ![Account Management Themes](/img/docs/lifecycle/manage-users/account-management/account-management-forms-home.png)
 
-### Update the Account Two Factor Index Template (Admin Facing)
+## Update the Account Two Factor Index Template (Admin Facing)
 
 Let's update the Account Management index page with a `birthDate` field.
 
@@ -117,7 +117,7 @@ Changes include
 
 You can only use the `helpers.display` function to display top level user attributes such as `birthDate`. If you are trying to display user attributes stored in the `user.data` field, use Freemarker to display the field, like so: `${user.data.favColor}`. You can use [Freemarker built-in functions](https://freemarker.apache.org/docs/ref_builtins.html) to handle defaults or format the data.
 
-### See It in Action - Account Home (User Facing)
+## See It in Action - Account Home (User Facing)
 
 ![Account Management Edit Screen](/img/docs/lifecycle/manage-users/account-management/account-management-with-birth-crop.png)
 

--- a/astro/src/content/docs/lifecycle/manage-users/account-management/two-factor-authenticator.mdx
+++ b/astro/src/content/docs/lifecycle/manage-users/account-management/two-factor-authenticator.mdx
@@ -17,13 +17,13 @@ Available since version `1.26.0`
 
 The Authenticator method is enabled by default on every tenant. To toggle please navigate to <Breadcrumb>Tenants -> Edit Tenant -> Multi-Factor</Breadcrumb>. The authenticator method is also referred to as Google Authenticator or Time-Based One-Time Password (TOTP).
 
-### Enable MFA method on Tenant (Admin Facing)
+## Enable MFA method on Tenant (Admin Facing)
 
 The authenticator factor is enabled by default at the tenant level.  It can be toggled on and off as needed.
 
 ![Toggle Authenticator On Tenant](/img/docs/lifecycle/manage-users/account-management/toggle-authenticator-tenant.png)
 
-### Enable Authenticator Factor from Account Management (User Facing)
+## Enable Authenticator Factor from Account Management (User Facing)
 
 ![Account Management Index](/img/docs/lifecycle/manage-users/account-management/account-management-index-crop.png)
 
@@ -41,7 +41,7 @@ Next,
 2. Enter the code given.
 3. Click the <InlineUIElement>Enable</InlineUIElement> button.
 
-### Recovery Codes (User Facing)
+## Recovery Codes (User Facing)
 
 Now you will be presented with recovery codes. Save these in a safe space.
 
@@ -51,7 +51,7 @@ Now you will be presented with recovery codes. Save these in a safe space.
 
 Upon the next login, you will be prompted for a code displayed by the Authenticator App in addition to your password.
 
-### See It in Action (User Facing)
+## See It in Action (User Facing)
 
 With the Authenticator method enabled, if you log out and log back in you will be presented with the following screen in addition to the typical login screen.
 

--- a/astro/src/content/docs/lifecycle/manage-users/account-management/two-factor-email.mdx
+++ b/astro/src/content/docs/lifecycle/manage-users/account-management/two-factor-email.mdx
@@ -17,7 +17,7 @@ Available since version `1.26.0`
 
 Email two factor is not enabled by default. Configure your tenant by navigating to <Breadcrumb>Tenants -> Edit Tenant -> Multi-Factor</Breadcrumb>.
 
-### Enable MFA method on Tenant (Admin Facing)
+## Enable MFA method on Tenant (Admin Facing)
 
 ![Configure Tenant Email](/img/docs/lifecycle/manage-users/account-management/enable-email-tenant.png)
 
@@ -26,7 +26,7 @@ You can enable SMS MFA on the tenant level by following these steps:
 - Toggle this MFA method by clicking `enabled`
 - Select a two factor authentication template (FusionAuth ships with a default to be customized if needed)
 
-### Enable Email Factor from Account Management (User Facing)
+## Enable Email Factor from Account Management (User Facing)
 
 ![Account Management Index](/img/docs/lifecycle/manage-users/account-management/account-management-index-crop.png)
 
@@ -45,7 +45,7 @@ Next,
 3. Enter the `Verification Code`
 4. Click <InlineUIElement>Enable</InlineUIElement>.
 
-### Recovery Codes (User Facing)
+## Recovery Codes (User Facing)
 
 Now you will be presented with recovery codes. Save these in a safe space.
 
@@ -55,7 +55,7 @@ Now you will be presented with recovery codes. Save these in a safe space.
 
 Upon the next login, you will be prompted for an emailed code in addition to your password.
 
-### See It in Action (User Facing)
+## See It in Action (User Facing)
 
 With email MFA enabled, if you log out and log back in you will be presented with the following screen in addition to the typical login screen.
 

--- a/astro/src/content/docs/lifecycle/manage-users/account-management/two-factor-sms.mdx
+++ b/astro/src/content/docs/lifecycle/manage-users/account-management/two-factor-sms.mdx
@@ -17,7 +17,7 @@ Available since version `1.26.0`
 
 SMS two factor is not enabled by default. Configure your tenant by navigating to <Breadcrumb>Tenants -> Edit Tenant -> Multi-Factor</Breadcrumb>.
 
-### Enable MFA method on Tenant (Admin Facing)
+## Enable MFA method on Tenant (Admin Facing)
 
 ![Configure Tenant SMS](/img/docs/lifecycle/manage-users/account-management/enable-sms-tenant.png)
 
@@ -27,7 +27,7 @@ You can enable the SMS factor on the tenant level by following these steps:
 - Select a `messenger` (previously created, see [documentation](/docs/customize/email-and-messages/))
 - Select a `template` (FusionAuth ships with a default to be customized if needed)
 
-### Enable SMS Factor from Account Management (User Facing)
+## Enable SMS Factor from Account Management (User Facing)
 
 ![Account Management Index](/img/docs/lifecycle/manage-users/account-management/account-management-index-crop.png)
 
@@ -46,7 +46,7 @@ Next,
 3. Enter the `Verification Code` 
 4. Click <InlineUIElement>Enable</InlineUIElement>.
 
-### Recovery Codes (User Facing)
+## Recovery Codes (User Facing)
 
 Now you will be presented with recovery codes. Save these in a safe space.
 
@@ -56,7 +56,7 @@ Now you will be presented with recovery codes. Save these in a safe space.
 
 Upon the next login, you will be prompted for a code sent by SMS code in addition to your password.
 
-### See It in Action (User Facing)
+## See It in Action (User Facing)
 
 With SMS MFA enabled, if you log out and log back in you will be presented with the following screen in addition to the typical login screen.
 

--- a/astro/src/content/docs/lifecycle/manage-users/account-management/updating-user-data.mdx
+++ b/astro/src/content/docs/lifecycle/manage-users/account-management/updating-user-data.mdx
@@ -17,7 +17,7 @@ Available since `1.26.0`
 
 FusionAuth Self Service Registration Forms allows users to update most of their own data from a hosted page.  Below we will document two common tasks users - updating passwords and other user data fields.
 
-### User Profile Data (User Facing)
+## User Profile Data (User Facing)
 
 To edit your profile data, navigate to the account self service home and click on the edit icon in the top right.
 
@@ -29,7 +29,7 @@ Once on the account self service edit screen your information (user object) can 
 
 Any changes here will be saved to your user in FusionAuth.
 
-### Update User Password (User Facing)
+## Update User Password (User Facing)
 
 To edit profile data (including the password) on the user, navigate to account self service home and click on the edit icon in the top right.
 

--- a/astro/src/content/docs/operate/secure/networking.mdx
+++ b/astro/src/content/docs/operate/secure/networking.mdx
@@ -22,13 +22,13 @@ The FusionAuth IP resolution configuration allows you to tell FusionAuth which p
 Use caution when applying IP address resolution settings if your FusionAuth Admin application is using an Access control list. Saving an incorrect set of trusted proxies can make your Admin application inaccessible.
 </Aside>
 
-### Configuration
+## Configuration
 
 To modify the IP resolution trust policy, navigate to <Breadcrumb>Settings -> System -> Networking</Breadcrumb>.
 
 ![Networking Configuration](/img/docs/operate/secure-and-monitor/networking-settings.png)
 
-### Form Fields
+## Form Fields
 
 <APIBlock>
   <APIField name="Trust policy">


### PR DESCRIPTION
There are currently documentation pages where the headings start at level 3 (###) instead of level 2 (##). This causes the table of contents not to be displayed and triggers a JavaScript error in the ScrollSpy during scrolling.

This PR shifts these headings one level up.