### PR TITLE
fix: generate llms docs links from entry ids

### DIFF
--- a/astro/src/pages/docs/llms.txt.ts
+++ b/astro/src/pages/docs/llms.txt.ts
@@ -7,7 +7,8 @@ export const GET: APIRoute = async ({}) => {
     return new Response(
         `## FusionAuth.io Documentation\n\n${docs
             .map((doc) => {
-                return `- [${doc.data.title}](https://fusionauth.io/docs/${doc.slug}/)\n`;
+                const slug = doc.id === "index" ? "" : doc.id.replace(/\/index$/, "");
+                return `- [${doc.data.title}](https://fusionauth.io/docs/${slug})\n`;
             })
             .join("")}`,
         { headers: { "Content-Type": "text/plain; charset=utf-8" } }


### PR DESCRIPTION
Astro 6 moved from slug -> id which breaks LLMs.txt generation. This fixes it. I generated llms.txt locally to test.