### PR TITLE
ENG-4659: Advanced Themes Exposes 

### DIFF
--- a/astro/src/content/docs/apis/themes/advanced-themes.mdx
+++ b/astro/src/content/docs/apis/themes/advanced-themes.mdx
@@ -28,6 +28,10 @@ Available since version `1.8.0`
 
 UI login themes can be configured to enable custom branding for your FusionAuth login workflow.  Themes are configured per Tenant or optionally by Application.
 
+<Aside type="caution">
+Theme templates may expose sensitive configuration data including SSO cookies, tenant settings, JWT configuration, SMTP credentials, and user information. Only use themes from trusted sources and review all custom theme code before deployment.
+</Aside>
+
 The following APIs are provided to manage Themes.
 
 ## Create an Advanced Theme

--- a/astro/src/content/docs/apis/themes/advanced-themes.mdx
+++ b/astro/src/content/docs/apis/themes/advanced-themes.mdx
@@ -29,7 +29,7 @@ Available since version `1.8.0`
 UI login themes can be configured to enable custom branding for your FusionAuth login workflow.  Themes are configured per Tenant or optionally by Application.
 
 <Aside type="caution">
-Theme templates may expose sensitive configuration data including SSO cookies, tenant settings, JWT configuration, SMTP credentials, and user information. Only use themes from trusted sources and review all custom theme code before deployment.
+Theme templates have access to sensitive configuration data including SSO cookies, tenant settings, JWT configuration, SMTP credentials, and user information. Only use themes from trusted sources and review all custom theme code before deployment.
 </Aside>
 
 The following APIs are provided to manage Themes.

--- a/astro/src/content/docs/customize/look-and-feel/advanced-themes/index.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/advanced-themes/index.mdx
@@ -24,7 +24,7 @@ With the Simple Theme Editor, you can select from a set of pre-built themes and 
 </Aside>
 
 <Aside type="caution">
-Theme templates may expose sensitive configuration data including SSO cookies, tenant settings, JWT configuration, SMTP credentials, and user information. Only use themes from trusted sources and review all custom theme code before deployment.
+Theme templates have access to sensitive configuration data including SSO cookies, tenant settings, JWT configuration, SMTP credentials, and user information. Only use themes from trusted sources and review all custom theme code before deployment.
 </Aside>
 
 ## Create a Theme

--- a/astro/src/content/docs/customize/look-and-feel/advanced-themes/index.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/advanced-themes/index.mdx
@@ -23,6 +23,10 @@ Since version `1.51.0`, you can instead use the [Simple Theme Editor](/docs/cust
 With the Simple Theme Editor, you can select from a set of pre-built themes and customize them with a few basic options.
 </Aside>
 
+<Aside type="caution">
+Theme templates may expose sensitive configuration data including SSO cookies, tenant settings, JWT configuration, SMTP credentials, and user information. Only use themes from trusted sources and review all custom theme code before deployment.
+</Aside>
+
 ## Create a Theme
 
 FusionAuth provides the ability to create and manage themes in the UI as well as a [Themes API](/docs/apis/themes). Any user of the FusionAuth role of `admin` or `theme_manager` may view, edit, update, and delete Themes.

--- a/astro/src/content/docs/customize/look-and-feel/advanced-themes/template-variables.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/advanced-themes/template-variables.mdx
@@ -4,6 +4,7 @@ description: Detailed documentation about the theme template variables.
 ---
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import Aside from 'src/components/Aside.astro';
 import ThemeTemplateVariables from 'src/content/docs/_shared/_theme_template_variables.astro';
 
 Template variables are provided to allow intelligent customization of theme templates. You can use Freemarker to display, hide, or otherwise logically modify what your end users sees based on these values.
@@ -13,6 +14,10 @@ Each template has different variables that are available to it. These variables 
 When the variable is FusionAuth specific, such as the tenant or application, the fields of the variable are the same as the JSON object described in the Retrieve section of the corresponding API documentation.
 
 By default FusionAuth will provide HTML escaping on all values rendered in HTML, this protects you from script injection attacks. If you find a value that is being incorrectly escaped you may need to utilize the FreeMarker built in for no-escape `?no_esc`.
+
+<Aside type="caution">
+Template variables may expose sensitive configuration data including tenant settings, JWT configuration, SMTP credentials, and user information. Avoid logging or exposing sensitive variables in custom themes.
+</Aside>
 
 {/*  don't update these variables directly. */}
 {/*  update site/_date/templates.yaml (further instructions there) */}

--- a/astro/src/content/docs/customize/look-and-feel/advanced-themes/template-variables.mdx
+++ b/astro/src/content/docs/customize/look-and-feel/advanced-themes/template-variables.mdx
@@ -16,7 +16,7 @@ When the variable is FusionAuth specific, such as the tenant or application, the
 By default FusionAuth will provide HTML escaping on all values rendered in HTML, this protects you from script injection attacks. If you find a value that is being incorrectly escaped you may need to utilize the FreeMarker built in for no-escape `?no_esc`.
 
 <Aside type="caution">
-Template variables may expose sensitive configuration data including tenant settings, JWT configuration, SMTP credentials, and user information. Avoid logging or exposing sensitive variables in custom themes.
+Template variables have access to sensitive configuration data including tenant settings, JWT configuration, SMTP credentials, and user information. Avoid logging or exposing sensitive variables in custom themes.
 </Aside>
 
 {/*  don't update these variables directly. */}


### PR DESCRIPTION
FreeMarker themed template data model exposes ssoCookie, HTTPContext, and framework internals to unauthenticated visitors

- [ENG-4659](https://linear.app/fusionauth/issue/ENG-4659/improve-documentation-freemarker-themed-template-data-model-exposes)
