### PR TITLE
Finishes Implementation of kapaEnable option

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -3,7 +3,7 @@ import CodeCopyButton from 'src/components/CodeCopyButton.astro';
 import FusionAuthLogo from './FusionAuthLogo.astro';
 import Kapa from 'src/components/Kapa.astro';
 
-const { sections = [
+const { enableKapa, sections = [
   {
     "heading": "Get Started",
     "items": [
@@ -99,6 +99,6 @@ const { sections = [
     </div>
   </div>
 
-  <Kapa />
+  <Kapa enableKapa={enableKapa} />
   <CodeCopyButton />
 </footer>

--- a/astro/src/components/FullScreenHelp.astro
+++ b/astro/src/components/FullScreenHelp.astro
@@ -6,16 +6,6 @@
   <!-- The Kapa widget will be dynamically moved here -->
 </div>
 
-<style>
-  /* force the wrapper to take up the entire screen, sitting on top of the docs */
-  .kapa-fullscreen-wrapper {
-
-  }
-  #kapa-docs-container {
-    margin-bottom: 15rem;
-  }
-
-</style>
 
 <script is:inline>
   (function () {
@@ -27,12 +17,12 @@
         : "light";
     }
 
-    function setStyles(shadowRoot, styles) {
+    function setStyles(shadowRoot) {
       const style = document.createElement("style");
       style.innerHTML =
         `#kapa-modal-content { display: block !important; max-width: 100ch !important; margin: 0 !important; } 
         .mantine-Modal-body { justify-items: center !important; flex: auto !important;} 
-        .mantine-Modal-body .scrollable-container { min-height: 25vh !important; max-height: 35vh !important; flex: 1 1 0% !important; } 
+        .mantine-Modal-body .scrollable-container { min-height: 35vh !important; max-height: 35vh !important; flex: 1 1 0% !important; } 
         .mantine-Modal-inner { position: static !important; display: block !important; }
         .mantine-Modal-content { box-shadow: 0px 0px 3px var(--mantine-color-default-border) !important; border-radius: 8px; }
         .mantine-Modal-overlay { display: none !important;}

--- a/astro/src/components/FullScreenHelp.astro
+++ b/astro/src/components/FullScreenHelp.astro
@@ -1,5 +1,7 @@
 ---
+
 ---
+
 <div class="kapa-fullscreen-wrapper" id="kapa-docs-container">
   <!-- The Kapa widget will be dynamically moved here -->
 </div>
@@ -7,64 +9,61 @@
 <style>
   /* force the wrapper to take up the entire screen, sitting on top of the docs */
   .kapa-fullscreen-wrapper {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    z-index: 999999;
-    background-color: var(--sl-color-bg, #ffffff); 
+
+  }
+  #kapa-docs-container {
+    margin-bottom: 15rem;
   }
 
-  :global(html.dark) .kapa-fullscreen-wrapper {
-    background-color: var(--sl-color-bg, #0f172a); 
-  }
-
-  /* fill the full-screen wrapper */
-  :global(#kapa-widget-container),
-  :global(iframe[src*='kapa.ai']) {
-    position: absolute !important;
-    top: 0 !important;
-    left: 0 !important;
-    right: 0 !important;
-    bottom: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
-    max-width: 100% !important;
-    max-height: 100% !important;
-    border-radius: 0 !important;
-    box-shadow: none !important;
-  }
 </style>
 
 <script is:inline>
   (function () {
-    if (document.querySelector('script[data-kapa-main]')) return;
+    if (document.querySelector("script[data-kapa-main]")) return;
 
     function getActiveTheme() {
-      return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+      return document.documentElement.classList.contains("dark")
+        ? "dark"
+        : "light";
     }
 
-    const script = document.createElement('script');
+    function setStyles(shadowRoot, styles) {
+      const style = document.createElement("style");
+      style.innerHTML =
+        `#kapa-modal-content { display: block !important; max-width: 100ch !important; margin: 0 !important; } 
+        .mantine-Modal-body { justify-items: center !important; flex: auto !important;} 
+        .mantine-Modal-body .scrollable-container { min-height: 25vh !important; max-height: 35vh !important; flex: 1 1 0% !important; } 
+        .mantine-Modal-inner { position: static !important; display: block !important; }
+        .mantine-Modal-content { box-shadow: 0px 0px 3px var(--mantine-color-default-border) !important; border-radius: 8px; }
+        .mantine-Modal-overlay { display: none !important;}
+        .mantine-Paper-root { border-color: var(--mantine-color-gray-6); }
+        .mantine-Paper-root textarea::placeholder { color: var(--mantine-color-gray-7)}
+        `;
+      shadowRoot.appendChild(style);
+    }
+
+    const script = document.createElement("script");
     script.async = true;
-    script.src = '/js/kapa-widget.bundle.js';
-    script.id = 'kapa-widget-script'; 
+    script.src = "/js/kapa-widget.bundle.js";
+    script.id = "kapa-widget-script";
 
     const attrs = {
-      'data-website-id': '7f016d35-50d6-4a5f-9f9d-32cb4374841f',
-      'data-project-name': 'FusionAuth',
-      'data-project-color': '#0F172A',
-      'data-project-color-dark': '#334155',
-      'data-project-logo': '/img/icons/help/fa-black-logo.png',
-      'data-color-scheme': getActiveTheme(),
-      'data-user-analytics-cookie-enabled': 'false',
-      'data-user-analytics-fingerprint-enabled': 'false',
-      'data-user-satisfaction-feedback-enabled': 'false',
-      'data-modal-full-screen': 'true',
-      'data-button-hide': 'true',
-      'data-modal-open-by-default': 'true',
-      'data-launcher-button-hidden': 'true',
-      'data-modal-close-button-hidden': 'true'
+      "data-website-id": "7f016d35-50d6-4a5f-9f9d-32cb4374841f",
+      "data-project-name": "FusionAuth",
+      "data-project-color": "#0F172A",
+      "data-project-color-dark": "#334155",
+      "data-project-logo": "/img/icons/help/fa-black-logo.png",
+      "data-color-scheme": getActiveTheme(),
+      "data-user-analytics-cookie-enabled": "false",
+      "data-user-analytics-fingerprint-enabled": "false",
+      "data-user-satisfaction-feedback-enabled": "false",
+      "data-modal-full-screen": "true",
+      "data-button-hide": "true",
+      "data-modal-open-by-default": "true",
+      "data-launcher-button-hidden": "true",
+      "data-modal-close-button-hidden": "true",
+      "lock-scroll": "false",
+      "data-view-mode": "sidebar"
     };
 
     Object.entries(attrs).forEach(([key, value]) => {
@@ -74,15 +73,20 @@
     document.head.appendChild(script);
 
     const domObserver = new MutationObserver((mutations, obs) => {
-      const kapaContainer = document.getElementById('kapa-widget-container');
-      const ourWrapper = document.getElementById('kapa-docs-container');
-      
-      if (kapaContainer && ourWrapper && kapaContainer.parentElement !== ourWrapper) {
+      const kapaContainer = document.getElementById("kapa-widget-container");
+      const ourWrapper = document.getElementById("kapa-docs-container");
+
+      if (
+        kapaContainer &&
+        ourWrapper &&
+        kapaContainer.parentElement !== ourWrapper
+      ) {
         // Move the widget into the full-screen wrapper
         ourWrapper.appendChild(kapaContainer);
-        document.body.style.overflow = '';
-        obs.disconnect(); 
-        
+        setStyles(kapaContainer.shadowRoot);
+        document.body.style.overflow = "scroll";
+        obs.disconnect();
+
         // re-open window if user closes with X, outside click, or escape -- can't block those events
         setInterval(() => {
           if (window.Kapa) {

--- a/astro/src/content.config.js
+++ b/astro/src/content.config.js
@@ -69,6 +69,7 @@ const articlesCollection = defineCollection({
     order: z.number().default(1000),
     title: z.string(),
     featured: z.boolean().default(false),
+    enableKapa: z.boolean().optional(),
   }),
 });
 
@@ -98,6 +99,7 @@ const docsCollection = defineCollection({
     sideNavSimple: z.boolean().default(false),
     hideBgImage: z.boolean().optional(),
     rssUrl: z.string().optional(),
+    enableKapa: z.boolean().optional(),
   }),
 });
 
@@ -129,6 +131,7 @@ const blogCollection = defineCollection({
     excerpt_separator: z.string().optional(),
     canonicalUrl: z.string().optional(),
     blurb: z.string().optional(),
+    enableKapa: z.boolean().optional(),
   }),
 });
 

--- a/astro/src/layouts/Default.astro
+++ b/astro/src/layouts/Default.astro
@@ -15,6 +15,7 @@ interface Props {
   date?: string;
   description?: string;
   disableTOC?: boolean;
+  enableKapa?: boolean;
   frontmatter?: Record<string, any>;
   headings?: any[];
   htmlTitle?: string;
@@ -40,6 +41,7 @@ let {
   description = "Looks like the developers forgot to include a description for this page. Sorry about that.",
   disableTOC,
   frontmatter,
+  enableKapa,
   headings = [],
   htmlTitle = "",
   icon,
@@ -61,6 +63,7 @@ let {
 author = frontmatter?.author ?? author;
 date = frontmatter?.date ?? date;
 description = frontmatter?.description ?? description;
+enableKapa = frontmatter?.enableKapa ?? true;
 icon = frontmatter?.icon ?? icon;
 darkIcon = frontmatter?.darkIcon ?? darkIcon;
 image = frontmatter?.image ?? image;
@@ -270,7 +273,7 @@ const cleanedHtmlTitle = htmlTitle.replace(/[#*`_~]/g, '').replace(/\[(.*?)\]\(.
   </div>
 
 <div id="main-footer" data-markdown-ignore>
-  <Footer />
+  <Footer enableKapa={enableKapa} />
 </div>
   <CodeCopyButton />
 </body>

--- a/astro/src/pages/help.mdx
+++ b/astro/src/pages/help.mdx
@@ -3,6 +3,7 @@ layout: src/layouts/Docs.astro
 title: FusionAuth Help
 description: Chat with an LLM about FusionAuth.
 disableTOC: true
+enableKapa: false
 ---
 import FullScreenHelp from 'src/components/FullScreenHelp.astro';
 


### PR DESCRIPTION
Kapa footer didn't work on the full-page Kapa help section. This PR finishes an implementation of `enableKapa` which exists in the kapa component allowing this to be disabled for the page.