### PR TITLE
fix: /blog and /articles canonical links

### DIFF
--- a/astro/src/layouts/BlogIndex.astro
+++ b/astro/src/layouts/BlogIndex.astro
@@ -8,7 +8,7 @@ import Icon from '../components/icon/Icon.astro';
 import { getHref, parseContent } from 'src/tools/blog';
 import { getLatestDateString } from 'src/tools/date';
 
-const { title, section, sectionTitle, subjectRef, subjectName, page, showCategories, path, personalLink, description } = Astro.props;
+const { title, section, sectionTitle, subjectRef, subjectName, page, showCategories, path, personalLink, description, isIndexPage = false } = Astro.props;
 const blogs = await Promise.all(page.data.map(parseContent));
 const first = blogs[0];
 const theRest = blogs.slice(1, blogs.length);
@@ -43,13 +43,9 @@ const getPaginationRef = (stop) => {
   }
 }
 
-let canonicalUrl = Astro.url.href;
-if (Astro.url.href.endsWith(`${section}.html`)) {
-  canonicalUrl = canonicalUrl.replace(`.html`, '/');
-}
 ---
 <html class="antialiased" lang="en">
-<HeadComponent {title} {description} {canonicalUrl} />
+<HeadComponent {title} {description} {isIndexPage} />
 <body class="antialiased leading-tight bg-white dark:bg-slate-900" data-pagefind-ignore="all">
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5P7VLHG"

--- a/astro/src/pages/articles/[...slug].astro
+++ b/astro/src/pages/articles/[...slug].astro
@@ -24,8 +24,9 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content, headings } = await render(entry);
+const isIndexPage = entry.id === 'index' || entry.id.endsWith('/index');
 ---
-<Layout frontmatter={entry.data} {headings} id={entry.id}
+<Layout frontmatter={entry.data} {headings} {isIndexPage} id={entry.id}
         excludeFromSearchIndex={entry.id?.endsWith('index.mdx') || entry.id?.endsWith('index.md')}>
   <Content/>
 </Layout>

--- a/astro/src/pages/blog/author/[author]/[...page].astro
+++ b/astro/src/pages/blog/author/[author]/[...page].astro
@@ -20,6 +20,7 @@ const { author } = Astro.params;
   subjectRef={author}
   subjectName={authorName}
   page={page}
+  isIndexPage={page.currentPage === 1}
   showCategories={true}
   personalLink={{
     text: AUTHORS[authorName]?.linkText,

--- a/astro/src/pages/blog/category/[category]/[...page].astro
+++ b/astro/src/pages/blog/category/[category]/[...page].astro
@@ -28,4 +28,5 @@ const categories = new Map([
         subjectRef={category}
         subjectName={categoryName}
         page={page}
+        isIndexPage={page.currentPage === 1}
         showCategories={false}/>

--- a/astro/src/pages/blog/index.astro
+++ b/astro/src/pages/blog/index.astro
@@ -39,9 +39,10 @@ const latestPosts = blogs.filter(blog => !onThePage.includes(blog)).slice(0, 4);
 ---
 <!DOCTYPE html>
 <html class="antialiased" lang="en">
-<HeadComponent 
+<HeadComponent
   title="FusionAuth Blog"
   description="Get the latest on FusionAuth: insights on CIAM, OAuth, Passwordless Auth, and more."
+  isIndexPage={true}
 />
 <body class="antialiased leading-tight dark:bg-slate-900 " data-pagefind-ignore="all">
 <BlogNav slot="nav" darkModeToggle={true}/>

--- a/astro/src/pages/blog/latest/[...page].astro
+++ b/astro/src/pages/blog/latest/[...page].astro
@@ -14,4 +14,5 @@ const { page } = Astro.props;
         sectionTitle="Blogs"
         subjectName="Latest Posts"
         page={page}
+        isIndexPage={page.currentPage === 1}
         showCategories={false}/>

--- a/astro/src/pages/blog/tag/[tag]/[...page].astro
+++ b/astro/src/pages/blog/tag/[tag]/[...page].astro
@@ -16,4 +16,5 @@ const { tag } = Astro.params;
         subjectRef={tag}
         subjectName={tagName}
         page={page}
+        isIndexPage={page.currentPage === 1}
         showCategories={true}/>


### PR DESCRIPTION
Extension of https://github.com/FusionAuth/fusionauth-site/pull/4251 and https://github.com/FusionAuth/fusionauth-site/pull/4249 where we fixed canonical links for /docs pages

This extends that fix to /blogs and /articles pages. Some subtleties again

- Generally folders have a trailing slash but leaf pages do not
- index.md files are served from folders
- Tags, e.g. https://fusionauth.io/blog/category/company/ have trailing slash on the first page but not for subsequent pages, e.g. https://fusionauth.io/blog/category/company/2
- Similar for /author etc

Once this is merged we can extend Algolia scraper to cover /articles and /blog too which should cover all pages that the existing search solution is used on.

To test, I rebuilt locally and scraped the site, followed redirects, and checked that the actual URL the content was served on matches what we list as canonical in the built site, so I'm fairly confident this is correct but this might need a further tweak once the Algolia scraper has indexed the additional pages.