### PR TITLE
ENG-4371: Tenant-scoped audit log events

### DIFF
--- a/astro/src/content/docs/extend/events-and-webhooks/events/_event.astro
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/_event.astro
@@ -7,7 +7,7 @@ import { parseInline } from 'marked';
 import semver from 'semver';
 import Breadcrumb from 'src/components/Breadcrumb.astro';
 
-const { description, plan, eventType, name, scope, transactional, version } = Astro.props;
+const { description, plan, eventType, name, scope, tenantScopeVersion, transactional, version } = Astro.props;
 ---
 <h2>{name}</h2>
 
@@ -36,8 +36,13 @@ const { description, plan, eventType, name, scope, transactional, version } = As
 
 <h3>Event Scope</h3>
 { scope === 'instance' &&
+  <>
   <p>This is a system scoped event. If enabled in <Breadcrumb>Settings -> Webhooks -> Your Webhook</Breadcrumb>, this event will be sent.</p>
   <p>The tenant webhook enable or disable settings do not apply and will be ignored.</p>
+  { tenantScopeVersion &&
+      <p>In version {tenantScopeVersion} and later, the event subject may be scoped to a tenant. In such cases events are delivered only to the tenants specified by the webhook configuration.</p>
+  }
+  </>
 }
 { scope === 'tenant' && version && semver.gte(version, '1.38.0') &&
   <p>This is a tenant scoped event.</p>

--- a/astro/src/content/docs/extend/events-and-webhooks/events/audit-log-create.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/events/audit-log-create.mdx
@@ -7,14 +7,15 @@ import Event from 'src/content/docs/extend/events-and-webhooks/events/_event.ast
 import EventBody from 'src/content/docs/extend/events-and-webhooks/events/_event-body.astro';
 import ReferenceLink from 'src/content/docs/_shared/_reference-link.mdx';
 
-export const eventType = 'audit.log.create';
+export const eventType = 'audit-log.create';
 
 <Event name="Audit Log Create" 
        eventType={eventType}
        version="1.30.0" 
        description="This event is generated when an audit log is created." 
        scope="instance" 
-       transactional="false" />
+       transactional="false"
+       tenantScopeVersion="1.65.0" />
 
 <EventBody eventType={eventType}
            jsonFile="audit-log-create.json">
@@ -28,6 +29,10 @@ export const eventType = 'audit.log.create';
 
   <APIField slot="trailing-fields" name="event.id" type="UUID">
     The unique Id of the event. You may receive an event more than once based upon your transaction settings. This Id may be used to identify a duplicate event.
+  </APIField>
+
+  <APIField slot="trailing-fields" name="event.tenantId" type="UUID" since="1.65.0">
+    The unique tenant identifier. This value may not be returned if not applicable.
   </APIField>
 
   <APIField slot="trailing-fields" name="event.type" type="String">

--- a/astro/src/content/docs/extend/events-and-webhooks/index.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/index.mdx
@@ -190,6 +190,10 @@ The exceptions to this are the following system events which are not tenant spec
 
 These events are configured at the system level and cannot be scoped to a certain tenant.
 
+<Aside type="version" title="Available since 1.65.0">
+When an audit log is created with a `tenantId`, the `audit-log.create` event is delivered as a tenant-scoped event.
+</Aside>
+
 ### Headers
 
 ![Webhook Settings - HTTP Headers](/img/docs/extend/events-and-webhooks/webhook-settings-headers.png)

--- a/astro/src/content/docs/extend/events-and-webhooks/writing-a-webhook.mdx
+++ b/astro/src/content/docs/extend/events-and-webhooks/writing-a-webhook.mdx
@@ -3,6 +3,7 @@ title: Write a Webhook
 description: Learn how to write a webhook to handle and process FusionAuth.
 ---
 import ApplicationWebhooksWarning from 'src/content/docs/extend/events-and-webhooks/_application-webhooks-warning.mdx';
+import Aside from 'src/components/Aside.astro';
 import InlineField from 'src/components/InlineField.astro';
 import RemoteCode from 'src/components/RemoteCode.astro';
 import { YouTube } from '@astro-community/astro-embed-youtube';
@@ -43,6 +44,10 @@ As of version 1.37.0, all events can be tenant scoped except system events:
 * `audit-log.create`
 * `create-log.create`
 * `kickstart.success`
+
+<Aside type="version" title="Available since 1.65.0">
+When an audit log is created with a `tenantId`, the `audit-log.create` event is delivered as a tenant-scoped event.
+</Aside>
 
 If you want to get events for certain applications, the preferred method is to send events for a tenant. Filter on the `applicationId` when consuming the event and discard events from any applications not of interest.
 

--- a/astro/src/content/json/events/audit-log-create.json
+++ b/astro/src/content/json/events/audit-log-create.json
@@ -112,7 +112,8 @@
         "usernameStatus": "ACTIVE",
         "verified": true
       },
-      "reason": "FusionAuth User Interface"
+      "reason": "FusionAuth User Interface",
+      "tenantId": "a743e2cd-55bb-789c-b076-8846fdd3a51f"
     },
     "createInstant": 1629141543064,
     "id": "29e3f639-649e-4a5c-bc4b-eec7f89ee20c",
@@ -128,6 +129,7 @@
       },
       "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Safari/537.36"
     },
+    "tenantId": "a743e2cd-55bb-789c-b076-8846fdd3a51f",
     "type": "audit-log.create"
   }
 }


### PR DESCRIPTION
Documentation for changes to delivery of `audit-log.create` events for audit logs scoped to a particular tenant.