### PR TITLE
Fixes issue when there's no h2 for the built TOC

### DIFF
--- a/astro/src/components/TOC.astro
+++ b/astro/src/components/TOC.astro
@@ -17,6 +17,8 @@ function buildToc(headings: Heading[]) {
     } else {
       if (parentHeadings.get(heading.depth - 1)) {
         parentHeadings.get(heading.depth - 1).subheadings.push(heading);
+      } else {
+        toc.push(heading)
       }
     }
   });


### PR DESCRIPTION
When there was no H2, there was no level for the build-time `nestedHeadings` to anchor on. This was an edge case, but I discovered on [this page](http://localhost:3000/docs/sdks/typescript#installing)

Current state: https://fusionauth.io/docs/sdks/typescript
Test state: https://4006.18-118-165-255.sslip.io/docs/sdks/typescript