### PR TITLE
Bump to latest version of astro-gen-markdown-pages

### DIFF
--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -23,7 +23,7 @@
 				"@tailwindcss/typography": "^0.5.19",
 				"@tailwindcss/vite": "^4.3.3",
 				"astro": "^7.1.3",
-				"astro-gen-markdown-pages": "^0.3.1",
+				"astro-gen-markdown-pages": "^0.3.2",
 				"astro-iconset": "^0.0.4",
 				"astro-index-pages": "file:src/integrations/astro-index-pages",
 				"astro-link-checker": "^0.2.1",
@@ -4151,9 +4151,9 @@
 			}
 		},
 		"node_modules/astro-gen-markdown-pages": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/astro-gen-markdown-pages/-/astro-gen-markdown-pages-0.3.1.tgz",
-			"integrity": "sha512-E4aOoXNEMMKJo1iQTdWWNlDc8h/BDybp4brLTsLXUVNWZ2whaSrTAElsWyHh/SIIq33SnV2q9vDTAYthKNJB6A==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/astro-gen-markdown-pages/-/astro-gen-markdown-pages-0.3.2.tgz",
+			"integrity": "sha512-5TJ6vLldXYPapysuFMRcRNlOCqFdUHh5JR2tB6xRhHIHdUIbfd3nC4Q8L3+j8PUgPRxI2e6MxM8brmo7EtkHIQ==",
 			"license": "MIT",
 			"dependencies": {
 				"node-html-parser": "^6.1.0",

--- a/astro/package.json
+++ b/astro/package.json
@@ -31,7 +31,7 @@
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.3.3",
 		"astro": "^7.1.3",
-		"astro-gen-markdown-pages": "^0.3.1",
+		"astro-gen-markdown-pages": "^0.3.2",
 		"astro-iconset": "^0.0.4",
 		"astro-index-pages": "file:src/integrations/astro-index-pages",
 		"astro-link-checker": "^0.2.1",

--- a/astro/src/components/ScalarClient.astro
+++ b/astro/src/components/ScalarClient.astro
@@ -87,7 +87,7 @@ if (show) {
 ---
 
 {specB64 && (
-  <details class="accordion group open:h-auto" data-scalar-widget>
+  <details class="accordion group open:h-auto" data-scalar-widget data-markdown-ignore>
     <summary class="accordion-summary">
       <div class="accordion-title">OpenAPI Spec</div>
       <svg class="accordion-chevron" viewBox="0 0 20 20" fill="currentColor">


### PR DESCRIPTION
- better handles APIs and APIFields
- also, add class to ignore openapi scalar component in markdown gen entirely