### PR TITLE
Add ogImage frontmatter support for per-post social graph images

### DIFF
--- a/astro/src/content.config.js
+++ b/astro/src/content.config.js
@@ -80,6 +80,7 @@ const blogCollection = defineCollection({
     ),
     htmlTitle: z.string().optional(),
     image: z.string().optional(),
+    ogImage: z.string().optional(),
     authors: z.string().optional(), // comma-separated string
     categories: z.string().optional(), // comma-separated string
     tags: z.string().optional(), // comma-separated string

--- a/astro/src/layouts/Blog.astro
+++ b/astro/src/layouts/Blog.astro
@@ -26,6 +26,7 @@ const description = frontmatter.description ? frontmatter.description : '';
 const canonicalUrl = frontmatter.canonicalUrl ? frontmatter.canonicalUrl : '';
 const categories = frontmatter.categories ? frontmatter.categories.split(',').map(cat => cat.trim()) : [];
 const image = frontmatter.image ? frontmatter.image : '/img/blogs/header-example.svg';
+const ogImage = frontmatter.ogImage ? frontmatter.ogImage : image;
 const authors = frontmatter.authors ? frontmatter.authors.split(',').map(author => author.trim()) : [];
 const publishedDate = frontmatter.publish_date;
 const updatedDate = frontmatter.updated_date;
@@ -67,7 +68,7 @@ const markdownStyles = [
 ---
 <!DOCTYPE html>
 <html class="antialiased" lang="en">
-<HeadComponent title={ htmlTitle } canonicalUrl={canonicalUrl} description={description} openGraphImage={image}></HeadComponent>
+<HeadComponent title={ htmlTitle } canonicalUrl={canonicalUrl} description={description} openGraphImage={ogImage}></HeadComponent>
 <body class="antialiased leading-tight dark:bg-articles-dark dark:bg-slate-900 dark:text-slate-200">
   <script>
     document.addEventListener("DOMContentLoaded", async () => {


### PR DESCRIPTION
Adds support for a custom `ogImage` frontmatter field on blog posts, separate from the post's hero `image`.

**Why:** Some posts need a different image for social sharing than what's displayed as the hero. Without this, the hero image is always used for OG/Twitter cards.

**What changed:**
- `Blog.astro` — reads `ogImage` from frontmatter; falls back to `image` if not set. No existing posts are affected.

**How to use:**
Add `ogImage` to a post's frontmatter pointing to a file in `/img/blogs/[post]`:

```yaml
ogImage: /img/blogs/my-post-social.png
```

Recommended image size: 1200×630px.