### PR TITLE
Remove note about default min idle pool size not being set

### DIFF
--- a/astro/src/components/docs/reference/_configuration-properties.mdx
+++ b/astro/src/components/docs/reference/_configuration-properties.mdx
@@ -22,7 +22,7 @@ export const addlJavaArgsText = 'Any additional arguments that you want to pass 
   </APIField>
 
   <APIField name="database.minimum-idle" type="Integer" defaults="10">
-    The minimum number of idle connections that FusionAuth will keep in the connection pool. This ensures that the pool always has that number of connections. By default, this is not set, so the connection pool will be a fixed size of the value of the `maximum-pool-size` configuration option.
+    The minimum number of idle connections that FusionAuth will keep in the connection pool. This ensures that the pool always has that number of connections.
   </APIField>
 
   <APIField name="database.maximum-pool-size" type="Integer" defaults="20">


### PR DESCRIPTION
Follow up to #4532. We do set a default value, 10. 