### PR TITLE
fix: guard against null group and empty headers in ScrollSpy

### DIFF
--- a/astro/public/js/ScrollSpy-0.1.0.js
+++ b/astro/public/js/ScrollSpy-0.1.0.js
@@ -23,6 +23,8 @@ class ScrollSpy {
   }
 
   #handleScroll() {
+    if (this.#headers.length === 0) return;
+
     const scroll = document.documentElement.scrollTop;
     let header = this.#headers[0];
     for (const h of this.#headers) {
@@ -37,6 +39,7 @@ class ScrollSpy {
     document.querySelectorAll('[data-widget="scroll-spy"] [data-widget="scroll-spy-item"]').forEach(li => li.classList.remove('active', 'section-active'));
 
     const group = headerLink.closest('[data-widget="scroll-spy-item"]');
+    if (!group) return;
     group.classList.add('active');
   }
 }

--- a/astro/public/js/ScrollSpy-0.1.0.js
+++ b/astro/public/js/ScrollSpy-0.1.0.js
@@ -39,7 +39,9 @@ class ScrollSpy {
     document.querySelectorAll('[data-widget="scroll-spy"] [data-widget="scroll-spy-item"]').forEach(li => li.classList.remove('active', 'section-active'));
 
     const group = headerLink.closest('[data-widget="scroll-spy-item"]');
+
     if (!group) return;
+    
     group.classList.add('active');
   }
 }

--- a/astro/src/scripts/ScrollSpy.ts
+++ b/astro/src/scripts/ScrollSpy.ts
@@ -15,7 +15,9 @@ const handleScroll = () => {
   document.querySelectorAll('[data-widget="scroll-spy"] [data-widget="scroll-spy-item"].active').forEach(li => li.classList.remove('active'));
 
   const group = headerLink.closest('[data-widget="scroll-spy-item"]');
+
   if (!group) return;
+  
   group.classList.add('active');
 }
 

--- a/astro/src/scripts/ScrollSpy.ts
+++ b/astro/src/scripts/ScrollSpy.ts
@@ -4,6 +4,8 @@ const SHIFT = 100 as const;
 let headers: HTMLElement[] | null = null;
 
 const handleScroll = () => {
+  if (!headers || headers.length === 0) return;
+
   const scroll = document.documentElement.scrollTop;
   const header = headers.findLast((h) => scroll + SHIFT > h.offsetTop) ?? head(headers);
 
@@ -13,6 +15,7 @@ const handleScroll = () => {
   document.querySelectorAll('[data-widget="scroll-spy"] [data-widget="scroll-spy-item"].active').forEach(li => li.classList.remove('active'));
 
   const group = headerLink.closest('[data-widget="scroll-spy-item"]');
+  if (!group) return;
   group.classList.add('active');
 }
 


### PR DESCRIPTION
## Summary

Fixes the #1 error in PostHog error tracking (~44K occurrences across Chrome, Firefox, and Safari variants), caused by two null-safety gaps in ScrollSpy.

### Root cause

The April 29 fix (#4270) split the chained `.querySelector(...).closest(...)` call and added a null check for `headerLink` — but two cases were left unguarded:

1. **`group` can be null** — `closest('[data-widget="scroll-spy-item"]')` returns `null` when the matched header link has no scroll-spy-item ancestor. `group.classList.add('active')` then throws `TypeError: Cannot read properties of null (reading 'classList')`.

2. **Empty headers array** — After the selector was narrowed to `h2[id], h3[id]` only, pages with no matching headings leave the array empty. `headers[0]` is `undefined`, and `header.id` throws before ever reaching the `headerLink` check.

### Changes

- `astro/public/js/ScrollSpy-0.1.0.js` — used by the Webflow brochure site via direct `<script src>` reference
- `astro/src/scripts/ScrollSpy.ts` — used by the Astro site via `Head.astro`

Both files receive:
- `if (headers.length === 0) return` at the top of `handleScroll`
- `if (!group) return` before `group.classList.add('active')`

The existing `headerLink` null check is unchanged.

## Reviewer notes

- The old minified `ScrollSpy-0.1.0.js` is still cached in CloudFront from before the April 29 deploy. Deploying this change will trigger the wildcard invalidation configured in `s3_website.yml` and flush that cache.
- No filename change was made — the Webflow site references `ScrollSpy-0.1.0.js` directly and we don't control that reference from this repo.