### PR TITLE
Clarify that APIs that require a global API key will reject tenant api keys and the tenant-specifying header

### DIFF
--- a/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/development/kickstart.mdx
@@ -224,9 +224,9 @@ You'll notice there is a special variable that you did not define in the `variab
 
 #### Tenants
 
-If you don't create a tenant using the Tenant API in your kickstart file then you're all set. If you do find yourself creating more than one tenant then you will need to specify the Tenant Id on the API requests.
+If you don't create a tenant using the Tenant API in your kickstart file, you're all set. If you do find yourself creating more than one tenant, you must specify the Tenant Id on the API requests.
 
-There is a top level property in the request called `tenantId` and you simply set that value to indicate which Tenant you wish to use.
+APIs that do not require global API key authentication support a top-level `tenantId` property to specify a Tenant. For a list of APIs that accept non-global API keys, see [API Endpoints Guarded by API Keys](/docs/reference/api-endpoints).
 
 Create a new application in a second, new tenant. Because you need to know the `tenantId`, generate a new UUID using the `#{UUID()}` function call and assign that value to `secondTenantId`. Now, you can re-use this value to create the tenant and to make the Create Application API request.
 

--- a/astro/src/content/releases/v1-65-0.mdx
+++ b/astro/src/content/releases/v1-65-0.mdx
@@ -12,7 +12,13 @@ Made the linking strategy of an enabled identity provider immutable, to prevent 
 </Item>
 
 <Item category="breaking-change" issue="3452">
-To harden security, removed access via tenant-scoped API keys to certain endpoints. To access these endpoints, you must now use a [global API key](/docs/reference/api-endpoints).
+To harden security, removed access via tenant-scoped API keys to endpoints that impact a FusionAuth installation beyond the scope of a single tenant. To access these endpoints, you must now use a global API key.
+
+APIs that require a global API key now _reject_ requests that include the `X-FusionAuth-TenantId` header (e.g. [`/api/key/generate/` endpoint](/docs/apis/keys#generate-a-key)) with a `401` status code.
+
+This also removes support for the `tenantId` property in [Kickstart](/docs/get-started/download-and-install/development/kickstart) configuration calls to APIs that require a global API key.
+
+For a full list of APIs that now require a global API key, see [API Endpoints Guarded by API Keys](/docs/reference/api-endpoints).
 </Item>
 
 <Item category="new-feature" issue="3189">


### PR DESCRIPTION
Make it more obvious on the Kickstart page and in the release notes that these APIs reject `X-FusionAuth-TenantId` and the corresponding top-level `tenantId` Kickstart field.