### PR TITLE
Removes leading class that led to bad spacing

### DIFF
--- a/astro/src/layouts/Blog.astro
+++ b/astro/src/layouts/Blog.astro
@@ -109,7 +109,7 @@ const markdownStyles = [
           </a>
         )}
       </ul>
-      <h1 class="capitalize font-extrabold leading-10 mb-3 text-3xl text-white lg:text-4xl xl:text-4xl 2xl:text-5xl">
+      <h1 class="capitalize font-extrabold mb-3 text-3xl text-white lg:text-4xl xl:text-4xl 2xl:text-5xl">
         { title }
       </h1>
       <p class="font-normal leading-5 mb-1 text-slate-400">


### PR DESCRIPTION
Old:
<img width="776" height="408" alt="image" src="https://github.com/user-attachments/assets/3fda8a6a-0a34-4c70-a862-5788dfa93bb9" />

New
<img width="783" height="429" alt="image" src="https://github.com/user-attachments/assets/5462ad85-3c34-46d8-bfe4-e732274b28b6" />

