### PR TITLE
refactor: delay Kapa Integration until the user clicks Ask AI button

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 import Logo from './FusionAuthLogo.astro';
+import Kapa from "src/components/Kapa.astro";
 
 const { sections = [
   {
@@ -95,4 +96,5 @@ const { sections = [
     </div>
   </div>
 
+  <Kapa />
 </footer>

--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -5,7 +5,6 @@ interface Props {
   description?: string;
   enableBaseParent?: boolean;
   enableGTM?: boolean;
-  enableKapa?: boolean;
   title?: string;
   openGraphImage?: string;
   canonicalUrl?: string;
@@ -17,7 +16,6 @@ const {
   description,
   enableBaseParent = false,
   enableGTM = true,
-  enableKapa = true,
   title, openGraphImage,
   canonicalUrl,
   isIndexPage = false,
@@ -103,10 +101,6 @@ const slug = Astro.params.slug;
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-5P7VLHG');</script>
     <!-- End Google Tag Manager -->
-  }
-
-  {enableKapa &&
-    <script async src="https://widget.kapa.ai/kapa-widget.bundle.js" data-website-id="26ad3b7e-7d94-491c-ab54-95712d1fafee" data-project-name="FusionAuth" data-project-color="#0F172A" data-project-logo="https://uploads-ssl.webflow.com/617b1b1f42c1da41aeae3413/663bee0e6eec6b85377a3939_fa-square-icon-144.png" data-user-analytics-cookie-enabled="false" data-button-animation-enabled="false" data-mcp-server-url="https://ai.fusionauth.io/mcp/docs" data-mcp-button-hidden="false"></script>
   }
 
   { enableBaseParent &&

--- a/astro/src/components/Kapa.astro
+++ b/astro/src/components/Kapa.astro
@@ -1,0 +1,78 @@
+---
+const {
+  enableKapa = true,
+} = Astro.props;
+
+if (!enableKapa) return '';
+---
+
+<div class="fixed right-5 bottom-5 z-100">
+    <button id="kapa-button" class="relative flex flex-col items-center justify-center h-20 w-18 cursor-pointer rounded-lg border border-slate-200 dark:bg-slate-900 dark:border-slate-800 bg-white dark:hover:bg-slate-800 dark:hover:border-indigo-500 group hover:bg-slate-100 hover:border-indigo-500 overflow-hidden shadow-lg">
+        <img
+                class="size-8 group-hover:scale-110 transition-transform duration-500"
+                src="https://uploads-ssl.webflow.com/617b1b1f42c1da41aeae3413/663bee0e6eec6b85377a3939_fa-square-icon-144.png" alt="FusionAuth Logo"/>
+
+        <span class="text-lg">Ask AI</span>
+
+        <span class="absolute inset-0 bg-black/50 transition-opacity duration-300 hidden group-[.is-loading]:flex items-center justify-center">
+            <i class="fa-solid fa-spinner fa-spin text-2xl"></i>
+        </span>
+    </button>
+</div>
+
+<script>
+  const kapaButton = document.getElementById('kapa-button');
+
+  function loadScriptIfNotExists() {
+    return new Promise<void>((resolve) => {
+      const scriptSrc = "https://widget.kapa.ai/kapa-widget.bundle.js";
+
+      // Check if the script already exists in the document
+      if (document.querySelector(`script[src="${scriptSrc}"]`)) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement("script");
+
+      // Set the async property correctly
+      script.async = true;
+      script.onload = function () {
+        (window as any).Kapa.render({
+          onRender: () => resolve()
+        })
+      }
+      script.src = scriptSrc;
+
+      // Define other script attributes
+      const attributes = {
+        "data-website-id": "26ad3b7e-7d94-491c-ab54-95712d1fafee",
+        "data-project-name": "FusionAuth",
+        "data-project-color": "#0F172A",
+        "data-project-logo": "https://uploads-ssl.webflow.com/617b1b1f42c1da41aeae3413/663bee0e6eec6b85377a3939_fa-square-icon-144.png",
+        "data-render-on-load": "false",
+        'data-user-analytics-cookie-enabled': "false",
+        'data-button-animation-enabled': "false",
+        'data-mcp-server-url': "https://ai.fusionauth.io/mcp/docs",
+        'data-mcp-button-hidden': "false",
+        'data-launcher-button-hidden': "true",
+      };
+
+      // Set attributes on the script element
+      Object.entries(attributes).forEach(([key, value]) => {
+        script.setAttribute(key, value);
+      });
+
+      // Append to the document head
+      document.head.appendChild(script);
+    });
+  }
+
+  kapaButton.addEventListener('click', async () => {
+    kapaButton.classList.add('is-loading');
+    await loadScriptIfNotExists();
+
+    (window as any).Kapa("open");
+    kapaButton.classList.remove('is-loading');
+  });
+</script>

--- a/astro/src/layouts/Blank.astro
+++ b/astro/src/layouts/Blank.astro
@@ -1,6 +1,7 @@
 ---
 import '../css/style.css';
 import Head from '../components/Head.astro';
+import Kapa from 'src/components/Kapa.astro';
 
 interface Props {
   description?: string;
@@ -53,7 +54,7 @@ title = frontmatter.title ? frontmatter.title : title;
 
 <!DOCTYPE html>
 <html class="antialiased min-h-full dark" lang="en">
-<Head title={title} description={description} canonicalUrl={frontmatter.canonicalUrl} enableBaseParent={enableBaseParent} enableGTM={enableGTM} enableKapa={enableKapa}/>
+<Head title={title} description={description} canonicalUrl={frontmatter.canonicalUrl} enableBaseParent={enableBaseParent} enableGTM={enableGTM}/>
 <body class="antialiased min-h-full text-slate-700">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5P7VLHG"
@@ -63,5 +64,6 @@ title = frontmatter.title ? frontmatter.title : title;
   <main class:list={contentStyles}>
     <slot/>
   </main>
+  <Kapa enableKapa={enableKapa} />
 </body>
 </html>

--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -12,6 +12,7 @@ import Icon from '../components/icon/Icon.astro';
 import { specialCaps } from '../tools/string';
 import IndexableBody from '../components/search/IndexableBody.astro';
 import { Marked } from "marked";
+import Kapa from "src/components/Kapa.astro";
 
 interface Props {
   author?: string;
@@ -216,6 +217,7 @@ const cleanedHtmlTitle = htmlTitle
       </aside>
     }
   </main>
+  <Kapa />
   <Search/>
 </IndexableBody>
 </html>


### PR DESCRIPTION
This pull request refactors how the Kapa AI widget is integrated across the site. Instead of injecting the Kapa script directly in the `Head.astro` component, it introduces a new reusable `Kapa.astro` component that handles rendering the widget and loading the script on demand. The Kapa widget is now conditionally rendered in the appropriate layout and footer components, improving modularity and maintainability.

Main reason for this is that Kapa loads several dependencies like Recaptcha eagerly, and not when opening the Kapa modal. Also tracking is disabled so there is no reason to load the Kapa Widget into the page every time.

**Refactor and modularization of Kapa widget integration:**

* Created a new `Kapa.astro` component that encapsulates the Kapa AI widget button and script loading logic, with support for the `enableKapa` prop to control its rendering.
* Removed the Kapa script injection and `enableKapa` prop from `Head.astro`, delegating responsibility for rendering the widget to the new `Kapa.astro` component. [[1]](diffhunk://#diff-b9a21c15440e3c5cb4f3cbfdf5dd5fce698fbbd93ab82f40860ceb9e61fc346eL8) [[2]](diffhunk://#diff-b9a21c15440e3c5cb4f3cbfdf5dd5fce698fbbd93ab82f40860ceb9e61fc346eL20) [[3]](diffhunk://#diff-b9a21c15440e3c5cb4f3cbfdf5dd5fce698fbbd93ab82f40860ceb9e61fc346eL108-L111)

**Layout and component updates:**

* Updated `Blank.astro` and `Default.astro` layouts to import and render the `Kapa.astro` component, passing the `enableKapa` prop as needed. [[1]](diffhunk://#diff-d280226314024a1fce7aa7adcc09d95f58ab074819bf30dc4537b370a51cb1daR4) [[2]](diffhunk://#diff-d280226314024a1fce7aa7adcc09d95f58ab074819bf30dc4537b370a51cb1daL56-R57) [[3]](diffhunk://#diff-d280226314024a1fce7aa7adcc09d95f58ab074819bf30dc4537b370a51cb1daR67) [[4]](diffhunk://#diff-a436edace7463fea3455c18959be10368dee6d7b3c8b4f8e5eb7bdaa16985d03R15) [[5]](diffhunk://#diff-a436edace7463fea3455c18959be10368dee6d7b3c8b4f8e5eb7bdaa16985d03R220)
* Added the `Kapa.astro` component to the `Footer.astro` component, ensuring the Kapa widget is available site-wide. [[1]](diffhunk://#diff-9da7fcb06493cbdbb0c454e70474cdc63e47d1ab53af6aa7f3c1ba88a7febde4R3) [[2]](diffhunk://#diff-9da7fcb06493cbdbb0c454e70474cdc63e47d1ab53af6aa7f3c1ba88a7febde4R99)