### PR TITLE
fix: algolia search cleaner css fix

### DIFF
--- a/astro/src/components/search/DocSearch.astro
+++ b/astro/src/components/search/DocSearch.astro
@@ -56,14 +56,14 @@ import '@docsearch/css';
   }
 
   #docsearch {
-    @apply min-w-0 w-[94%];
+    @apply min-w-0 w-full;
   }
 
   #docsearch .DocSearch-Button {
     background-color: var(--docsearch-search-button-background);
     color: var(--docsearch-search-button-text-color);
     
-    @apply flex items-center w-full h-auto m-0 text-sm
+    @apply box-border flex items-center w-full h-auto m-0 text-sm
       rounded-md border border-slate-900/10 shadow-xs
       hover:shadow-none focus:shadow-none focus:outline-none
       pt-1.5 pr-3 pb-1.5 pl-2.5;


### PR DESCRIPTION
also fixes the overflow but without the hardcoded 94% which is a bit nicer

<img width="1858" height="560" alt="CleanShot 2026-05-13 at 08 16 41@2x" src="https://github.com/user-attachments/assets/bb05764a-33ce-4a3e-b242-df847507d630" />
