### PR TITLE
Update Remix quickstart for React Router migration (#4068)

### DIFF
--- a/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
+++ b/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
@@ -29,6 +29,10 @@ For this Quickstart, you'll need:
 
 Start with getting FusionAuth up and running and creating a new Remix application.
 
+<Aside type="note">
+Remix has been merged into [React Router](https://reactrouter.com), which is now the recommended way to build Remix-style apps. This guide uses React Router's tooling and current APIs throughout.
+</Aside>
+
 ### Clone The Code
 
 First, grab the code from the repository and change into that folder.
@@ -48,21 +52,38 @@ All the files you'll create in this guide already exist in the `complete-applica
 
 ### Create A Basic Remix Application
 
-Next, you'll set up a basic Remix app. While this guide builds a new Remix project, you can use the same method to integrate your existing project with FusionAuth.
+Next, you'll set up a basic Remix app using React Router's scaffolding tool. While this guide builds a new project, you can use the same method to integrate your existing project with FusionAuth.
 
-Create the default Remix starter project.
+Create the default starter project.
 
 ```shell
-npx create-remix@latest mysite
+npx create-react-router@latest mysite
 ```
 
-If `create-remix` isn't on your machine, npx will prompt you to install it. Confirm the installation with a `y` input.
+If `create-react-router` isn't on your machine, npx will prompt you to install it. Confirm the installation with a `y` input.
 
-Choose the following options:
-- Just the basics
-- Remix App Server
-- TypeScript
-- Yes (to running `npm install`)
+When prompted, choose **No** for the deployment target ("Do you want me to set up that too?"). This guide runs the app on Vite's built-in server, not a specific hosting target.
+
+Change into the new project and pin the dev server to port 3000. Open `mysite/vite.config.ts` and add a `server` block:
+
+```ts
+import { reactRouter } from "@react-router/dev/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [reactRouter()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  server: {
+    port: 3000,
+  },
+});
+```
+
+<Aside type="caution">
+Vite's dev server normally runs on port 5173 by default. The FusionAuth application created by Kickstart has its redirect and logout URLs hardcoded to `http://localhost:3000`, so without this change the OAuth login flow will fail with a redirect URI mismatch.
+</Aside>
 
 Add additional npm packages the site will use using the commands below.
 
@@ -80,24 +101,33 @@ Now create the `.env` file in your `mysite` folder and add the following to it (
 
 ### Preliminary Setup
 
-Before you configure authentication, you need to change the default files created by Remix.
+Before you configure authentication, you need to change the default files created by the scaffolding tool.
 
-Replace the contents of the file `mysite/app/root.tsx` with the following code.
+First, **delete the scaffolded `mysite/app/routes/home.tsx` file and the `mysite/app/welcome/` folder.** You'll add your own routes as you go, so these defaults aren't needed.
+
+Next, replace the contents of the file `mysite/app/root.tsx` with the following code.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/root.tsx"
  lang="typescript" />
 
 This is what these changes do:
-- Add some styling with `import css from "~/css/changebank.css";` at the top.
-- Specify the `<head>` content for the page (title and CSS link) in the two functions at the bottom.
+- Import the app's styling with `import "~/css/changebank.css";` at the top.
+- Specify the `<head>` content for the page (title and CSS link) in `meta` and the `Layout` component.
+- Define an `ErrorBoundary` so unhandled route errors render a plain error page instead of crashing.
 
-At the top of the file `mysite/app/entry.server.tsx`, add the following line.
+Routes are no longer discovered automatically by filename. Instead, `mysite/app/routes.ts` lists every route explicitly. Create it with the following content. You'll add to this file as you create each route below.
 
-```tsx
-import 'dotenv/config';
+```ts
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
+
+export default [
+  index("routes/_index.tsx"),
+] satisfies RouteConfig;
 ```
 
-This allows any other file run on the server to use settings from `.env`.
+<Aside type="tip">
+If you'd rather keep the older filename-based routing convention (where a file's name determines its URL), you can install the `@react-router/fs-routes` package instead of listing routes by hand. This guide uses explicit registration since it's the more current, idiomatic approach.
+</Aside>
 
 ## Authentication
 
@@ -108,7 +138,7 @@ Authentication in Remix requires two parts:
 
 ### Services
 
-The `app` folder in the `mysite` project holds all your code. The `routes` folder is a reserved word in Remix, and contains your application's pages. Let's make a `services` folder to keep your authentication code separate.
+The `app` folder in the `mysite` project holds all your code. The `routes` folder holds your application's pages. Let's make a `services` folder to keep your authentication code separate.
 
 ```shell
 mkdir app/services
@@ -119,29 +149,31 @@ In this `services` folder, add a file called `session.server.ts` and copy in the
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/services/session.server.ts"
  lang="typescript" />
 
-This code provides a way for Remix to store cookies that maintain the user's session. (If you'd prefer to use file-based sessions instead of cookie-based, you can read about it in an earlier [blog post about using Remix](/blog/remix-demo).)
+This code provides a way for the app to store cookies that maintain the user's session. (If you'd prefer to use file-based sessions instead of cookie-based, you can read about it in an earlier [blog post about using Remix](/blog/remix-demo).)
 
 Next, create an authentication file in the `services` folder, `auth.server.ts`, that uses the session provider you just created.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/services/auth.server.ts"
  lang="typescript" />
 
-In the line `new Authenticator<User>`, you can specify which user details you want to keep in the session. This example uses a single string containing the user's email, but you could define an object with more details or just a user Id.
-
-Note that the `User` must have a value. If the Authenticator returns nothing to store in the session, then a user will not stay logged in.
+In the line `new Authenticator<User>()`, the type parameter specifies which user details you want to keep in the session. This example uses a single string containing the user's email, but you could define an object with more details or just a user Id.
 
 In `authOptions`, you specify the FusionAuth URLs stored in the `.env` file, which match those created by Kickstart when you ran the Docker command to start FusionAuth.
 
-Finally, `authStrategy` returns the user's email, decoded from the JWT returned by FusionAuth.
+Finally, `authStrategy` returns the user's email, decoded from the ID token returned by FusionAuth.
+
+<Aside type="caution">
+Unlike some older authentication setups, `authenticator.authenticate()` here only returns the logged-in user, and no longer commits anything to the session automatically. Each route below is responsible for reading, updating, and saving the session cookie itself.
+</Aside>
 
 ### Routes
 
-First replace the homepage of your app in `mysite/app/routes/_index.tsx` with the following code.
+Create the homepage of your app at `mysite/app/routes/_index.tsx` with the following code.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/routes/_index.tsx"
  lang="typescript" />
 
-Remix extends React with a few more custom elements that automatically hide the difference between client and server from the programmer. For example, the line `<Link to="/login" className="button-lg">Login</Link>` allows Remix to load the linked page in the background without a separate page refresh.
+Remix extends React with a few more custom elements that automatically hide the difference between client and server from the programmer. For example, the line `<Link to="/login" className="button-lg">Login</Link>` allows the app to load the linked page in the background without a separate page refresh.
 
 If you have not worked with React before, there are a few differences from normal HTML to note:
 
@@ -149,10 +181,10 @@ If you have not worked with React before, there are a few differences from norma
 - To add JavaScript values into your HTML, you wrap the value in `{  }`.
 - The `style` values are not strings but object literals in braces, wrapped in more braces.
 
-The `_index.tsx` file imports the Authenticator service you created in the previous section, checks if the user has a session, and redirects the user to their profile if they do. This `isAuthenticated` function does not call FusionAuth but checks the user's cookie instead.
+The `_index.tsx` file checks the session cookie for a logged-in user, and redirects to the account page if one is found. This check does not call FusionAuth; it only reads the user's existing cookie.
 
 <Aside type="caution">
-Note that this code runs in a Remix `loader` function on the server, not the client. Remember that Remix provides two functions that run only on the server: `loader` for GET requests and `action` for POST, PATCH, and UPDATE requests. These functions will always run before any HTML is returned to the client. By contrast, the `default` function (that returns HTML) is exported from a route and runs only in the browser (unless the user browses directly to the route without already being on the site). Since Remix mixes server-side and client-side code in the same file, it is essential not to put any authentication handling or secrets in the client-side code.
+Note that this code runs in a `loader` function on the server, not the client. `loader` functions run for GET requests and always execute before any HTML is returned to the client. By contrast, the `default` function (that returns HTML) is exported from a route and runs only in the browser (unless the user browses directly to the route without already being on the site). Since routes mix server-side and client-side code in the same file, it is essential not to put any authentication handling or secrets in the client-side code.
 </Aside>
 
 The link you created looks for a login route, so let's code it. Create the file `mysite/app/routes/login.tsx` and add the following code to it.
@@ -160,24 +192,41 @@ The link you created looks for a login route, so let's code it. Create the file 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/routes/login.tsx"
  lang="typescript" />
 
-This route is purely server-side, as it exports no default function. Instead, the GET loader function redirects the user to FusionAuth. (The user will automatically be logged in without FusionAuth if they already have a session cookie in their browser).
+This route is purely server-side, as it exports no default function. Instead, the GET loader function redirects the user to FusionAuth. (The user will automatically be logged in without visiting FusionAuth if they already have a session cookie in their browser).
 
 Now create the file `mysite/app/routes/logout.tsx` and add the following code to it.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/routes/logout.tsx"
  lang="typescript" />
 
-When a user browses to this route, they will be logged out by the Authenticator clearing their session, and redirected to the home page.
+When a user browses to this route, their session cookie is destroyed and they're redirected to the home page.
 
 The final route to create is `mysite/app/routes/auth.callback.tsx`.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/routes/auth.callback.tsx"
  lang="typescript" />
 
-This is where FusionAuth is configured to direct the user after authentication. It may look like this code is doing yet another authentication with `authenticator.authenticate`, but the Authenticator will already have created a session for the user, so no call to FusionAuth will be made here. It is just a way to direct the user to the appropriate page after login.
+This is where FusionAuth redirects the user after authentication. `authenticator.authenticate` completes the OAuth2 token exchange and returns the user's email; the route then stores that email in the session cookie itself before redirecting to the account page.
 
 <Aside type="tip">
-If you are wondering why `auth.callback.tsx` has two dots, it's because Remix routing treats the first dot as a slash in the URL, `/auth/callback`.
+If you are wondering why `auth.callback.tsx` has two dots, it's because this routing convention treats the first dot as a slash in the URL, `/auth/callback`.
+</Aside>
+
+Now add all four routes to `mysite/app/routes.ts`, replacing its contents with:
+
+```ts
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
+
+export default [
+  index("routes/_index.tsx"),
+  route("login", "routes/login.tsx"),
+  route("logout", "routes/logout.tsx"),
+  route("auth/callback", "routes/auth.callback.tsx"),
+] satisfies RouteConfig;
+```
+
+<Aside type="caution">
+A route file that isn't listed in `routes.ts` won't be reachable, even if it exists in the `routes` folder. This is different from older filename-convention routing, where any file under `routes/` was automatically served.
 </Aside>
 
 ## Customization
@@ -197,20 +246,39 @@ Add the account page `mysite/app/routes/account.tsx` with the following code.
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/routes/account.tsx"
  lang="typescript" />
 
-The `loader` function at the top of the page prohibits the user from viewing this page if they are not authenticated. Any page you create that needs the user to be authenticated requires this function.
+The `loader` function at the top of the page checks the session cookie and redirects to `/login` if there's no logged-in user. Any page you create that needs the user to be authenticated requires a check like this.
 
-The line `const email: string = useLoaderData<typeof loader>();` provides whatever data the loader function returns for use in the HTML. It's used in the line `<p className="header-email">{email}</p>`.
+The `loaderData` prop passed into the `Account` component provides whatever data the loader function returns for use in the HTML. It's used in the line `<p className="header-email">{email}</p>`.
 
 The final page you need is `mysite/app/routes/change.tsx`, with the following code.
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/routes/change.tsx"
  lang="typescript" />
 
-This page has identical Remix and authentication functionality to the Account page and some pure React code that updates the DOM whenever the state changes.
+This page has identical authentication functionality to the Account page and some pure React code that updates the DOM whenever the state changes.
+
+<Aside type="tip">
+Note that `ChangeEvent` is imported with `import type` rather than as a regular import, since it's only a TypeScript type, not a value.
+</Aside>
+
+Finally, add both pages to `mysite/app/routes.ts`:
+
+```ts
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
+
+export default [
+  index("routes/_index.tsx"),
+  route("login", "routes/login.tsx"),
+  route("logout", "routes/logout.tsx"),
+  route("auth/callback", "routes/auth.callback.tsx"),
+  route("account", "routes/account.tsx"),
+  route("change", "routes/change.tsx"),
+] satisfies RouteConfig;
+```
 
 ## Run The Application
 
-Start the Remix server from the root `mysite` directory.
+Start the server from the root `mysite` directory.
 
 ```shell
 npm run dev
@@ -228,7 +296,7 @@ Log in using `richard@example.com` and `password`. The change page will allow yo
 
 ### Remix Authentication
 
-- [Remix Docs](https://remix.run/docs)
+- [React Router Docs](https://reactrouter.com)
 - [Passport.js authentication concepts](https://www.passportjs.org/concepts/authentication/downloads/html/)
 - [Remix Auth](https://github.com/sergiodxa/remix-auth)
 - [Remix-Auth-Oauth2 Docs](https://github.com/sergiodxa/remix-auth-oauth2)
@@ -239,6 +307,10 @@ Log in using `richard@example.com` and `password`. The change page will allow yo
 * I get "This site can’t be reached localhost refused to connect" when I click the login button.
 
 Ensure FusionAuth is running in the Docker container. You should be able to log in as the admin user `admin@example.com` with a password of `password` at [http://localhost:9011/admin](http://localhost:9011/admin).
+
+* I get "invalid_request" / "Invalid Authorization Code" after logging in to FusionAuth.
+
+Double check that your dev server is actually running on port 3000 (see the `vite.config.ts` change earlier). The FusionAuth application's redirect URL is hardcoded to that port, so running on a different port will cause this error.
 
 * It still doesn't work.
 

--- a/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
+++ b/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
@@ -212,7 +212,7 @@ This is where FusionAuth redirects the user after authentication. `authenticator
 If you are wondering why `auth.callback.tsx` has two dots, it's because this routing convention treats the first dot as a slash in the URL, `/auth/callback`.
 </Aside>
 
-Now add all four routes to `mysite/app/routes.ts`, replacing its contents with:
+Now add all the routes to `mysite/app/routes.ts`, replacing its contents with:
 
 ```ts
 import { type RouteConfig, index, route } from "@react-router/dev/routes";

--- a/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
+++ b/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
@@ -168,7 +168,7 @@ Unlike some older authentication setups, `authenticator.authenticate()` here onl
 
 ### Routes
 
-Create the homepage of your app at `mysite/app/routes/_index.tsx` with the following code.
+Create the homepage of your app at `mysite/app/routes/_index.tsx` with the following code:
 
 <RemoteCode url="https://raw.githubusercontent.com/FusionAuth/fusionauth-quickstart-javascript-remix-web/main/complete-application/app/routes/_index.tsx"
  lang="typescript" />

--- a/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
+++ b/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
@@ -82,7 +82,7 @@ export default defineConfig({
 ```
 
 <Aside type="caution">
-Vite's dev server normally runs on port 5173 by default. The FusionAuth application created by Kickstart has its redirect and logout URLs hardcoded to `http://localhost:3000`, so without this change the OAuth login flow will fail with a redirect URI mismatch.
+By default, the Vite dev server runs on port `5173`. This Quickstart, however, expects the Vite dev server to run on port `3000`. Without this change, your OAuth login flow will fail with a redirect URI mismatch.
 </Aside>
 
 Add additional npm packages the site will use using the commands below.

--- a/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
+++ b/astro/src/content/docs/get-started/quickstarts/web/quickstart-javascript-remix-web.mdx
@@ -226,7 +226,7 @@ export default [
 ```
 
 <Aside type="caution">
-A route file that isn't listed in `routes.ts` won't be reachable, even if it exists in the `routes` folder. This is different from older filename-convention routing, where any file under `routes/` was automatically served.
+A route file that isn't listed in `routes.ts` won't be reachable, even if it exists in the `routes` folder. This is different from older filename-convention routing, which automatically served any file under `routes/`.
 </Aside>
 
 ## Customization


### PR DESCRIPTION
## Overview

Updates the Remix quickstart guide, addressing FusionAuth/fusionauth-site#4068 ("Remix quickstart is out of date").

The guide was QA'd by going through it as a reader from a clean start, and the walkthrough was tested end to end against a fresh FusionAuth instance. Login, the account and change pages, logout, and post-logout access control all work with the updated guide.

## What changed

The quickstart was rewritten to match the current tooling and to fix a login problem found during QA:

1. **Login fix.** The client ID in the configuration was uppercase, but FusionAuth compares it case-sensitively during the token exchange, which broke login. The guide and its example code now use the lowercase ID.

2. **React Router migration.** Remix has been merged into React Router and `create-remix` no longer scaffolds a project, so the guide now uses the React Router tooling and current authentication APIs throughout. This includes the new scaffolding command, pinning the dev server to the expected port, explicit route registration, and the updated session-handling pattern.

A new entry was added to the Troubleshooting section covering what happens when the dev server runs on the wrong port. If the app is not on port 3000, the redirect URL it sends does not match the one Kickstart registered for the FusionAuth application, so login fails after the user authenticates. The entry tells the reader to confirm the dev server is on port 3000 and points back to the vite.config.ts change that sets it.

## Dependency

This depends on the code-repo PR (FusionAuth/fusionauth-quickstart-javascript-remix-web#13) merging first. The guide's embedded code blocks are pulled live from the code repo's main branch, so until that PR merges they will show the old Remix code. Once it merges, the embedded code updates automatically to match the new guide text