### PR TITLE
Switch to recommended GA4 structure

### DIFF
--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -97,11 +97,13 @@ const slug = Astro.params.slug;
 
   {isProd && enableGTM &&
     <!-- Google Tag Manager -->
-    <script is:inline>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','G-MZ9FDPFDF0');</script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MZ9FDPFDF0" is:inline></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-MZ9FDPFDF0'); 
+    </script>
     <!-- End Google Tag Manager -->
   }
 


### PR DESCRIPTION
Previous structure _technically_ works. But it's the setup recommended for google tag manager. This change switches to what Google recommends for GA4-only configurations like ours.