### PR TITLE
add bluehawk tests for express quickstart 

### DIFF
--- a/astro/localcode/quickstart-express/tests/integration.spec.js
+++ b/astro/localcode/quickstart-express/tests/integration.spec.js
@@ -1,0 +1,104 @@
+const { test, expect } = require('@playwright/test');
+
+function trackPageDiagnostics(page) {
+  const consoleMessages = [];
+  const pageErrors = [];
+
+  page.on('console', msg => {
+    consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+  });
+
+  page.on('pageerror', err => {
+    pageErrors.push(err.message);
+  });
+
+  return async () => {
+    console.log('\n=== DEBUG INFO ===');
+    console.log('Page URL:', page.url());
+    try {
+      console.log('Page HTML:', await page.content());
+    } catch (contentError) {
+      console.log('Page HTML: <unavailable, page/context already closed>', contentError.message);
+    }
+    console.log('\nConsole messages:', consoleMessages);
+    console.log('\nPage errors:', pageErrors);
+    console.log('=== END DEBUG ===\n');
+  };
+}
+
+test('FusionAuth admin login', async ({ page }) => {
+  const dumpDiagnostics = trackPageDiagnostics(page);
+
+  try {
+    await page.goto('http://localhost:9011/admin/');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByPlaceholder('Login').fill('admin@example.com');
+    await page.getByPlaceholder('Password').fill('password');
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page).toHaveURL(/\/admin\//);
+    await expect(page.getByRole('heading', { name: 'Recent logins' })).toBeVisible();
+  } catch (error) {
+    await dumpDiagnostics();
+    throw error;
+  }
+});
+
+test('Express app login, note edit, and logout via FusionAuth', async ({ page }) => {
+  const dumpDiagnostics = trackPageDiagnostics(page);
+
+  try {
+    await page.goto('http://localhost:3000/');
+
+    // unauthenticated visit redirects through FusionAuth's login page
+    await page.waitForURL(/localhost:9011/, { timeout: 15000 });
+    await page.getByPlaceholder('Login').fill('richard@example.com');
+    await page.getByPlaceholder('Password').fill('password');
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await page.waitForURL('http://localhost:3000/**', { timeout: 15000 });
+    await expect(page.locator('textarea[name="content"]')).toBeVisible();
+
+    await page.fill('textarea[name="content"]', 'Playwright test note');
+    await page.click('button:has-text("Save Changes")');
+    await page.waitForTimeout(500);
+
+    const content = await page.content();
+    expect(content).toContain('Playwright test note');
+
+    await page.click('a.logout-btn');
+    await page.waitForTimeout(1000);
+
+    // re-visiting the app after logout should require login again
+    await page.goto('http://localhost:3000/');
+    await page.waitForURL(/localhost:9011/, { timeout: 15000 });
+  } catch (error) {
+    await dumpDiagnostics();
+    throw error;
+  }
+});
+
+test('Express app multi-user note isolation', async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const dumpDiagnostics = trackPageDiagnostics(page);
+
+  try {
+    await page.goto('http://localhost:3000/');
+    await page.waitForURL(/localhost:9011/, { timeout: 15000 });
+    await page.getByPlaceholder('Login').fill('richard@example.com');
+    await page.getByPlaceholder('Password').fill('password');
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await page.waitForURL('http://localhost:3000/**', { timeout: 15000 });
+    const content = await page.content();
+    expect(content).toMatch(/Welcome, Richard Hendricks/);
+
+    await context.close();
+  } catch (error) {
+    await dumpDiagnostics();
+    await context.close();
+    throw error;
+  }
+});

--- a/astro/localcode/quickstart-express/tests/test.sh
+++ b/astro/localcode/quickstart-express/tests/test.sh
@@ -1,2 +1,84 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+FA_REPO_DIR="$(mktemp -d)/fusionauth-quickstart-app"
+
+cleanup() {
+  echo "Cleaning up..."
+  kill $EXPRESS_PID 2>/dev/null || true
+  docker stop express-web-test 2>/dev/null || true
+  if [ -d "$FA_REPO_DIR" ]; then
+    cd "$FA_REPO_DIR" && docker compose down -v 2>/dev/null || true
+  fi
+  rm -rf "$(dirname "$FA_REPO_DIR")" 2>/dev/null || true
+  rm -rf "$TEST_APP_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Checking syntax of each staged express-app.js..."
+for STAGE_DIR in "$PROJECT_DIR"/0-start "$PROJECT_DIR"/1-fusionauth-added "$PROJECT_DIR"/2-multi-user; do
+  STAGE_NAME=$(basename "$STAGE_DIR")
+  echo "  Syntax-checking $STAGE_NAME..."
+  docker run --rm -v "$STAGE_DIR:/app" -w /app node:26 node --check express-app.js
+done
+
+echo "Cloning the shared FusionAuth quickstart-app instance..."
+git clone --depth 1 https://github.com/FusionAuth/fusionauth-quickstart-app.git "$FA_REPO_DIR"
+
+echo "Validating docker compose config..."
+(cd "$FA_REPO_DIR" && docker compose config > /dev/null)
+
+echo "Pulling latest FusionAuth image..."
+(cd "$FA_REPO_DIR" && docker compose pull)
+
+echo "Starting FusionAuth..."
+(cd "$FA_REPO_DIR" && docker compose up -d)
+
+echo "Waiting for FusionAuth to be ready..."
+timeout 480 bash -c 'until curl -sfL http://localhost:9011/admin/ 2>/dev/null | grep -q "<title>Login"; do
+  echo "  Waiting for FusionAuth..."
+  sleep 5
+done'
+echo "FusionAuth is ready."
+
+TEST_APP_DIR="$(mktemp -d)"
+echo "Setting up 2-multi-user stage for the live login test..."
+cp "$PROJECT_DIR/2-multi-user/express-app.js" "$TEST_APP_DIR/"
+cp "$PROJECT_DIR/1-fusionauth-added/.env" "$TEST_APP_DIR/"
+
+echo "Enabling self-service registration fields on the QuickStart App (matches guide's manual admin-UI step)..."
+API_KEY="this_really_should_be_a_long_random_alphanumeric_value_but_this_still_works"
+curl -sf -X PATCH http://localhost:9011/api/application/f0510a74-da7a-4101-a474-05e7f1d5ba7e \
+  -H "Authorization: $API_KEY" -H "Content-Type: application/json" \
+  -d '{
+    "application": {
+      "registrationConfiguration": {
+        "birthDate": {"enabled": true, "required": true},
+        "firstName": {"enabled": true, "required": true},
+        "lastName": {"enabled": true, "required": true}
+      }
+    }
+  }' > /dev/null
+
+echo "Installing Express app dependencies..."
+docker run --rm -v "$TEST_APP_DIR:/app" -w /app node:26 \
+  npm install express passport passport-oauth2 express-session dotenv jsonwebtoken
+
+echo "Starting Express app..."
+docker run --network host --name express-web-test --rm -v "$TEST_APP_DIR:/app" -w /app node:26 node express-app.js &
+EXPRESS_PID=$!
+
+echo "Waiting for Express app to be ready..."
+timeout 120 bash -c 'until curl -sf http://localhost:3000 > /dev/null 2>&1; do
+  echo "  Waiting for Express app..."
+  sleep 2
+done'
+echo "Express app is ready."
+
+echo "Running Playwright tests..."
+docker run --network host --name playwright-test --rm -e NODE_PATH=/usr/lib/node_modules -v "$SCRIPT_DIR/integration.spec.js":/tests/integration.spec.js mcr.microsoft.com/playwright:v1.62.0 bash -c "npm install -g @playwright/test@1.62.0 && playwright test /tests/integration.spec.js"
+TEST_EXIT_CODE=$?
+
+exit $TEST_EXIT_CODE


### PR DESCRIPTION
The Express quickstart previously embedded all code inline as fenced code blocks in `express.mdx`. This PR moves the source files into `code-example-repositories/fusionauth-quickstart-javascript-express-web/` and replaces the inline blocks with `LocalCode` references.

Because this is a self-contained guide where readers type code from scratch rather than cloning a repository, `repositoryUrl.txt` is set to `internal` — the export workflow will skip it and not attempt to publish to an external repo.

Depends on https://github.com/FusionAuth/fusionauth-site/pull/4371