### PR TITLE
Add FusionAuth Cloud status link to footer

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -34,6 +34,7 @@ const { sections = [
     "items": [
       { "label": "support forum", "href": "https://fusionauth.io/community/forum/" },
       { "label": "slack community", "href": "/community" },
+      { "label": "FusionAuth Cloud status", "href": "https://status.fusionauth.io/" },
       { "label": "blog", "href": "/blog/" },
       { "label": "articles", "href": "/articles/" },
     ]


### PR DESCRIPTION
Add status.fusionauth.io link to the resources section in the footer with the label "FusionAuth Cloud status" to help users monitor cloud instance availability.