### PR TITLE
bug with remote code and a prefix

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -10,6 +10,7 @@
 		"preview": "astro preview",
 		"astro": "astro",
 		"lint": "eslint",
+		"test": "node --test --experimental-strip-types \"src/components/**/*.test.ts\"",
 		"lint-pr": "node ../src/scripts/lint-recent-files.mjs"
 	},
 	"dependencies": {

--- a/astro/src/components/RemoteCode.astro
+++ b/astro/src/components/RemoteCode.astro
@@ -4,6 +4,7 @@
   */
 
 import { Code } from 'astro:components';
+import { selectLines, selectTagged } from './remoteCodeUtils';
 
 export interface Props {
   /**
@@ -79,43 +80,6 @@ const extractCode = async (url: string, tags?: string): Promise<string> => {
 
 const remoteSelectedCode = await extractCode(url, tags);
 
-function selectTagged (content: string, tags: string): string {
-  let lines = content.split('\n');
-  const startLine = lines.findIndex((line) => line.includes(`tag::${tags}`));
-  const endLine = lines.findIndex((line) => line.includes(`end::${tags}`));
-
-  lines = lines.slice(startLine + 1, endLine);
-  const prefixLengths = lines.filter((line) => line.trim().length > 0).map((line) => prefixSpaces(line));
-  const shortestPrefix = Math.min(...prefixLengths);
-  if (shortestPrefix > 0) {
-    lines = lines.map((line) => line.substring(shortestPrefix));
-  }
-
-  return lines.join('\n').replace(/\s+$/g, '');
-}
-
-function selectLines (content: string, lineNum: number, lineEnd: number): string {
-  const lines = content.split('\n');
-  if ((lineNum > 0) && (lineEnd > 0)) {
-    return lines.slice(lineNum - 1, lineEnd - 1).join('\n');
-  }
-
-  if (lineNum > 0) {
-    return lines[lineNum - 1];
-  }
-
-  return content;
-}
-
-function prefixSpaces(str: string): number {
-  let count = 0;
-  for (let i = 0; i < str.length; i++) {
-    if (str.charAt(i) == ' ' || str.charAt(i) == '\t') {
-      count++;
-    }
-  }
-  return count;
-}
 ---
 {(title === '' || title === undefined)
   ? null

--- a/astro/src/components/remoteCodeUtils.test.ts
+++ b/astro/src/components/remoteCodeUtils.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { prefixSpaces, selectTagged } from './remoteCodeUtils.ts';
+
+test('prefixSpaces counts only leading whitespace', () => {
+  assert.equal(prefixSpaces('class Example:'), 0);
+  assert.equal(prefixSpaces('  class Example:'), 2);
+  assert.equal(prefixSpaces('\tclass Example:'), 1);
+});
+
+test('selectTagged does not trim first character when line has internal spaces', () => {
+  const source = [
+    '# tag::token-verifier',
+    'class FusionAuthTokenVerifier(TokenVerifier):',
+    '    """Verifies tokens using the FusionAuth JWT validation endpoint."""',
+    '',
+    '    def __init__(',
+    '# end::token-verifier',
+  ].join('\n');
+
+  const selected = selectTagged(source, 'token-verifier');
+
+  assert.equal(selected.startsWith('class FusionAuthTokenVerifier(TokenVerifier):'), true);
+  assert.equal(selected.includes('\nlass FusionAuthTokenVerifier(TokenVerifier):'), false);
+});

--- a/astro/src/components/remoteCodeUtils.ts
+++ b/astro/src/components/remoteCodeUtils.ts
@@ -1,0 +1,39 @@
+export function selectTagged(content: string, tags: string): string {
+  let lines = content.split('\n');
+  const startLine = lines.findIndex((line) => line.includes(`tag::${tags}`));
+  const endLine = lines.findIndex((line) => line.includes(`end::${tags}`));
+
+  lines = lines.slice(startLine + 1, endLine);
+  const prefixLengths = lines.filter((line) => line.trim().length > 0).map((line) => prefixSpaces(line));
+  const shortestPrefix = Math.min(...prefixLengths);
+  if (shortestPrefix > 0) {
+    lines = lines.map((line) => line.substring(shortestPrefix));
+  }
+
+  return lines.join('\n').replace(/\s+$/g, '');
+}
+
+export function selectLines(content: string, lineNum: number, lineEnd: number): string {
+  const lines = content.split('\n');
+  if ((lineNum > 0) && (lineEnd > 0)) {
+    return lines.slice(lineNum - 1, lineEnd - 1).join('\n');
+  }
+
+  if (lineNum > 0) {
+    return lines[lineNum - 1];
+  }
+
+  return content;
+}
+
+export function prefixSpaces(str: string): number {
+  let count = 0;
+  for (let i = 0; i < str.length; i++) {
+    if (str.charAt(i) == ' ' || str.charAt(i) == '\t') {
+      count++;
+    } else {
+      break;
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
Pulled over a fix from https://github.com/FusionAuth/fusionauth-astro-components/pull/129

selectTagged was computing the shortest leading-whitespace prefix using a prefixSpaces helper that counted all spaces in a line (including internal ones), not just leading ones. For a line like class Foo(Bar):, the space between class and Foo was counted, yielding shortestPrefix = 1, causing every line to have its first character stripped (e.g. class → lass).

Added tests for this and tested it locally.