### PR TITLE
refactor: use astro font provider for Inter

### DIFF
--- a/astro/astro.config.ts
+++ b/astro/astro.config.ts
@@ -1,4 +1,4 @@
-import {defineConfig} from 'astro/config';
+import {defineConfig, fontProviders} from 'astro/config';
 import compress from "astro-compress";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
@@ -75,6 +75,12 @@ const config = defineConfig({
   build: {
     format: 'file'
   },
+  fonts: [{
+    provider: fontProviders.fontsource(),
+    name: 'Inter',
+    cssVariable: '--font-inter-var',
+    weights: [300, 400, 500, 600, 700, 800, 900],
+  }],
   vite: {
     plugins: [tailwindcss(), lightboxProvider()],
   },

--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -1,4 +1,5 @@
 ---
+import Font from 'astro/components/Font.astro';
 import SearchFilter  from 'src/components/search/SearchFilter.astro';
 
 interface Props {
@@ -58,7 +59,7 @@ const slug = Astro.params.slug;
   { canonical && <link rel="canonical" href={canonical} /> }
   <meta name="algolia-site-verification" content="857638C054AD182F" />
   <link rel="sitemap" href="/sitemap-index.xml">
-  <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+  <Font cssVariable="--font-inter-var" />
   <link rel="stylesheet" href="/css/brands.min.css"/>
   <link rel="stylesheet" href="/css/duotone.min.css"/>
   <link rel="stylesheet" href="/css/fontawesome.min.css"/>

--- a/astro/src/css/style.css
+++ b/astro/src/css/style.css
@@ -42,7 +42,7 @@
   --color-orange-900: #7c2d12;
 
   /* --- Others --- */
-  --font-sans: "Inter", "-apple-system", "system-ui", "BlinkMacSystemFont", "Arial", "sans-serif";
+  --font-sans: var(--font-inter-var), "-apple-system", "system-ui", "BlinkMacSystemFont", "Arial", "sans-serif";
   --font-awesome: "Font Awesome 6 Pro";
   --border-width-10: 10px;
   --shadow-aside: 0 2px 4px 0 rgba(0,0,13,0.14), 0 0 0 1px rgba(63,63,68,0.05), 0 1px 3px 0 rgba(63,63,68,0.15);


### PR DESCRIPTION
Current the font [Inter](https://fontsource.org/fonts/inter) is loaded directly from the Inter website https://rsms.me/inter/

This change uses the built-in font provider of Astro to load the font, making it faster and less error prone.