### PR TITLE
fix: prevent Flash of inAccurate coloR Theme

### DIFF
--- a/astro/public/js/ThemeSelector-0.1.0.js
+++ b/astro/public/js/ThemeSelector-0.1.0.js
@@ -3,7 +3,6 @@
 class ThemeSelector {
   #button;
   #menu;
-  #theme;
 
   constructor() {
     // Bail if there is no theme selector
@@ -17,10 +16,6 @@ class ThemeSelector {
     this.#menu.addEventListener('mousemove', event => this.#handleMouseMove(event));
     this.#menu.querySelectorAll('button').forEach(button => button.addEventListener('click', event => this.#handleChange(event)))
 
-    this.#theme = localStorage.getItem('theme') || 'system';
-    this.changeTheme(this.#theme);
-    this.closeMenu();
-
     document.addEventListener('click', () => this.closeMenu());
     document.addEventListener('keydown', event => this.#handleKeyDown(event));
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => this.#handleChange(event));
@@ -33,7 +28,6 @@ class ThemeSelector {
       document.documentElement.classList.remove('dark');
     }
 
-    this.#theme = theme;
     this.closeMenu();
     localStorage.setItem('theme', theme);
   }
@@ -113,9 +107,4 @@ class ThemeSelector {
   }
 }
 
-// Initialize the class on the body
-const theme = localStorage.getItem('theme') || 'system';
-if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-  document.documentElement.classList.add('dark');
-}
 document.addEventListener('DOMContentLoaded', () => new ThemeSelector());

--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -71,6 +71,17 @@ const slug = Astro.params.slug;
   <script defer src="/js/Search-0.2.3.js" type="text/javascript"></script>
   <script defer src="/js/ScrollSpy-0.1.0.js" type="text/javascript"></script>
   <script defer src="/js/Tabs-0.1.0.js" type="text/javascript"></script>
+  <script is:inline>
+    const getTheme = () => {
+      const theme = localStorage?.getItem('theme');
+      if (theme && theme !== 'system') {
+        return theme;
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    document.documentElement.classList.toggle('dark', getTheme() === 'dark');
+  </script>
   <script defer src="/js/ThemeSelector-0.1.0.js" type="text/javascript"></script>
   <script defer src="/js/Visibility-0.1.2.js" type="text/javascript"></script>
   <script defer src="/js/BlogScrollTable-0.1.0.js" type="text/javascript"></script>

--- a/astro/src/components/ThemeSelector.astro
+++ b/astro/src/components/ThemeSelector.astro
@@ -2,7 +2,7 @@
 import Icon from './icon/Icon.astro';
 ---
 <div data-widget="theme-selector" class="relative z-10">
-  <button type="button" class="flex items-center border-slate-500 rounded-lg hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-300 border-0 mt-0 p-0 text-slate-400 w-auto dark:hover:bg-transparent hover:bg-transparent">
+  <button type="button" class="flex items-center border-slate-500 rounded-lg  hover:text-slate-700  dark:hover:text-slate-300 border-0 mt-0 p-0 text-slate-400 w-auto dark:hover:bg-transparent hover:bg-transparent">
     <span class="text-lg mx-2"><Icon name="moon"></Icon></span>
   </button>
 


### PR DESCRIPTION
This change should mitigate the flashing of light mode when using the dark mode theme.

Now the `dark` class is added to the HTML element as soon while the page is loading, because the script is run inline.