### PR TITLE
Fix incorrect values in SCIM schemas response

### DIFF
--- a/astro/src/content/json/scim/scim-schemas-response.json
+++ b/astro/src/content/json/scim/scim-schemas-response.json
@@ -6,7 +6,7 @@
       "description": "Enterprise User",
       "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
       "meta": {
-        "location": "https://piedpiper.com/api/scim/resource/v2/Schemas/v2/Schemas/urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+        "location": "https://piedpiper.com/api/scim/resource/v2/Schemas/urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
         "resourceType": "Schema"
       },
       "name": "EnterpriseUser"
@@ -19,7 +19,7 @@
           "multiValued": false,
           "mutability": "readWrite",
           "name": "displayName",
-          "required": false,
+          "required": true,
           "returned": "default",
           "type": "string",
           "uniqueness": "none"


### PR DESCRIPTION
Default SCIM schema has been updated with fixes for https://github.com/FusionAuth/fusionauth-issues/issues/3384 and https://github.com/FusionAuth/fusionauth-issues/issues/3385. 