### PR TITLE
Update the documention related to FusionAuth Cloud specific proxy requirements

### DIFF
--- a/astro/src/content/docs/get-started/run-in-the-cloud/cloud.mdx
+++ b/astro/src/content/docs/get-started/run-in-the-cloud/cloud.mdx
@@ -581,11 +581,11 @@ You may notice FusionAuth Cloud now supports a `[uuid].durable.fusionauth.io` CN
 
 If you are using a proxy in front of your FusionAuth Cloud instance, there are a few requirements to be aware of.
 
-The latest FusionAuth Cloud instances use [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to negotiate TLS connections. Ensure your proxy supports SNI.
+The latest FusionAuth Cloud instances use [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to negotiate TLS connections. Ensure your proxy supports SNI for its connection back to your FusionAuth Cloud deployment.
 
 In order for FusionAuth to provision TLS certificates for your custom domains, your proxy must handle ACM HTTP validation requests made over port 80. Configure a redirect rule so that an HTTP request with a path matching `^/\.well-known/pki-validation/[0-9a-f]{32}\.txt$` is redirected to `https://validation.us-east-1.acm-validations.aws/121700706967/` with the original request path appended.
 
-For example, a request to:
+For example, if your custom domain is `auth.example.com`, a request to:
 
 ```
 http://auth.example.com/.well-known/pki-validation/abc123def456abc123def456abc123de.txt

--- a/astro/src/content/docs/get-started/run-in-the-cloud/cloud.mdx
+++ b/astro/src/content/docs/get-started/run-in-the-cloud/cloud.mdx
@@ -577,6 +577,30 @@ You may notice FusionAuth Cloud now supports a `[uuid].durable.fusionauth.io` CN
 
 `auth.piedpiper.com CNAME [uuid].durable.fusionauth.io`
 
+## Using a Proxy with FusionAuth Cloud
+
+If you are using a proxy in front of your FusionAuth Cloud instance, there are a few requirements to be aware of.
+
+The latest FusionAuth Cloud instances use [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to negotiate TLS connections. Ensure your proxy supports SNI.
+
+In order for FusionAuth to provision TLS certificates for your custom domains, your proxy must handle ACM HTTP validation requests made over port 80. Configure a redirect rule so that an HTTP request with a path matching `^/\.well-known/pki-validation/[0-9a-f]{32}\.txt$` is redirected to `https://validation.us-east-1.acm-validations.aws/121700706967/` with the original request path appended.
+
+For example, a request to:
+
+```
+http://auth.example.com/.well-known/pki-validation/abc123def456abc123def456abc123de.txt
+```
+
+should be redirected to:
+
+```
+https://validation.us-east-1.acm-validations.aws/121700706967/.well-known/pki-validation/abc123def456abc123def456abc123de.txt
+```
+
+Additionally, ensure you have configured DDoS and other protections correctly. FusionAuth Cloud's built-in protection depends in part on receiving correct client IP addresses; a proxy may mask or modify those addresses and render this protection less effective.
+
+For general proxy configuration, including required headers, see the [FusionAuth and Proxies](/docs/operate/deploy/proxy-setup) documentation.
+
 ## Accessing User Data
 
 If you need to export user data from FusionAuth Cloud, because you are migrating away from FusionAuth or setting up a production instance in your data center, open a [support ticket](https://account.fusionauth.io/account/support/). Your data is yours!

--- a/astro/src/content/docs/operate/deploy/proxy-setup.mdx
+++ b/astro/src/content/docs/operate/deploy/proxy-setup.mdx
@@ -164,16 +164,11 @@ If you are self-hosting, you can also proxy requests *from* FusionAuth, such as 
 
 ## FusionAuth Cloud Instances
 
-The latest FusionAuth Cloud Instances will use [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to negotiate a TLS connection. If you are using a proxy in front of your FusionAuth instance, ensure it supports the use of SNI for TLS connections.
-
-Additionally, in order for FusionAuth to provision TLS certificates for your custom domains, you must ensure HTTP port 80 traffic is allowed to pass through to the FusionAuth server. These requests will only be used to validate the certificate, and all other requests will be redirected to HTTPS on port 443.
+If you are using a proxy with a FusionAuth Cloud instance, see our [Using a Proxy with FusionAuth Cloud](/docs/get-started/run-in-the-cloud/cloud#using-a-proxy-with-fusionauth-cloud) documentation for more Cloud-specific requirements.
 
 ## Limits
 
 There are no limits on using a proxy with FusionAuth.
 
 You can use a proxy with self-hosted FusionAuth or with FusionAuth Cloud.
-
-When using a proxy with FusionAuth Cloud, ensure you have configured DDOS and other protections correctly at the proxy.
-FusionAuth Cloud's built-in protection depends, in part, on receiving correct client IP addresses, but a proxy may mask or modify those and render this protection less effective.
 


### PR DESCRIPTION
### Changes Made: 

Moved FusionAuth Cloud specific proxy requirements to the FusionAuth Cloud page. Linked the two pages together to help users navigate between the two. Added some copy around needing to add a redirect rule if using a proxy with FusionAuth Cloud. 

### Screens: 

#### New section in FusionAuth Cloud docs:

<img width="1607" height="819" alt="Screenshot 2026-07-09 at 1 58 29 PM" src="https://github.com/user-attachments/assets/44adb179-6dd1-4a08-961f-8767045d71d0" />


#### Updated copy in Proxy docs:

<img width="1108" height="173" alt="Screenshot 2026-07-09 at 1 58 49 PM" src="https://github.com/user-attachments/assets/eb2fab1c-66bd-488f-9f1a-9a31692480ab" />

