### PR TITLE
Fix incorrect parameter doc for login validation lambda

### DIFF
--- a/astro/src/content/docs/extend/code/lambdas/login-validation.mdx
+++ b/astro/src/content/docs/extend/code/lambdas/login-validation.mdx
@@ -37,7 +37,7 @@ The `result` object contains an [Errors](/docs/apis/errors) object. For more inf
 class Context {
 
     /**
-     * The method used to authenticate the user. This will only be populated when the action is `login`.
+     * The method used to authenticate the user.
      * @type {String} - Possible values are listed below.
      */
     authenticationType;


### PR DESCRIPTION
When I updated a lot of the lambda parameter documentation in #4187 I copied the description of the `authenticationType` parameter from the MFA requirement lambda. In the context of an MFA challenge we only have an `authenticationType` when logging in. But the login validation lambda is always called during login so, so we'll always know the auth type.