### PR TITLE
ENG-4655: deprecated origin and rpid req params

### DIFF
--- a/astro/src/content/docs/apis/_webauthn-authenticate-complete-request-body.mdx
+++ b/astro/src/content/docs/apis/_webauthn-authenticate-complete-request-body.mdx
@@ -33,17 +33,17 @@ The **credential** in the request body contains data returned by the [WebAuthn J
     The credential type of the passkey. The only value supported by WebAuthn is `public-key`.
   </APIField>
   <APIField name="origin" type="String" optional>
-    Ignored. The origin is validated from the signed WebAuthn client data instead of this value.
+    Ignored since `1.69.0`. Instead, FusionAuth validates the origin from the signed WebAuthn client data.
 
-    <DeprecatedSince since="1.70.0">
-      Required in releases before `1.70.0`. The browser request origin during the authentication ceremony. For example, `example.com`.
+    <DeprecatedSince since="1.69.0">
+      This field is required prior to version `1.69.0`. The browser request origin during the authentication ceremony. For example, `example.com`.
     </DeprecatedSince>
   </APIField>
   <APIField name="rpId" type="String" optional>
-    Ignored. The Relying Party Id is resolved from the tenant configuration and validated against the signed authenticator data instead of this value.
+    Ignored since `1.69.0`. Instead, FusionAuth resolves the Relying Party Id from the tenant configuration and validates the Id against the signed authenticator data.
 
-    <DeprecatedSince since="1.70.0">
-      Required in releases before `1.70.0`. If the tenant configuration overrides the Relying Party Id, this parameter should match **tenant.webAuthnConfiguration.relyingPartyId**, otherwise the value should be the browser request origin's effective domain during the ceremony.
+    <DeprecatedSince since="1.69.0">
+      This field is required prior to version `1.69.0`. If the tenant configuration overrides the Relying Party Id, this parameter should match **`tenant.webAuthnConfiguration.relyingPartyId`**, otherwise the value should be the browser request origin's effective domain during the ceremony.
     </DeprecatedSince>
   </APIField>
   <APIField name="twoFactorTrustId" type="String" optional>

--- a/astro/src/content/docs/apis/_webauthn-authenticate-complete-request-body.mdx
+++ b/astro/src/content/docs/apis/_webauthn-authenticate-complete-request-body.mdx
@@ -32,18 +32,18 @@ The **credential** in the request body contains data returned by the [WebAuthn J
   <APIField name="credential.type" type="String" required>
     The credential type of the passkey. The only value supported by WebAuthn is `public-key`.
   </APIField>
-  <APIField name="origin" type="String" required deprecated>
-    The browser request origin during the authentication ceremony. For example, `example.com`.
+  <APIField name="origin" type="String" optional>
+    Ignored. The origin is validated from the signed WebAuthn client data instead of this value.
 
     <DeprecatedSince since="1.70.0">
-      Now optional and ignored. The origin is validated from the signed WebAuthn client data instead of this value.
+      Required in releases before `1.70.0`. The browser request origin during the authentication ceremony. For example, `example.com`.
     </DeprecatedSince>
   </APIField>
-  <APIField name="rpId" type="String" required deprecated>
-    If the tenant configuration overrides the Relying Party Id, this parameter should match **tenant.webAuthnConfiguration.relyingPartyId**, otherwise the value should be the browser request origin's effective domain during the ceremony.
+  <APIField name="rpId" type="String" optional>
+    Ignored. The Relying Party Id is resolved from the tenant configuration and validated against the signed authenticator data instead of this value.
 
     <DeprecatedSince since="1.70.0">
-      Now optional and ignored. The Relying Party Id is resolved from the tenant configuration and validated against the signed authenticator data instead of this value.
+      Required in releases before `1.70.0`. If the tenant configuration overrides the Relying Party Id, this parameter should match **tenant.webAuthnConfiguration.relyingPartyId**, otherwise the value should be the browser request origin's effective domain during the ceremony.
     </DeprecatedSince>
   </APIField>
   <APIField name="twoFactorTrustId" type="String" optional>

--- a/astro/src/content/docs/apis/_webauthn-authenticate-complete-request-body.mdx
+++ b/astro/src/content/docs/apis/_webauthn-authenticate-complete-request-body.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import JSON from 'src/components/JSON.astro';
 
 #### Request Body
@@ -31,11 +32,19 @@ The **credential** in the request body contains data returned by the [WebAuthn J
   <APIField name="credential.type" type="String" required>
     The credential type of the passkey. The only value supported by WebAuthn is `public-key`.
   </APIField>
-  <APIField name="origin" type="String" required>
+  <APIField name="origin" type="String" required deprecated>
     The browser request origin during the authentication ceremony. For example, `example.com`.
+
+    <DeprecatedSince since="1.70.0">
+      Now optional and ignored. The origin is validated from the signed WebAuthn client data instead of this value.
+    </DeprecatedSince>
   </APIField>
-  <APIField name="rpId" type="String" required>
+  <APIField name="rpId" type="String" required deprecated>
     If the tenant configuration overrides the Relying Party Id, this parameter should match **tenant.webAuthnConfiguration.relyingPartyId**, otherwise the value should be the browser request origin's effective domain during the ceremony.
+
+    <DeprecatedSince since="1.70.0">
+      Now optional and ignored. The Relying Party Id is resolved from the tenant configuration and validated against the signed authenticator data instead of this value.
+    </DeprecatedSince>
   </APIField>
   <APIField name="twoFactorTrustId" type="String" optional>
     The Multi-Factor Trust identifier returned by the Multi-Factor Login API response. This value may be provided to bypass the Multi-Factor challenge when a User has Multi-Factor enabled.

--- a/astro/src/content/docs/apis/_webauthn-register-complete-request-body.mdx
+++ b/astro/src/content/docs/apis/_webauthn-register-complete-request-body.mdx
@@ -1,5 +1,6 @@
 import APIBlock from 'src/components/api/APIBlock.astro';
 import APIField from 'src/components/api/APIField.astro';
+import DeprecatedSince from 'src/components/api/DeprecatedSince.astro';
 import JSON from 'src/components/JSON.astro';
 import WebauthnTransports from 'src/content/docs/apis/_webauthn-transports.mdx';
 
@@ -31,11 +32,19 @@ The **credential** in the request body contains data returned by the [WebAuthn J
   <APIField name="credential.type" type="String" required>
     The credential type of the new passkey. The only value supported by WebAuthn is `public-key`.
   </APIField>
-  <APIField name="origin" type="String" required>
+  <APIField name="origin" type="String" required deprecated>
     The browser request origin during the registration ceremony.
+
+    <DeprecatedSince since="1.70.0">
+      Now optional and ignored. The origin is validated from the signed WebAuthn client data instead of this value.
+    </DeprecatedSince>
   </APIField>
-  <APIField name="rpId" type="String" required>
+  <APIField name="rpId" type="String" required deprecated>
     If the tenant configuration overrides the Relying Party Id, this parameter should match **tenant.webAuthnConfiguration.relyingPartyId**, otherwise the value should be the browser request origin's effective domain during the ceremony.
+
+    <DeprecatedSince since="1.70.0">
+      Now optional and ignored. The Relying Party Id is resolved from the tenant configuration and validated against the signed authenticator data instead of this value.
+    </DeprecatedSince>
   </APIField>
   <APIField name="userId" type="UUID" required>
     The unique Id of the user registering this new passkey.

--- a/astro/src/content/docs/apis/_webauthn-register-complete-request-body.mdx
+++ b/astro/src/content/docs/apis/_webauthn-register-complete-request-body.mdx
@@ -33,17 +33,17 @@ The **credential** in the request body contains data returned by the [WebAuthn J
     The credential type of the new passkey. The only value supported by WebAuthn is `public-key`.
   </APIField>
   <APIField name="origin" type="String" optional>
-    Ignored. The origin is validated from the signed WebAuthn client data instead of this value.
+    Ignored since `1.69.0`. Instead, FusionAuth validates the origin from the signed WebAuthn client data.
 
-    <DeprecatedSince since="1.70.0">
-      Required in releases before `1.70.0`. The browser request origin during the registration ceremony.
+    <DeprecatedSince since="1.69.0">
+      This field is required prior to version `1.69.0`. The browser request origin during the registration ceremony.
     </DeprecatedSince>
   </APIField>
   <APIField name="rpId" type="String" optional>
-    Ignored. The Relying Party Id is resolved from the tenant configuration and validated against the signed authenticator data instead of this value.
+    Ignored since `1.69.0`. Instead, FusionAuth resolves the Relying Party Id from the tenant configuration and validates the Id against the signed authenticator data.
 
-    <DeprecatedSince since="1.70.0">
-      Required in releases before `1.70.0`. If the tenant configuration overrides the Relying Party Id, this parameter should match **tenant.webAuthnConfiguration.relyingPartyId**, otherwise the value should be the browser request origin's effective domain during the ceremony.
+    <DeprecatedSince since="1.69.0">
+      This field is required prior to version `1.69.0`. If the tenant configuration overrides the Relying Party Id, this parameter should match **`tenant.webAuthnConfiguration.relyingPartyId`**, otherwise the value should be the browser request origin's effective domain during the ceremony.
     </DeprecatedSince>
   </APIField>
   <APIField name="userId" type="UUID" required>

--- a/astro/src/content/docs/apis/_webauthn-register-complete-request-body.mdx
+++ b/astro/src/content/docs/apis/_webauthn-register-complete-request-body.mdx
@@ -32,18 +32,18 @@ The **credential** in the request body contains data returned by the [WebAuthn J
   <APIField name="credential.type" type="String" required>
     The credential type of the new passkey. The only value supported by WebAuthn is `public-key`.
   </APIField>
-  <APIField name="origin" type="String" required deprecated>
-    The browser request origin during the registration ceremony.
+  <APIField name="origin" type="String" optional>
+    Ignored. The origin is validated from the signed WebAuthn client data instead of this value.
 
     <DeprecatedSince since="1.70.0">
-      Now optional and ignored. The origin is validated from the signed WebAuthn client data instead of this value.
+      Required in releases before `1.70.0`. The browser request origin during the registration ceremony.
     </DeprecatedSince>
   </APIField>
-  <APIField name="rpId" type="String" required deprecated>
-    If the tenant configuration overrides the Relying Party Id, this parameter should match **tenant.webAuthnConfiguration.relyingPartyId**, otherwise the value should be the browser request origin's effective domain during the ceremony.
+  <APIField name="rpId" type="String" optional>
+    Ignored. The Relying Party Id is resolved from the tenant configuration and validated against the signed authenticator data instead of this value.
 
     <DeprecatedSince since="1.70.0">
-      Now optional and ignored. The Relying Party Id is resolved from the tenant configuration and validated against the signed authenticator data instead of this value.
+      Required in releases before `1.70.0`. If the tenant configuration overrides the Relying Party Id, this parameter should match **tenant.webAuthnConfiguration.relyingPartyId**, otherwise the value should be the browser request origin's effective domain during the ceremony.
     </DeprecatedSince>
   </APIField>
   <APIField name="userId" type="UUID" required>


### PR DESCRIPTION
Issue: [ENG-4655](https://linear.app/fusionauth/issue/ENG-4655/webauthn-ceremony-completion-validates-originrpid-against-request-body)

Deprecated origin and rpId parameters that are ignored now
