### PR TITLE
remove extra bracket

### DIFF
--- a/astro/src/components/api/API.astro
+++ b/astro/src/components/api/API.astro
@@ -116,7 +116,7 @@ const authenticationTypeName = {
   <div class="mb-14">
     <Astro.self method="PATCH" uri={uri}/>
     <Aside type="note" title="Please read">
-      <p>When using the PATCH method, you can either use the same request body documentation that is provided for the PUT request for backward compatibility. Or you may use either <a href="https://www.rfc-editor.org/rfc/rfc6902">JSON Patch/RFC 6902]</a> or <a href="https://www.rfc-editor.org/rfc/rfc7396">JSON Merge Patch/RFC 7396</a>. See the <a href="/docs/apis/#the-patch-http-method">PATCH documentation</a> for more information.</p>
+      <p>When using the PATCH method, you can either use the same request body documentation that is provided for the PUT request for backward compatibility. Or you may use either <a href="https://www.rfc-editor.org/rfc/rfc6902">JSON Patch/RFC 6902</a> or <a href="https://www.rfc-editor.org/rfc/rfc7396">JSON Merge Patch/RFC 7396</a>. See the <a href="/docs/apis/#the-patch-http-method">PATCH documentation</a> for more information.</p>
       <p>When using the PATCH method with a <code>Content-Type</code> of <code>application/json</code> the provided request parameters will be merged into the existing object, this means all parameters are optional when using the PATCH method and you only provide the values you want changed. A <code>null</code> value can be used to remove a value. Patching an <code>Array</code> will result in all values from the new list being appended to the existing list, this is a known limitation to the current implementation of PATCH.</p>
     </Aside>
   </div>


### PR DESCRIPTION
This shows up here: https://fusionauth.io/docs/apis/system and anywhere else we have a `PATCH` warning. See the `6902` mention.

<img width="947" height="428" alt="Screenshot 2026-05-15 at 3 07 07 PM" src="https://github.com/user-attachments/assets/54bcd6c5-aaf2-4b73-ab2d-5b311ea6edc5" />
