### PR TITLE
Refresh azure ad b2c blog post

### DIFF
--- a/astro/src/content/blog/how-to-migrate-from-azure-ad-b2c.mdx
+++ b/astro/src/content/blog/how-to-migrate-from-azure-ad-b2c.mdx
@@ -29,14 +29,14 @@ Azure AD is Microsoft Azure's name for an umbrella of related identity solutions
 
 * Azure AD B2C, their CIAM solution, which lets customers register, login, and manage their profile. Think Auth0, Cognito or FusionAuth.
 * Azure AD, their employee/workforce solution. It's a directory, authentication and authorization system. Think Okta or AWS SSO.
-* Azure AD EI, which is external identity management and used for users outside your organization.
+* Microsoft Entra External ID, which is external identity management and used for users outside your organization.
 * Azure AD DS offers domain services supporting older Windows focused functionality. AD DS offers a lot of what the original Active Directory provided.
 
 This article discusses migrations from Azure AD B2C, not any of the other Azure AD identity solutions.
 
 ## Weaknesses of Azure AD B2C
 
-While [Azure AD B2C](https://azure.microsoft.com/en-us/services/active-directory/external-identities/b2c/) is a low cost auth service and a far better choice than rolling your own auth, it has some downsides.
+While [Azure AD B2C](https://learn.microsoft.com/en-us/azure/active-directory-b2c/overview) is a low cost auth service and a far better choice than rolling your own auth, it has some downsides.
 
 These include:
 
@@ -56,7 +56,7 @@ For whatever reason, you may decide to move your customer and user data from Azu
 
 Like any tool, Azure AD B2C has strengths as well as weaknesses. When your application depends on Azure AD B2C's unique features or if the upsides outweigh the downsides, keep on using it.
 
-Azure AD B2C can be budget and developer friendly if you are all in on Azure. For example, if your usage is  under 50,000 MAUs, it is free. If the user interface and other limitations of Azure AD B2C are acceptable, migration doesn't make much sense. Since Azure AD B2C is serverless, it makes it easy to "set and forget" and allows you to focus on other aspects of your application. You know, the features your users want.
+Azure AD B2C can be budget and developer friendly if you are all in on Azure. For existing customers on the P1 tier, usage under 50,000 MAUs per month is included at no extra cost. If the user interface and other limitations of Azure AD B2C are acceptable, migration doesn't make much sense. Since Azure AD B2C is serverless, it makes it easy to "set and forget" and allows you to focus on other aspects of your application. You know, the features your users want.
 
 In addition, if you need custom user login flows and can successfully navigate the XML-based policy implementation, Azure AD B2C can be a good solution.
 

--- a/astro/src/content/blog/how-to-migrate-from-azure-ad-b2c.mdx
+++ b/astro/src/content/blog/how-to-migrate-from-azure-ad-b2c.mdx
@@ -19,12 +19,16 @@ At FusionAuth, potential customers are interested in migrating from Azure AD B2C
 
 This blog post will explain why and how you might choose to migrate from Azure AD B2C to another solution. This is more complicated than it might seem because you do not have any way to retrieve users' password hashes from Azure AD B2C. This negatively impacts your ability to migrate them without an unpleasant "reset password" login experience.
 
+<Aside type="caution">
+Azure AD B2C was closed to new customers on May 1, 2025. Its successor is [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/customers/overview-customers-ciam). Existing Azure AD B2C customers are supported until at least May 2030. This post is intended for existing Azure AD B2C customers considering a migration.
+</Aside>
+
 ## The many faces of Azure AD
 
 Azure AD is Microsoft Azure's name for an umbrella of related identity solutions. There are few options, which support different use cases, even though they may be built on the same technology.
 
 <Aside type="note">
-2024 update! [Azure AD is Microsoft Entra ID.](https://learn.microsoft.com/en-us/entra/fundamentals/new-name) But the usage of Azure AD is common. In this document, wherever you see Azure AD, rest assured we mean Microsoft Entra ID as well. Except if it is [Azure AD B2C](https://learn.microsoft.com/en-us/azure/active-directory-b2c/overview). Confused? You're not alone.
+2024 update! [Azure AD is Microsoft Entra ID.](https://learn.microsoft.com/en-us/entra/fundamentals/new-name) But the usage of Azure AD is common. In this document, wherever you see Azure AD, rest assured we mean Microsoft Entra ID as well. Except if it is [Azure AD B2C](https://learn.microsoft.com/en-us/azure/active-directory-b2c/overview). Confused? You're not alone. 2025 update: Azure AD B2C is now closed to new customers. Its successor is [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/customers/overview-customers-ciam).
 </Aside>
 
 * Azure AD B2C, their CIAM solution, which lets customers register, login, and manage their profile. Think Auth0, Cognito or FusionAuth.
@@ -53,6 +57,10 @@ These limitations can be acceptable initially, but eventually you may need a fea
 For whatever reason, you may decide to move your customer and user data from Azure AD B2C. Let's take a look at how you might do so, but first, let's talk about why you should say put.
 
 ## When you shouldn't migrate from Azure AD B2C
+
+<Aside type="note">
+This section applies to existing Azure AD B2C customers. New customers cannot sign up for Azure AD B2C as of May 2025.
+</Aside>
 
 Like any tool, Azure AD B2C has strengths as well as weaknesses. When your application depends on Azure AD B2C's unique features or if the upsides outweigh the downsides, keep on using it.
 

--- a/astro/src/content/blog/how-to-migrate-from-azure-ad-b2c.mdx
+++ b/astro/src/content/blog/how-to-migrate-from-azure-ad-b2c.mdx
@@ -28,7 +28,9 @@ Azure AD B2C was closed to new customers on May 1, 2025. Its successor is [Micro
 Azure AD is Microsoft Azure's name for an umbrella of related identity solutions. There are few options, which support different use cases, even though they may be built on the same technology.
 
 <Aside type="note">
-2024 update! [Azure AD is Microsoft Entra ID.](https://learn.microsoft.com/en-us/entra/fundamentals/new-name) But the usage of Azure AD is common. In this document, wherever you see Azure AD, rest assured we mean Microsoft Entra ID as well. Except if it is [Azure AD B2C](https://learn.microsoft.com/en-us/azure/active-directory-b2c/overview). Confused? You're not alone. 2025 update: Azure AD B2C is now closed to new customers. Its successor is [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/customers/overview-customers-ciam).
+2024 update: [Azure AD is Microsoft Entra ID.](https://learn.microsoft.com/en-us/entra/fundamentals/new-name) But the usage of Azure AD is common. In this document, wherever you see Azure AD, rest assured we mean Microsoft Entra ID as well. Except if it is [Azure AD B2C](https://learn.microsoft.com/en-us/azure/active-directory-b2c/overview).
+
+2025 update: Azure AD B2C is now closed to new customers. Its successor is [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/customers/overview-customers-ciam).
 </Aside>
 
 * Azure AD B2C, their CIAM solution, which lets customers register, login, and manage their profile. Think Auth0, Cognito or FusionAuth.


### PR DESCRIPTION
This PR refreshes the Azure AD B2C migration blog post for existing customers. 

See also the companion docs guide PR: FusionAuth/fusionauth-site#4301.

Updates include:

- Fixed stale and broken links (`azure.microsoft.com` -> `learn.microsoft.com`)
- Added deprecation notices (Azure AD B2C end of sale May 1 2025, successor is Microsoft Entra External ID)
- Updated free tier pricing claim to reflect that it applies to existing P1 customers only

