### PR TITLE
Update idp mfa security note

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/index.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/index.mdx
@@ -166,6 +166,8 @@ To mitigate these attacks, consider the following strategies:
 * Limit the applications for which an Identity Provider is configured.
 * Use a reconcile lambda to ensure that the email address or identifier provided by the Identity Provider is expected.
 * Use a `Disabled` linking strategy for an Identity Provider and manage links via the [Links API](/docs/apis/identity-providers/links); this allows business logic to execute before or during linking. Examples include disallowing any links to a certain domain or calling into another API for additional validation before creating a link.
+* Use the [Login Validation lambda](/docs/extend/code/lambdas/login-validation) to block the login if needed.
+* Use the [MFA Requirement lambda](/docs/extend/code/lambdas/mfa-requirement) to issue an MFA challenge as needed.
 
 ## Attribute Mappings
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/index.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/identity-providers/index.mdx
@@ -163,7 +163,7 @@ A malicious identity provider can negatively impact your system. For instance, i
 To mitigate these attacks, consider the following strategies:
 
 * Do not set up an Identity Provider.
-* Limit the applications for which an Identity Provider is configured.
+* Limit the applications or tenants for which an Identity Provider is configured.
 * Use a reconcile lambda to ensure that the email address or identifier provided by the Identity Provider is expected.
 * Use a `Disabled` linking strategy for an Identity Provider and manage links via the [Links API](/docs/apis/identity-providers/links); this allows business logic to execute before or during linking. Examples include disallowing any links to a certain domain or calling into another API for additional validation before creating a link.
 * Use the [Login Validation lambda](/docs/extend/code/lambdas/login-validation) to block the login if needed.


### PR DESCRIPTION
We have a warning on the Identity Provider page talking about securing users who log in via federation.

I added a few of the newer features/options for increasing security.