### PR TITLE
ENG-4130: Clarify `user.passwordChangeRequired` for users without passwords

### DIFF
--- a/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-registration-combined-request-body.mdx
@@ -114,7 +114,7 @@ This request requires that you specify both the User object and the User Registr
     The User's plain text password. This password will be hashed and the provided value will never be stored and cannot be retrieved.
   </APIField>
   <APIField name="user.passwordChangeRequired" type="Boolean" optional defaults="false">
-    Indicates that the User's password needs to be changed during their next login attempt.
+    Indicates that the User's password needs to be changed during their next login attempt. This does not apply if the user has no password.
   </APIField>
   <APIField name="user.preferredLanguages" type="Array<String>" optional>
     An array of locale strings that give, in order, the User's preferred languages. These are important for email templates and other localizable text. See [Locales](/docs/reference/data-types#locales).

--- a/astro/src/content/docs/apis/_user-request-body.mdx
+++ b/astro/src/content/docs/apis/_user-request-body.mdx
@@ -169,7 +169,7 @@ You must specify either the **email** or the **username** or both for the User. 
   </APIField>
 
   <APIField name="user.passwordChangeRequired" type="Boolean" optional defaults="false">
-    Indicates that the User's password needs to be changed during their next login attempt.
+    Indicates that the User's password needs to be changed during their next login attempt. This does not apply if the user has no password.
   </APIField>
 
   <APIField name="user.phoneNumber" type="String" optional since="1.59.0">


### PR DESCRIPTION
This clarifies a change in behavior introduced with phone identities and users without passwords.