### PR TITLE
fix: restore mobile menu functionality

### DIFF
--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -62,6 +62,7 @@ const slug = Astro.params.slug;
   <script defer src="/js/Search-0.2.3.js" type="text/javascript"></script>
   <script defer src="/js/ScrollSpy-0.1.0.js" type="text/javascript"></script>
   <script defer src="/js/ThemeSelector-0.1.0.js" type="text/javascript"></script>
+  <script defer src="/js/Visibility-0.1.2.js" type="text/javascript"></script>
   {applyTheme && <script is:inline>
     const getTheme = () => {
       const theme = localStorage?.getItem('theme');


### PR DESCRIPTION
`Visibility-0.1.2.js` was removed in a recent commit. This JS file was necessary for the mobile menu.

This PR restores the include of the file.