### PR TITLE
ENG-4760: Add documentation around iss param in authorization responses RFC-9207

### DIFF
--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -165,6 +165,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -180,6 +183,9 @@
 			"integrity": "sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -197,6 +203,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -212,6 +221,9 @@
 			"integrity": "sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -531,6 +543,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -543,6 +558,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"musl"
+			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -554,6 +572,9 @@
 			"integrity": "sha512-T4gxhXve3zyNAZesrXAd/rDZOGRkbfFIUFld4TGsw6BsjoIteCcDji6IMqeXyaWEVSykY2X8Eid2hr6aXGYAaw==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"optional": true,
 			"os": [
@@ -1213,6 +1234,9 @@
 			"cpu": [
 				"arm"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1228,6 +1252,9 @@
 			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1245,6 +1272,9 @@
 			"cpu": [
 				"ppc64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1260,6 +1290,9 @@
 			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
 			"cpu": [
 				"riscv64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1277,6 +1310,9 @@
 			"cpu": [
 				"s390x"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1292,6 +1328,9 @@
 			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1309,6 +1348,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1325,6 +1367,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1340,6 +1385,9 @@
 			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
 			"cpu": [
 				"arm"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1363,6 +1411,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1384,6 +1435,9 @@
 			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
 			"cpu": [
 				"ppc64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1407,6 +1461,9 @@
 			"cpu": [
 				"riscv64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1428,6 +1485,9 @@
 			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
 			"cpu": [
 				"s390x"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1451,6 +1511,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1473,6 +1536,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1494,6 +1560,9 @@
 			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2155,6 +2224,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2170,6 +2242,9 @@
 			"integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2187,6 +2262,9 @@
 			"cpu": [
 				"ppc64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2202,6 +2280,9 @@
 			"integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
 			"cpu": [
 				"s390x"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2219,6 +2300,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2234,6 +2318,9 @@
 			"integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2677,6 +2764,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2692,6 +2782,9 @@
 			"integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2709,6 +2802,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2724,6 +2820,9 @@
 			"integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3988,6 +4087,9 @@
 			"integrity": "sha512-MR1Q+wMx65FQlbSV7cRqWW87Knp0zkoaIV55Dt+xZl028wJABXEPEEmG3670SLq7lVZvcGIDwCgSg2kCYxvRwA==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"optional": true,
 			"os": [
@@ -7748,6 +7850,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7767,6 +7872,9 @@
 			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,
@@ -7788,6 +7896,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7807,6 +7918,9 @@
 			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,

--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -165,9 +165,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -183,9 +180,6 @@
 			"integrity": "sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -203,9 +197,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -221,9 +212,6 @@
 			"integrity": "sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -543,9 +531,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -558,9 +543,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -572,9 +554,6 @@
 			"integrity": "sha512-T4gxhXve3zyNAZesrXAd/rDZOGRkbfFIUFld4TGsw6BsjoIteCcDji6IMqeXyaWEVSykY2X8Eid2hr6aXGYAaw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"optional": true,
 			"os": [
@@ -1234,9 +1213,6 @@
 			"cpu": [
 				"arm"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1252,9 +1228,6 @@
 			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1272,9 +1245,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1290,9 +1260,6 @@
 			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
 			"cpu": [
 				"riscv64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1310,9 +1277,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1328,9 +1292,6 @@
 			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1348,9 +1309,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1367,9 +1325,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1385,9 +1340,6 @@
 			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
 			"cpu": [
 				"arm"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1411,9 +1363,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1435,9 +1384,6 @@
 			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
 			"cpu": [
 				"ppc64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1461,9 +1407,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1485,9 +1428,6 @@
 			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1511,9 +1451,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1536,9 +1473,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1560,9 +1494,6 @@
 			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2224,9 +2155,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2242,9 +2170,6 @@
 			"integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2262,9 +2187,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2280,9 +2202,6 @@
 			"integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2300,9 +2219,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2318,9 +2234,6 @@
 			"integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2764,9 +2677,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2782,9 +2692,6 @@
 			"integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2802,9 +2709,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2820,9 +2724,6 @@
 			"integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -4087,9 +3988,6 @@
 			"integrity": "sha512-MR1Q+wMx65FQlbSV7cRqWW87Knp0zkoaIV55Dt+xZl028wJABXEPEEmG3670SLq7lVZvcGIDwCgSg2kCYxvRwA==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"optional": true,
 			"os": [
@@ -7850,9 +7748,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7872,9 +7767,6 @@
 			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,
@@ -7896,9 +7788,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7918,9 +7807,6 @@
 			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,

--- a/astro/src/content/docs/_shared/_oauth-authorize-redirect-parameters.mdx
+++ b/astro/src/content/docs/_shared/_oauth-authorize-redirect-parameters.mdx
@@ -1,8 +1,16 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import AvailableSince from 'src/components/api/AvailableSince.astro';
 
 <APIBlock>
   <APIField name="code" type="String" required>The authorization code.</APIField>
+  <APIField name="iss" type="String" optional>
+    The authorization server's issuer identifier as defined by [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207). This value is the tenant's configured issuer and should be validated by the client against the authorization server metadata to prevent mix-up attacks.
+
+    See [Issuer Validation](/docs/lifecycle/authenticate-users/oauth/issuer-validation) for implementation guidance.
+
+    <AvailableSince since="1.69.0" />
+  </APIField>
   <APIField name="locale" type="String" optional>
     The [locale](/docs/reference/data-types#locales) that was to render the login page, or a previously selected locale by the user during a previous session. This may be useful to know in your own application so you can continue to localize the interface for the language the user selected while on the FusionAuth login page. See the [Theme Localization](/docs/customize/look-and-feel/localization) documentation for more information.
   </APIField>

--- a/astro/src/content/docs/apis/hosted-backend.mdx
+++ b/astro/src/content/docs/apis/hosted-backend.mdx
@@ -156,7 +156,7 @@ This endpoint is documented for educational purposes only.
 
 ### Request
 
-<API method="GET" uri="/app/callback?code={code}&locale={locale}&state={state}&userState={userState}&client_id={client_id}&tenantId={tenantId}" authentication={["none"]} title="Receive the callback from the authorization flow"/>
+<API method="GET" uri="/app/callback?code={code}&iss={iss}&locale={locale}&state={state}&userState={userState}&client_id={client_id}&tenantId={tenantId}" authentication={["none"]} title="Receive the callback from the authorization flow"/>
 
 #### Request Parameters
 
@@ -173,7 +173,7 @@ This endpoint is documented for educational purposes only.
 
 Example Request URL
 ```
-https://auth.example.com/app/callback?code=wJfjafZLvo_KH5-D4r-3YwMmStN3yHoZDGmBivjioz0&locale=en&state=eyJjIjoiODVhMDM4NjctZGNjZi00ODgyLWFkZGUtMWE3&userState=Authenticated&client_id=297ca84b-69a9-4508-8649-97644e1d0b3d&tenantId=e707be45-afa8-4881-9efb-4be7288395d2
+https://auth.example.com/app/callback?code=wJfjafZLvo_KH5-D4r-3YwMmStN3yHoZDGmBivjioz0&iss=https%3A%2F%2Fauth.example.com&locale=en&state=eyJjIjoiODVhMDM4NjctZGNjZi00ODgyLWFkZGUtMWE3&userState=Authenticated&client_id=297ca84b-69a9-4508-8649-97644e1d0b3d&tenantId=e707be45-afa8-4881-9efb-4be7288395d2
 ```
 
 ### Response

--- a/astro/src/content/docs/apis/oauth/authorize.mdx
+++ b/astro/src/content/docs/apis/oauth/authorize.mdx
@@ -127,7 +127,7 @@ To begin the Authorization Code Grant you will redirect to the Authorization end
 
     In general, you only need to provide this parameter when you wish to use the `form_post` response mode.
 
-    See [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes) for more detail on each mode and when to use them.
+    See [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes) for more detail on each mode, default values, and when each `response_mode` is appropriate.
   </APIField>
   <APIField name="response_type" type="String" required>
     The requested response type.
@@ -269,7 +269,7 @@ To begin the Implicit Grant you will redirect to the Authorization endpoint from
 
     In general, you only need to provide this parameter when you wish to use the `form_post` response mode.
 
-    See [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes) for more detail on each mode and when to use them.
+    See [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes) for more detail on each mode, default values, and when each `response_mode` is appropriate.
   </APIField>
   <APIField name="response_type" type="String" required>
     The requested response type, this value determines which tokens will be returned in the redirect URL.
@@ -353,7 +353,7 @@ Location: https://piedpiper.com/callback#
     See the [OAuth Tokens](/docs/lifecycle/authenticate-users/oauth/tokens#id-token) documentation for more information.
   </APIField>
   <APIField name="iss" type="String" since="1.69.0">
-    The authorization server's issuer identifier as defined by [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207). This value is the tenant's configured issuer and should be validated by the client against the authorization server metadata to prevent mix-up attacks.
+    The authorization server's issuer identifier as defined by [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207). This value is typically the tenant's configured issuer and should be validated by the client against the authorization server metadata to prevent mix-up attacks.
 
     See [Issuer Validation](/docs/lifecycle/authenticate-users/oauth/issuer-validation) for implementation guidance.
   </APIField>

--- a/astro/src/content/docs/apis/oauth/authorize.mdx
+++ b/astro/src/content/docs/apis/oauth/authorize.mdx
@@ -127,7 +127,7 @@ To begin the Authorization Code Grant you will redirect to the Authorization end
 
     In general, you only need to provide this parameter when you wish to use the `form_post` response mode.
 
-    See [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes) for more detail on each mode, default values, and when each `response_mode` is appropriate.
+    For more detail on each mode, default values, and when each `response_mode` is appropriate, see [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes).
   </APIField>
   <APIField name="response_type" type="String" required>
     The requested response type.

--- a/astro/src/content/docs/apis/oauth/authorize.mdx
+++ b/astro/src/content/docs/apis/oauth/authorize.mdx
@@ -126,6 +126,8 @@ To begin the Authorization Code Grant you will redirect to the Authorization end
     * `query` - This response mode can only be used when the **response_type** is set to `code`.
 
     In general, you only need to provide this parameter when you wish to use the `form_post` response mode.
+
+    See [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes) for more detail on each mode and when to use them.
   </APIField>
   <APIField name="response_type" type="String" required>
     The requested response type.
@@ -175,6 +177,7 @@ The following is an example HTTP 302 redirect, line breaks added to improve read
 HTTP/1.1 302 Found
 Location: https://piedpiper.com/callback?
            code=pU2DHOWjSCVh6NJKi1ClhBYNKfuqbZVT
+           &iss=https%3A%2F%2Fpiedpiper.fusionauth.io
            &locale=fr
            &state=abc123
            &userState=Authenticated
@@ -265,6 +268,8 @@ To begin the Implicit Grant you will redirect to the Authorization endpoint from
     * `query` - This response mode can only be used when the **response_type** is set to `code`.
 
     In general, you only need to provide this parameter when you wish to use the `form_post` response mode.
+
+    See [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes) for more detail on each mode and when to use them.
   </APIField>
   <APIField name="response_type" type="String" required>
     The requested response type, this value determines which tokens will be returned in the redirect URL.
@@ -321,6 +326,7 @@ Location: https://piedpiper.com/callback#
            access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODUxNDA5ODQsImlhdCI6MTQ4NTEzNzM4NCwiaXNzIjoiYWNtZS5jb20iLCJzdWIiOiIyOWFjMGMxOC0wYjRhLTQyY2YtODJmYy0wM2Q1NzAzMThhMWQiLCJhcHBsaWNhdGlvbklkIjoiNzkxMDM3MzQtOTdhYi00ZDFhLWFmMzctZTAwNmQwNWQyOTUyIiwicm9sZXMiOltdfQ.Mp0Pcwsz5VECK11Kf2ZZNF_SMKu5CgBeLN9ZOP04kZo
            &expires_in=3599
            &id_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODUxNDA5ODQsImlhdCI6MTQ4NTEzNzM4NCwiaXNzIjoiYWNtZS5jb20iLCJzdWIiOiIyOWFjMGMxOC0wYjRhLTQyY2YtODJmYy0wM2Q1NzAzMThhMWQiLCJhcHBsaWNhdGlvbklkIjoiNzkxMDM3MzQtOTdhYi00ZDFhLWFmMzctZTAwNmQwNWQyOTUyIiwicm9sZXMiOltdfQ.Mp0Pcwsz5VECK11Kf2ZZNF_SMKu5CgBeLN9ZOP04kZo
+           &iss=https%3A%2F%2Fpiedpiper.fusionauth.io
            &locale=fr
            &scope=openid
            &state=abc123
@@ -345,6 +351,11 @@ Location: https://piedpiper.com/callback#
     This token is represented as a JSON Web Token (JWT).
     This request parameter will be omitted if an id token was not requested in the **response_type** request parameter.
     See the [OAuth Tokens](/docs/lifecycle/authenticate-users/oauth/tokens#id-token) documentation for more information.
+  </APIField>
+  <APIField name="iss" type="String" since="1.69.0">
+    The authorization server's issuer identifier as defined by [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207). This value is the tenant's configured issuer and should be validated by the client against the authorization server metadata to prevent mix-up attacks.
+
+    See [Issuer Validation](/docs/lifecycle/authenticate-users/oauth/issuer-validation) for implementation guidance.
   </APIField>
   <APIField name="locale" type="String">
     The [locale](/docs/reference/data-types#locales) that was used to render the login page, or a previously selected locale by the user during a previous session.

--- a/astro/src/content/docs/apis/oauth/index.mdx
+++ b/astro/src/content/docs/apis/oauth/index.mdx
@@ -8,9 +8,10 @@ import Aside from 'src/components/Aside.astro';
 We provide these endpoints to support the following standards:
 
 * [OAuth 2.0 IETF RFC 6749](https://tools.ietf.org/html/rfc6749)
-* [OAuth 2.0 IETF RFC 8628](https://tools.ietf.org/html/rfc8628)
-* [JWK IETF RFC 7517](https://tools.ietf.org/html/rfc7517)
 * [OAuth 2.0 IETF RFC 7662](https://tools.ietf.org/html/rfc7662)
+* [JWK IETF RFC 7517](https://tools.ietf.org/html/rfc7517)
+* [OAuth 2.0 IETF RFC 8628](https://tools.ietf.org/html/rfc8628)
+* [OAuth 2.0 IETF RFC 9207](https://www.rfc-editor.org/rfc/rfc9207)
 * [OpenID Connect](http://openid.net/specs/openid-connect-core-1_0.html)
 
 <Aside type="note">

--- a/astro/src/content/docs/apis/oauth/oauth-error.mdx
+++ b/astro/src/content/docs/apis/oauth/oauth-error.mdx
@@ -28,6 +28,7 @@ Location: https://piedpiper.com/callback?
            error=unsupported_response_type
            &error_reason=invalid_response_type
            &error_description=Parameter+response_type+must+be+set+to+code+or+token.
+           &iss=https%3A%2F%2Fpiedpiper.fusionauth.io
            &state=bEF7UItzlhNvE31Rf0_axShomu_vU30tMeJcqMZ9LfA0
 ```
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/index.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/index.mdx
@@ -17,7 +17,7 @@ import ClientCredentialsScopesSingleEntity from 'src/content/docs/lifecycle/auth
 import ClientCredentialsScopesMultipleEntities from 'src/content/docs/lifecycle/authenticate-users/oauth/_client_credentials_scopes_multiple_entities.mdx';
 import { YouTube } from '@astro-community/astro-embed-youtube';
 
-FusionAuth supports the following grant types as defined by the OAuth 2.0 framework in [RFC 6749](https://tools.ietf.org/html/rfc6749), [RFC 8628](https://tools.ietf.org/html/rfc8628), and [OpenID Connect Core](https://openid.net/specs/openid-connect-core-1_0.html).
+FusionAuth supports the following grant types as defined by the OAuth 2.0 framework in [RFC 6749](https://tools.ietf.org/html/rfc6749), [RFC 8628](https://tools.ietf.org/html/rfc8628), [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207), and [OpenID Connect Core](https://openid.net/specs/openid-connect-core-1_0.html).
 
 * Authorization Code Grant
 * Implicit Grant
@@ -40,6 +40,8 @@ It is recommended to utilize the Authorization Code Grant unless you have a tech
 * [Example Device Authorization Grant](/docs/lifecycle/authenticate-users/oauth/#example-device-authorization-grant)
 
 You can also learn about [OAuth Modes](/docs/lifecycle/authenticate-users/oauth/modes), which are different methods of using OAuth that are higher level than the individual grants.
+
+You can also learn about [Response Modes](/docs/lifecycle/authenticate-users/oauth/response-modes), which control how authorization response parameters are delivered to the client (`query`, `fragment`, or `form_post`).
 
 ## Configure Application OAuth Settings
 
@@ -146,7 +148,7 @@ When the authorize request completes successfully it will respond with a status 
 Review the [Token](/docs/apis/oauth/token) endpoint documentation for more detail. The following is an example redirect URI containing the authorization code.
 
 ```
-https://www.piedpiper.com/login?code=+WYT3XemV4f81ghHi4V+RyNwvATDaD4FIj0BpfFC4Wzg=&userState=Authenticated
+https://www.piedpiper.com/login?code=+WYT3XemV4f81ghHi4V+RyNwvATDaD4FIj0BpfFC4Wzg=&iss=https%3A%2F%2Fpiedpiper.fusionauth.io&userState=Authenticated
 ```
 
 ### Exchange the authorization code for an access token
@@ -252,6 +254,7 @@ HTTP/1.1 302 Found
 Location: https://piedpiper.com/callback#
            access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0ODUxNDA5ODQsImlhdCI6MTQ4NTEzNzM4NCwiaXNzIjoiYWNtZS5jb20iLCJzdWIiOiIyOWFjMGMxOC0wYjRhLTQyY2YtODJmYy0wM2Q1NzAzMThhMWQiLCJhcHBsaWNhdGlvbklkIjoiNzkxMDM3MzQtOTdhYi00ZDFhLWFmMzctZTAwNmQwNWQyOTUyIiwicm9sZXMiOltdfQ.Mp0Pcwsz5VECK11Kf2ZZNF_SMKu5CgBeLN9ZOP04kZo
            &expires_in=3599
+           &iss=https%3A%2F%2Fpiedpiper.fusionauth.io
            &locale=fr
            &token_type=Bearer
            &userState=Authenticated

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
@@ -59,8 +59,8 @@ If you are using multiple authorization servers or identity providers, this chec
 
 RFC 9207 recommends that clients always validate the `iss` parameter when it is present. This is particularly important when:
 
-- Your application interacts with multiple authorization servers or identity providers.
-- You are building a multi-tenant application where each tenant may use a different issuer.
-- You want defense-in-depth against authorization response manipulation.
+* Your application interacts with multiple authorization servers or identity providers.
+* You are building a multi-tenant application where each tenant may use a different issuer.
+* You want defense-in-depth against authorization response manipulation.
 
 Even when interacting with a single authorization server, validating the `iss` parameter is a low-cost security measure that protects against future configuration changes or attacks.

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
@@ -32,9 +32,9 @@ Clients should validate the `iss` parameter by comparing it against the authoriz
 ### Validation Steps
 
 1. Before initiating the authorization request, retrieve or cache the authorization server metadata from the `/.well-known/openid-configuration` endpoint.
-2. When the authorization response is received (at your redirect URI), extract the `iss` parameter.
-3. Compare the `iss` value from the response to the `issuer` value from the authorization server metadata using exact string comparison.
-4. If the values do not match, reject the response and do not proceed with the token exchange.
+1. When the authorization response is received (at your redirect URI), extract the `iss` parameter.
+1. Compare the `iss` value from the response to the `issuer` value from the authorization server metadata using exact string comparison.
+1. If the values do not match, reject the response and do not proceed with the token exchange.
 
 ### Example
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
@@ -22,7 +22,7 @@ FusionAuth returns the `iss` parameter on all successful responses from the `/oa
 The value of the `iss` parameter is the issuer configured on the tenant. This value is treated as an opaque string for comparison purposes.
 
 <Aside type="caution">
-  To be spec-compliant with [RFC 9207 Section 2](https://www.rfc-editor.org/rfc/rfc9207#section-2), the issuer value must be a URL that uses the `https` scheme with no query or fragment components. If you intend to validate the `iss` parameter, configure your tenant issuer accordingly (e.g. `https://auth.example.com`).
+  To be compliant with [RFC 9207 Section 2](https://www.rfc-editor.org/rfc/rfc9207#section-2), the issuer value must be a URL that uses the `https` scheme with no query or fragment components. If you intend to validate the `iss` parameter, configure your tenant issuer accordingly (e.g. `https://auth.example.com`).
 </Aside>
 
 ## Validating the Issuer

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
@@ -1,0 +1,66 @@
+---
+title: OAuth Issuer Validation
+description: Learn how to validate the authorization response issuer parameter (RFC 9207) to prevent mix-up attacks.
+tags: oauth, issuer, rfc 9207, mix-up attack
+---
+import Aside from 'src/components/Aside.astro';
+
+<Aside type="version">
+  Available since `1.69.0`
+</Aside>
+
+FusionAuth includes the `iss` parameter in authorization responses as defined by [RFC 9207 - OAuth 2.0 Authorization Server Issuer Identification](https://www.rfc-editor.org/rfc/rfc9207). This parameter helps clients prevent mix-up attacks when interacting with multiple authorization servers.
+
+## Overview
+
+A mix-up attack occurs when a malicious authorization server tricks a client into sending an authorization code or tokens to the wrong endpoint. By including the `iss` parameter in every authorization response, the client can verify that the response came from the expected authorization server before proceeding with the token exchange.
+
+FusionAuth returns the `iss` parameter on all successful responses from the `/oauth2/authorize` endpoint, including both the Authorization Code Grant and Implicit Grant flows.
+
+## The Issuer Value
+
+The value of the `iss` parameter is the issuer configured on the tenant. This value is treated as an opaque string for comparison purposes.
+
+<Aside type="caution">
+  To be spec-compliant with [RFC 9207 Section 2](https://www.rfc-editor.org/rfc/rfc9207#section-2), the issuer value must be a URL that uses the `https` scheme with no query or fragment components. If you intend to validate the `iss` parameter, configure your tenant issuer accordingly (e.g. `https://auth.example.com`).
+</Aside>
+
+## Validating the Issuer
+
+Clients should validate the `iss` parameter by comparing it against the authorization server's metadata. The expected issuer value can be obtained from the [OpenID Connect Discovery](/docs/apis/oauth#openid-configuration) endpoint at `/.well-known/openid-configuration` in the `issuer` field.
+
+### Validation Steps
+
+1. Before initiating the authorization request, retrieve or cache the authorization server metadata from the `/.well-known/openid-configuration` endpoint.
+2. When the authorization response is received (at your redirect URI), extract the `iss` parameter.
+3. Compare the `iss` value from the response to the `issuer` value from the authorization server metadata using exact string comparison.
+4. If the values do not match, reject the response and do not proceed with the token exchange.
+
+### Example
+
+After a successful authorization code grant, the redirect to your application will include the `iss` parameter:
+
+```plaintext
+GET /callback?code=pU2DHOWjSCVh6NJKi1ClhBYNKfuqbZVT
+              &iss=https%3A%2F%2Fauth.example.com
+              &state=abc123
+```
+
+Your client should then verify:
+
+```
+iss == metadata.issuer
+"https://auth.example.com" == "https://auth.example.com"  ✓
+```
+
+If you are using multiple authorization servers or identity providers, this check ensures the response originated from the server you expected.
+
+## When To Validate
+
+RFC 9207 recommends that clients always validate the `iss` parameter when it is present. This is particularly important when:
+
+- Your application interacts with multiple authorization servers or identity providers.
+- You are building a multi-tenant application where each tenant may use a different issuer.
+- You want defense-in-depth against authorization response manipulation.
+
+Even when interacting with a single authorization server, validating the `iss` parameter is a low-cost security measure that protects against future configuration changes or attacks.

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/issuer-validation.mdx
@@ -53,7 +53,7 @@ iss == metadata.issuer
 "https://auth.example.com" == "https://auth.example.com"  ✓
 ```
 
-If you are using multiple authorization servers or identity providers, this check ensures the response originated from the server you expected.
+If you are using multiple authorization servers or identity providers, this check ensures the response originated from the authorization server from which the client expected to receive it.
 
 ## When To Validate
 

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
@@ -56,7 +56,7 @@ This mode is the default for the Implicit Grant. Fragment values are not sent to
 
 ## Form Post
 
-When `response_mode=form_post`, the authorization server returns an HTML document containing a form with the response parameters as hidden fields. The form auto-submits via a POST request to the redirect URI.
+When `response_mode=form_post`, the authorization server returns an HTML document containing a form with the response parameters as hidden fields. The form auto-submits via a POST request to the redirect URI:
 
 ```plaintext
 HTTP/1.1 200 OK

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
@@ -1,0 +1,90 @@
+---
+title: OAuth Response Modes
+description: Learn about OAuth 2.0 response modes (query, fragment, form_post) and when to use each one.
+tags: oauth, response mode, form_post, fragment, query
+---
+import Aside from 'src/components/Aside.astro';
+
+The `response_mode` parameter controls how the authorization server delivers response parameters back to the client after an authorization request. FusionAuth supports three response modes: `query`, `fragment`, and `form_post`.
+
+## Default Behavior
+
+When the `response_mode` parameter is not provided on the authorization request, FusionAuth selects a default based on the `response_type`:
+
+| response_type              | Default response_mode |
+|----------------------------|-----------------------|
+| `code`                     | `query`               |
+| `token`                    | `fragment`            |
+| `token id_token`           | `fragment`            |
+| `id_token`                 | `fragment`            |
+
+These defaults align with the OAuth 2.0 and OpenID Connect specifications. In most cases, you only need to explicitly set `response_mode` when you want to use `form_post`.
+
+## Query
+
+When `response_mode=query`, the response parameters are appended to the redirect URI as query string parameters.
+
+```plaintext
+HTTP/1.1 302 Found
+Location: https://app.example.com/callback?
+           code=pU2DHOWjSCVh6NJKi1ClhBYNKfuqbZVT
+           &iss=https%3A%2F%2Fauth.example.com
+           &state=abc123
+```
+
+This mode is the default for the Authorization Code Grant. It is appropriate here because the authorization code is short-lived and single-use, limiting the risk of exposure through browser history or referrer headers.
+
+<Aside type="caution">
+  The `query` response mode can only be used when `response_type` is set to `code`. Using it with token-bearing response types (`token`, `id_token`) would expose sensitive credentials in the URL, which is logged by browsers, proxies, and web servers.
+</Aside>
+
+## Fragment
+
+When `response_mode=fragment`, the response parameters are appended to the redirect URI after the `#` fragment delimiter.
+
+```plaintext
+HTTP/1.1 302 Found
+Location: https://app.example.com/callback#
+           access_token=eyJhbGciOiJSUzI1NiIs...
+           &iss=https%3A%2F%2Fauth.example.com
+           &token_type=Bearer
+           &expires_in=3599
+           &state=abc123
+```
+
+This mode is the default for the Implicit Grant. Fragment values are not sent to the server in HTTP requests, which means the tokens are only accessible to client-side JavaScript running in the browser. This provides a layer of protection against tokens leaking to intermediaries.
+
+## Form Post
+
+When `response_mode=form_post`, the authorization server returns an HTML document containing a form with the response parameters as hidden fields. The form auto-submits via a POST request to the redirect URI.
+
+```plaintext
+HTTP/1.1 200 OK
+Content-Type: text/html
+
+<html>
+<body onload="document.forms[0].submit()">
+  <form method="post" action="https://app.example.com/callback">
+    <input type="hidden" name="code" value="pU2DHOWjSCVh6NJKi1ClhBYNKfuqbZVT"/>
+    <input type="hidden" name="iss" value="https://auth.example.com"/>
+    <input type="hidden" name="state" value="abc123"/>
+  </form>
+</body>
+</html>
+```
+
+The client receives the parameters in the POST request body rather than in the URL.
+
+### When to Use Form Post
+
+The `form_post` response mode is useful when:
+
+- **Avoiding URL exposure** — Response parameters are delivered in the request body, keeping them out of browser history, referrer headers, and server access logs. This is particularly valuable when the response includes an `id_token` (which may contain user claims).
+- **Server-side processing** — Your redirect endpoint is a traditional server-side handler that processes POST requests. The parameters arrive as standard form-encoded fields, which eliminates the need for client-side JavaScript to parse fragments.
+- **Authorization Code Grant with additional security** — While the authorization code is already short-lived, `form_post` prevents the code from appearing in the URL entirely. This reduces the attack surface in environments with aggressive URL logging or caching.
+
+### Considerations
+
+- The client's redirect URI must accept POST requests when using `form_post`. If your endpoint only handles GET requests, the form submission will fail.
+- The `form_post` mode is defined in the [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html) specification.
+- This mode works with both the Authorization Code Grant (`response_type=code`) and the Implicit Grant (`response_type=token`, `token id_token`, or `id_token`).

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
@@ -40,7 +40,7 @@ This mode is the default for the Authorization Code Grant. It is appropriate her
 
 ## Fragment
 
-When `response_mode=fragment`, the response parameters are appended to the redirect URI after the `#` fragment delimiter.
+When `response_mode=fragment`, the response parameters are appended to the redirect URI after the `#` fragment delimiter:
 
 ```plaintext
 HTTP/1.1 302 Found

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
@@ -22,7 +22,7 @@ These defaults align with the OAuth 2.0 and OpenID Connect specifications. In mo
 
 ## Query
 
-When `response_mode=query`, the response parameters are appended to the redirect URI as query string parameters.
+When `response_mode=query`, the response parameters are appended to the redirect URI as query string parameters:
 
 ```plaintext
 HTTP/1.1 302 Found

--- a/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/oauth/response-modes.mdx
@@ -79,12 +79,12 @@ The client receives the parameters in the POST request body rather than in the U
 
 The `form_post` response mode is useful when:
 
-- **Avoiding URL exposure** — Response parameters are delivered in the request body, keeping them out of browser history, referrer headers, and server access logs. This is particularly valuable when the response includes an `id_token` (which may contain user claims).
-- **Server-side processing** — Your redirect endpoint is a traditional server-side handler that processes POST requests. The parameters arrive as standard form-encoded fields, which eliminates the need for client-side JavaScript to parse fragments.
-- **Authorization Code Grant with additional security** — While the authorization code is already short-lived, `form_post` prevents the code from appearing in the URL entirely. This reduces the attack surface in environments with aggressive URL logging or caching.
+* **Avoiding URL exposure** — Response parameters are delivered in the request body, keeping them out of browser history, referrer headers, and server access logs. This is particularly valuable when the response includes an `id_token` (which may contain user claims).
+* **Server-side processing** — Your redirect endpoint is a traditional server-side handler that processes POST requests. The parameters arrive as standard form-encoded fields, which eliminates the need for client-side JavaScript to parse fragments.
+* **Authorization Code Grant with additional security** — While the authorization code is already short-lived, `form_post` prevents the code from appearing in the URL entirely. This reduces the attack surface in environments with aggressive URL logging or caching.
 
 ### Considerations
 
-- The client's redirect URI must accept POST requests when using `form_post`. If your endpoint only handles GET requests, the form submission will fail.
-- The `form_post` mode is defined in the [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html) specification.
-- This mode works with both the Authorization Code Grant (`response_type=code`) and the Implicit Grant (`response_type=token`, `token id_token`, or `id_token`).
+* The client's redirect URI must accept `POST` requests when using `form_post`. If your endpoint only handles `GET` requests, the form submission will fail.
+* The `form_post` mode is defined in the [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html) specification.
+* This mode works with both the Authorization Code Grant (`response_type=code`) and the Implicit Grant (`response_type=token`, `token id_token`, or `id_token`).


### PR DESCRIPTION
### Adding documentation around the implementation of  RFC-9207

- Add documentation around the `iss` parameter.
- Added a new page detailing how it can be used to prevent a mix-up attack.
- Noticed sparse documentation around the different `response_mode` values we support so I added a dedicated OAuth2 Page.

