### PR TITLE
Reduce HTML page sizes

### DIFF
--- a/astro/src/components/api/APIField.astro
+++ b/astro/src/components/api/APIField.astro
@@ -40,7 +40,7 @@ if (rawSlotContent) {
   parsedMarkdownHTML = marked.parse(trimmedContent);
 }
 ---
-<div class:list={['border-t border-slate-300 dark:border-slate-800', { hidden: !renderif }]}>
+{renderif && <div class="border-t border-slate-300 dark:border-slate-800">
   <div class="flex flex-wrap items-baseline mt-6 space-x-3">
     <code class="api-field-name">{name}</code>
 
@@ -74,4 +74,4 @@ if (rawSlotContent) {
   <div class="mb-7 ml-4 text-sm font-normal">
     <div class="mb-7 ml-4 text-sm font-normal" set:html={parsedMarkdownHTML}></div>
   </div>
-</div>
+</div>}


### PR DESCRIPTION
* Actually remove element when not rendered -- we shouldn't include these tokens in every single APIField element even when we're not rendering them!