### PR TITLE
fix: limit ScrollSpy to h2 and h3 headings, add header link validation

### DIFF
--- a/astro/public/js/ScrollSpy-0.1.0.js
+++ b/astro/public/js/ScrollSpy-0.1.0.js
@@ -13,7 +13,7 @@ class ScrollSpy {
     document.addEventListener('scroll', event => this.#handleScroll(event));
 
     this.#headers = [];
-    const elements = document.querySelectorAll('h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]');
+    const elements = document.querySelectorAll('h2[id], h3[id]');
     for (const e of elements) {
       this.#headers.push(e);
     }
@@ -31,9 +31,12 @@ class ScrollSpy {
       }
     }
 
+    const headerLink = document.querySelector(`[data-widget="scroll-spy"] a[href="#${header.id}"]`);
+    if (!headerLink) return;
+
     document.querySelectorAll('[data-widget="scroll-spy"] [data-widget="scroll-spy-item"]').forEach(li => li.classList.remove('active', 'section-active'));
 
-    const group = document.querySelector(`[data-widget="scroll-spy"] a[href="#${header.id}"]`).closest('[data-widget="scroll-spy-item"]');
+    const group = headerLink.closest('[data-widget="scroll-spy-item"]');
     group.classList.add('active');
   }
 }


### PR DESCRIPTION
The TOC only shows h2 and h3 elements (`depth={2} maxDepth={3}`)

Scroll Spy did try to also handle h4 (to h6), meaning when those elements were present in the content it tried to highlight them in the TOC.

This change limits the headers to h2 and h3, and also handles the case if an element is not found in the TOC.